### PR TITLE
fix: ship database factories in published dist tarball

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,7 +19,6 @@
 
 # Testing
 /tests                              export-ignore
-/database/factories                 export-ignore
 /database/migrations/testing        export-ignore
 /phpunit.xml                        export-ignore
 /phpcs.xml                          export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Database factories are now shipped in the published dist tarball. Previously `/database/factories` was marked `export-ignore` in `.gitattributes`, so installs via `composer require --prefer-dist` autoloaded `ArtisanPackUI\Forms\Database\Factories\*` from a directory that did not exist, causing `Class not found` errors in downstream test suites and seeders. ([#41](https://github.com/ArtisanPack-UI/forms/issues/41))
+
 ## [1.1.1] - 2026-05-26
 
 ### Changed


### PR DESCRIPTION
## Description

Removes `/database/factories` from `.gitattributes` so the directory is no longer excluded by `git archive` / `composer install --prefer-dist`.

The `composer.json` autoload entry has mapped `ArtisanPackUI\Forms\Database\Factories\\` → `database/factories/` since 1.1.1, but the dist tarball did not contain those files. Downstream consumer apps hit `Class not found` on `FormFactory`, `FormSubmissionFactory`, etc. as soon as they tried to use them in seeders or feature tests (originally reproduced in Keystone CMS — 10 failing tests, all factory-not-found).

**Closes:** #41

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #41

## Motivation and Context

Consumer apps depend on these factories for their own test suites. Sibling packages like `cms-framework` already ship factories the same way; the autoload mapping in `composer.json` declares the intent, so the `.gitattributes` line was always inconsistent with it.

## Changes Made

- Removed `/database/factories                 export-ignore` from `.gitattributes`
- Added a `### Fixed` entry to the `[Unreleased]` section of `CHANGELOG.md`

`/database/migrations/testing` remains `export-ignore` — that directory contains a test-only users table migration and should still be excluded.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4.21
- Project Version: 1.1.2 (release branch)

**Tests Performed:**
1. `git archive --worktree-attributes --format=tar HEAD | tar -tf - | grep database/` — confirmed all 7 factory files (`FormFactory`, `FormFieldFactory`, `FormNotificationFactory`, `FormStepFactory`, `FormSubmissionFactory`, `FormSubmissionValueFactory`, `FormUploadFactory`) now appear in the tarball, alongside the production migrations
2. Verified `database/migrations/testing/` is still excluded
3. `vendor/bin/pest --compact` — full suite: **814 passed (1927 assertions)**
4. `./vendor/bin/php-cs-fixer fix --dry-run --diff` — clean

## Accessibility Tests Run

- [x] N/A — packaging-only change (`.gitattributes` + `CHANGELOG.md`), no runtime or UI changes

## Tests Added

- [x] All tests passing

**Test details:** No new tests added. The package's own test suite does not exercise these factories (they exist for downstream consumers), and the fix is a packaging-metadata change with no runtime code path to assert against. Adding a CI job that re-runs `git archive --worktree-attributes` to assert factory presence would be a sensible follow-up but is out of scope for this bug fix.

## Documentation

- [x] CHANGELOG entry added under `[Unreleased]`

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] N/A — no UI/runtime accessibility surface
- [x] Code follows project style guide
- [x] Self-review completed
- [x] N/A — comments not needed for a one-line `.gitattributes` deletion
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Database factories are now correctly included in the published distribution package. This resolves "Class not found" errors that previously occurred in downstream installations when using composer prefer-dist installations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/forms/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->