### PR TITLE
fix: resolve TypeScript errors in React components for consumer typecheck

### DIFF
--- a/resources/js/react/components/admin/ConditionalLogicEditor.tsx
+++ b/resources/js/react/components/admin/ConditionalLogicEditor.tsx
@@ -207,7 +207,7 @@ export function ConditionalLogicEditor( {
 						<Select
 							value={logic.action}
 							onChange={( e ) => handleActionChange( e.target.value )}
-							size="sm"
+							className="select-sm"
 							options={availableActions}
 							optionValue="value"
 							optionLabel="label"
@@ -216,7 +216,7 @@ export function ConditionalLogicEditor( {
 						<Select
 							value={logic.logic}
 							onChange={( e ) => handleLogicTypeChange( e.target.value )}
-							size="sm"
+							className="select-sm"
 							options={[
 								{ value: 'all', label: 'all' },
 								{ value: 'any', label: 'any' },
@@ -238,7 +238,7 @@ export function ConditionalLogicEditor( {
 									<Select
 										value={rule.field}
 										onChange={( e ) => handleUpdateRule( index, { field: e.target.value } )}
-										size="sm"
+										className="select-sm"
 										options={availableFields.map( ( f ) => ( {
 											value: f.uuid,
 											label: f.label || f.name,
@@ -253,7 +253,7 @@ export function ConditionalLogicEditor( {
 										onChange={( e ) => handleUpdateRule( index, {
 											operator: e.target.value as ConditionalOperator,
 										} )}
-										size="sm"
+										className="select-sm"
 										options={OPERATOR_DEFINITIONS.map( ( op ) => ( {
 											value: op.value,
 											label: op.label,
@@ -268,7 +268,7 @@ export function ConditionalLogicEditor( {
 											<Select
 												value={String( rule.value ?? '' )}
 												onChange={( e ) => handleUpdateRule( index, { value: e.target.value } )}
-												size="sm"
+												className="select-sm"
 												options={[
 													{ value: '', label: 'Select...' },
 													...fieldOptions.map( ( opt ) => ( {
@@ -285,7 +285,7 @@ export function ConditionalLogicEditor( {
 												value={String( rule.value ?? '' )}
 												onChange={( e ) => handleUpdateRule( index, { value: e.target.value } )}
 												placeholder="Value"
-												size="sm"
+												className="input-sm"
 											/>
 										)
 									)}

--- a/resources/js/react/components/admin/FieldEditor.tsx
+++ b/resources/js/react/components/admin/FieldEditor.tsx
@@ -16,6 +16,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Checkbox, Input, Select, Tabs, Textarea } from '@artisanpack-ui/react';
 
 import type {
+	ConditionalLogic,
 	FieldOption,
 	FieldType,
 	FieldWidth,
@@ -241,7 +242,9 @@ export function FieldEditor( {
 				content: (
 					<ConditionalLogicEditor
 						value={field.conditional_logic}
-						onChange={( logic ) => updateField( { conditional_logic: logic } )}
+						onChange={( logic ) => updateField( {
+							conditional_logic: logic as ConditionalLogic | null,
+						} )}
 						fields={allFields}
 						excludeFieldId={field.id}
 					/>

--- a/resources/js/react/components/admin/FieldPalette.tsx
+++ b/resources/js/react/components/admin/FieldPalette.tsx
@@ -145,11 +145,10 @@ export function FieldPalette( {
 			{externalSearch === undefined && (
 				<Input
 					type="search"
-					size="sm"
 					placeholder="Search fields..."
 					value={internalSearch}
 					onChange={( e ) => setInternalSearch( e.target.value )}
-					className="w-full"
+					className="input-sm w-full"
 				/>
 			)}
 

--- a/resources/js/react/components/admin/NotificationEditor.tsx
+++ b/resources/js/react/components/admin/NotificationEditor.tsx
@@ -15,10 +15,10 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Alert, Button, Checkbox, Input, Loading, Select, Textarea } from '@artisanpack-ui/react';
 
 import type {
+	ConditionalLogic,
 	Form,
 	FormField,
 	FormNotification,
-	NotificationConditionalLogic,
 	NotificationType,
 	NotificationTypeInfo,
 	StoreNotificationRequest,
@@ -588,7 +588,7 @@ export function NotificationEditor( {
 							<ConditionalLogicEditor
 								value={selectedNotification.conditional_logic}
 								onChange={( logic ) => updateNotification( selectedNotification.id, {
-									conditional_logic: logic as NotificationConditionalLogic | null,
+									conditional_logic: logic as ConditionalLogic | null,
 								} )}
 								fields={fields}
 								actions={[

--- a/resources/js/react/components/admin/NotificationEditor.tsx
+++ b/resources/js/react/components/admin/NotificationEditor.tsx
@@ -18,6 +18,7 @@ import type {
 	Form,
 	FormField,
 	FormNotification,
+	NotificationConditionalLogic,
 	NotificationType,
 	NotificationTypeInfo,
 	StoreNotificationRequest,
@@ -587,7 +588,7 @@ export function NotificationEditor( {
 							<ConditionalLogicEditor
 								value={selectedNotification.conditional_logic}
 								onChange={( logic ) => updateNotification( selectedNotification.id, {
-									conditional_logic: logic,
+									conditional_logic: logic as NotificationConditionalLogic | null,
 								} )}
 								fields={fields}
 								actions={[

--- a/resources/js/react/components/admin/SubmissionsList.tsx
+++ b/resources/js/react/components/admin/SubmissionsList.tsx
@@ -353,8 +353,7 @@ export function SubmissionsList( {
 			<div className="flex flex-wrap items-center gap-3">
 				<Input
 					type="search"
-					size="sm"
-					className="w-64"
+					className="input-sm w-64"
 					placeholder="Search submissions..."
 					value={search}
 					onChange={( e ) => {
@@ -384,7 +383,7 @@ export function SubmissionsList( {
 				</div>
 
 				<Select
-					size="sm"
+					className="select-sm"
 					value={dateRange}
 					onChange={( e ) => {
 						setDateRange( e.target.value as SubmissionDateRange );

--- a/resources/js/react/components/fields/LayoutField.tsx
+++ b/resources/js/react/components/fields/LayoutField.tsx
@@ -9,7 +9,10 @@
  * @since      1.1.0
  */
 
+import type { JSX } from 'react';
 import type { FieldComponentProps } from './types';
+
+type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
 /**
  * Renders a heading element (h1-h6).
@@ -18,7 +21,7 @@ export function HeadingField( { field }: FieldComponentProps ) {
 	const level = field.field_config && 'level' in field.field_config
 		? Number( field.field_config.level )
 		: 2;
-	const Tag = `h${Math.min( Math.max( level, 1 ), 6 )}` as keyof JSX.IntrinsicElements;
+	const Tag = ( `h${Math.min( Math.max( level, 1 ), 6 )}` as HeadingTag ) satisfies keyof JSX.IntrinsicElements;
 
 	return (
 		<Tag className={`font-bold ${field.css_classes ?? ''}`}>

--- a/resources/js/react/components/fields/LayoutField.tsx
+++ b/resources/js/react/components/fields/LayoutField.tsx
@@ -18,10 +18,11 @@ type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
  * Renders a heading element (h1-h6).
  */
 export function HeadingField( { field }: FieldComponentProps ) {
-	const level = field.field_config && 'level' in field.field_config
+	const rawLevel = field.field_config && 'level' in field.field_config
 		? Number( field.field_config.level )
 		: 2;
-	const Tag = ( `h${Math.min( Math.max( level, 1 ), 6 )}` as HeadingTag ) satisfies keyof JSX.IntrinsicElements;
+	const level = Number.isFinite( rawLevel ) ? Math.min( Math.max( rawLevel, 1 ), 6 ) : 2;
+	const Tag = ( `h${level}` as HeadingTag ) satisfies keyof JSX.IntrinsicElements;
 
 	return (
 		<Tag className={`font-bold ${field.css_classes ?? ''}`}>

--- a/resources/js/shared/conditionalLogic.ts
+++ b/resources/js/shared/conditionalLogic.ts
@@ -15,7 +15,7 @@ import type {
 	ConditionalLogicRule,
 	ConditionalOperator,
 	FormField,
-} from '../../types/artisanpack-forms';
+} from '../types/artisanpack-forms';
 
 /**
  * Builds a mapping of field UUIDs to field names and vice versa.
@@ -306,7 +306,7 @@ export function evaluateFieldVisibility(
 	const action = logic.action ?? 'show';
 	const logicType = logic.logic ?? 'all';
 
-	const results = logic.rules.map( ( rule ) =>
+	const results = logic.rules.map( ( rule: ConditionalLogicRule ) =>
 		evaluateRule( rule, formData, uuidToName ),
 	);
 

--- a/resources/js/shared/validation.ts
+++ b/resources/js/shared/validation.ts
@@ -10,7 +10,7 @@
  * @since      1.1.0
  */
 
-import type { FormField, ValidationRules } from '../../types/artisanpack-forms';
+import type { FormField, ValidationRules } from '../types/artisanpack-forms';
 
 /** Layout field types that do not collect data. */
 const LAYOUT_FIELDS = new Set( ['heading', 'paragraph', 'divider', 'html'] );

--- a/resources/js/types/artisanpack-forms.d.ts
+++ b/resources/js/types/artisanpack-forms.d.ts
@@ -130,6 +130,7 @@ export interface ConditionalLogic {
 export interface FieldOption {
     label: string;
     value: string;
+    [key: string]: string;
 }
 
 /**

--- a/src/FormsServiceProvider.php
+++ b/src/FormsServiceProvider.php
@@ -358,7 +358,7 @@ class FormsServiceProvider extends ServiceProvider
     {
         if ( $this->app->runningInConsole() ) {
             $this->publishes( [
-                __DIR__ . '/../resources/types/artisanpack-forms.d.ts' => resource_path( 'types/artisanpack-forms.d.ts' ),
+                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'types/artisanpack-forms.d.ts' ),
             ], 'forms-types' );
         }
     }
@@ -377,9 +377,9 @@ class FormsServiceProvider extends ServiceProvider
     {
         if ( $this->app->runningInConsole() ) {
             $this->publishes( [
-                __DIR__ . '/../resources/js/react'                     => resource_path( 'js/vendor/artisanpack-forms/react' ),
-                __DIR__ . '/../resources/js/shared'                    => resource_path( 'js/vendor/artisanpack-forms/shared' ),
-                __DIR__ . '/../resources/types/artisanpack-forms.d.ts' => resource_path( 'js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts' ),
+                __DIR__ . '/../resources/js/react'                        => resource_path( 'js/vendor/artisanpack-forms/react' ),
+                __DIR__ . '/../resources/js/shared'                       => resource_path( 'js/vendor/artisanpack-forms/shared' ),
+                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts' ),
             ], 'forms-react' );
         }
     }
@@ -398,9 +398,9 @@ class FormsServiceProvider extends ServiceProvider
     {
         if ( $this->app->runningInConsole() ) {
             $this->publishes( [
-                __DIR__ . '/../resources/js/vue'                       => resource_path( 'js/vendor/artisanpack-forms/vue' ),
-                __DIR__ . '/../resources/js/shared'                    => resource_path( 'js/vendor/artisanpack-forms/shared' ),
-                __DIR__ . '/../resources/types/artisanpack-forms.d.ts' => resource_path( 'js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts' ),
+                __DIR__ . '/../resources/js/vue'                          => resource_path( 'js/vendor/artisanpack-forms/vue' ),
+                __DIR__ . '/../resources/js/shared'                       => resource_path( 'js/vendor/artisanpack-forms/shared' ),
+                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts' ),
             ], 'forms-vue' );
         }
     }

--- a/tests/Feature/TypeDefinitionsTest.php
+++ b/tests/Feature/TypeDefinitionsTest.php
@@ -19,7 +19,7 @@ describe( 'TypeScript Type Definitions', function (): void {
             // Find the source path key that ends with the expected file
             $matchingKeys = array_filter(
                 array_keys( $paths ),
-                fn ( $key ) => str_ends_with( $key, 'resources/types/artisanpack-forms.d.ts' ),
+                fn ( $key ) => str_ends_with( $key, 'resources/js/types/artisanpack-forms.d.ts' ),
             );
 
             expect( $matchingKeys )->not->toBeEmpty();
@@ -31,7 +31,7 @@ describe( 'TypeScript Type Definitions', function (): void {
         } );
 
         it( 'has the source type definitions file present', function (): void {
-            $sourcePath = __DIR__ . '/../../resources/types/artisanpack-forms.d.ts';
+            $sourcePath = __DIR__ . '/../../resources/js/types/artisanpack-forms.d.ts';
 
             expect( file_exists( $sourcePath ) )->toBeTrue();
         } );
@@ -40,7 +40,7 @@ describe( 'TypeScript Type Definitions', function (): void {
     describe( 'type definitions content', function (): void {
         beforeEach( function (): void {
             $this->content = file_get_contents(
-                __DIR__ . '/../../resources/types/artisanpack-forms.d.ts',
+                __DIR__ . '/../../resources/js/types/artisanpack-forms.d.ts',
             );
         } );
 


### PR DESCRIPTION
## Description

Fixes the TypeScript errors surfaced by consumers (e.g. Keystone CMS) when they import the published React components and run `tsc --noEmit`.

**Closes:** #42
**Closes:** #39

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #42, #39

## Motivation and Context

Downstream projects importing `resources/js/vendor/artisanpack-forms/react/*` saw ~20 `tsc --noEmit` errors against `@artisanpack-ui/react ^1.0.0` and React 19 strict mode. The errors blocked clean CI typecheck steps and forced consumers to keep ignore lists or allow-failure on `js_quality`.

## Changes Made

- Replaced `size="sm"` on `<Input>` / `<Select>` with `className="input-sm"` / `className="select-sm"` (the package's option types no longer accept `size`).
- Added an index signature to `FieldOption` so it satisfies `SelectOption` / `RadioOption` from `@artisanpack-ui/react`.
- `LayoutField.tsx`: imported `JSX` from `react` (React 19) and narrowed the dynamic `Tag` variable to a `HeadingTag` union so it's usable as a JSX component.
- Converted `GenericConditionalLogic` at the boundary in `FieldEditor` (`as ConditionalLogic | null`) and `NotificationEditor` (`as NotificationConditionalLogic | null`).
- Moved `artisanpack-forms.d.ts` from `resources/types/` to `resources/js/types/` and updated `shared/conditionalLogic.ts` + `shared/validation.ts` imports to `../types/...` so the path resolves consistently in source and in the published `js/vendor/artisanpack-forms/` layout. Updated `FormsServiceProvider` publish targets and `TypeDefinitionsTest` accordingly.
- Added an explicit `ConditionalLogicRule` type on the previously implicit-`any` `rule` callback in `evaluateFieldVisibility`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4.3
- Project Version: 1.1.2

**Tests Performed:**
1. `composer test` — full Pest suite (814 tests, 1927 assertions) passes.
2. `composer fix` + `composer cs` — code style clean.
3. Manual: published the React components into a consumer and confirmed `tsc --noEmit` no longer reports the 5 error categories from #42/#39.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Type-only change; the visual sizing on Inputs/Selects is preserved via DaisyUI's `input-sm` / `select-sm` classes, so no accessibility behavior changes.

## Tests Added

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** Updated `TypeDefinitionsTest` paths to the new types location. No new tests added — the regressions are caught by consumer `tsc --noEmit`, which is outside this repo's Pest scope.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** Inline comments preserved; no API surface change.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed (N/A — type-only)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Field options now support additional custom string properties beyond standard labels and values.

* **Refactor**
  * Improved type safety across form editors and conditional logic handling.
  * Consolidated styling for admin components to use consistent compact input/select classes.

* **Tests**
  * Updated type definition tests to reflect the new type locations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/forms/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->