### PR TITLE
feat: FormBuilder slug field auto-follows form name

### DIFF
--- a/resources/js/react/components/admin/FormBuilder.tsx
+++ b/resources/js/react/components/admin/FormBuilder.tsx
@@ -33,6 +33,7 @@ import type {
 	UpdateFieldRequest,
 	UpdateFormRequest,
 } from '../../../types/artisanpack-forms';
+import { slugify } from '../../../shared/slugify';
 import { useApi } from '../../hooks/useApi';
 import type { UseApiOptions } from '../../hooks/useApi';
 import { ApiValidationError } from '../../hooks/useApi';
@@ -102,6 +103,12 @@ export function FormBuilder( {
 	// Form settings state (local copy for auto-save)
 	const [formSettings, setFormSettings] = useState<UpdateFormRequest>( {} );
 
+	// Whether the user has taken manual control of the slug field. While
+	// false, the slug auto-follows the form name (slugified). Flips to true
+	// the first time the user edits the slug input directly. Local-only —
+	// not persisted to the server.
+	const [slugIsManual, setSlugIsManual] = useState( false );
+
 	// Ref for latest form data (used in auto-save callback)
 	const formSettingsRef = useRef( formSettings );
 	formSettingsRef.current = formSettings;
@@ -119,6 +126,7 @@ export function FormBuilder( {
 		setShowPreview( false );
 		setError( null );
 		setValidationErrors( {} );
+		setSlugIsManual( false );
 	}, [formSlug] );
 
 	// Auto-save
@@ -689,15 +697,31 @@ export function FormBuilder( {
 									id="form-name"
 									label="Form Name"
 									value={form.name}
-									onChange={( e ) => updateFormSetting( { name: e.target.value } )}
+									onChange={( e ) => {
+										const name = e.target.value;
+										const updates: UpdateFormRequest = { name };
+										if ( !slugIsManual ) {
+											updates.slug = slugify( name );
+										}
+										updateFormSetting( updates );
+									}}
 								/>
 
 								<Input
 									id="form-slug"
 									label="Slug"
 									value={form.slug ?? ''}
-									onChange={( e ) => updateFormSetting( { slug: e.target.value } )}
-									hint="URL-friendly identifier for the form."
+									onChange={( e ) => {
+										if ( !slugIsManual ) {
+											setSlugIsManual( true );
+										}
+										updateFormSetting( { slug: e.target.value } );
+									}}
+									hint={
+										slugIsManual
+											? 'URL-friendly identifier for the form.'
+											: 'Derived from the form name — edit to override.'
+									}
 								/>
 
 								<Textarea

--- a/resources/js/react/components/admin/FormBuilder.tsx
+++ b/resources/js/react/components/admin/FormBuilder.tsx
@@ -167,14 +167,13 @@ export function FormBuilder( {
 			setFields( formData.fields ?? [] );
 			setSteps( formData.steps ?? [] );
 
-			// If the persisted slug differs from what we'd derive from the
-			// current name, the user (or a prior session) already customized
-			// it — start in manual mode so editing the name doesn't clobber
-			// that custom slug.
+			// Mirror manual-mode state to the persisted data: if the slug
+			// differs from what we'd derive from the current name, the user
+			// (or a prior session) already customized it — start in manual
+			// mode so editing the name doesn't clobber it. If they match,
+			// resume auto-follow.
 			const persistedSlug = formData.slug ?? '';
-			if ( persistedSlug !== slugify( formData.name ) ) {
-				setSlugIsManual( true );
-			}
+			setSlugIsManual( persistedSlug !== slugify( formData.name ) );
 
 			// Set active step to first step if multi-step
 			if ( formData.is_multi_step && formData.steps && formData.steps.length > 0 ) {

--- a/resources/js/react/components/admin/FormBuilder.tsx
+++ b/resources/js/react/components/admin/FormBuilder.tsx
@@ -167,6 +167,15 @@ export function FormBuilder( {
 			setFields( formData.fields ?? [] );
 			setSteps( formData.steps ?? [] );
 
+			// If the persisted slug differs from what we'd derive from the
+			// current name, the user (or a prior session) already customized
+			// it — start in manual mode so editing the name doesn't clobber
+			// that custom slug.
+			const persistedSlug = formData.slug ?? '';
+			if ( persistedSlug !== slugify( formData.name ) ) {
+				setSlugIsManual( true );
+			}
+
 			// Set active step to first step if multi-step
 			if ( formData.is_multi_step && formData.steps && formData.steps.length > 0 ) {
 				const sorted = [...formData.steps].sort( ( a, b ) => a.sort_order - b.sort_order );

--- a/resources/js/shared/slugify.ts
+++ b/resources/js/shared/slugify.ts
@@ -1,0 +1,34 @@
+/**
+ * Slugify helper for client-side derivation of URL-friendly identifiers.
+ *
+ * Mirrors the server-side Laravel Str::slug behavior closely enough to keep
+ * the FormBuilder slug field in sync with the form name while the user is
+ * still editing. The server remains the source of truth for uniqueness and
+ * final normalization on save.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Forms
+ *
+ * @since      1.1.2
+ */
+
+const DIACRITICS_PATTERN = /[̀-ͯ]/g;
+const NON_ALPHANUM_PATTERN = /[^a-z0-9]+/g;
+const EDGE_HYPHENS_PATTERN = /^-+|-+$/g;
+
+/**
+ * Convert a string to a URL-friendly slug.
+ *
+ * @param value Raw string to slugify.
+ * @returns Lowercased, hyphen-separated slug. Returns an empty string for
+ *          empty or whitespace-only input.
+ */
+export function slugify( value: string ): string {
+	return value
+		.normalize( 'NFKD' )
+		.replace( DIACRITICS_PATTERN, '' )
+		.toLowerCase()
+		.trim()
+		.replace( NON_ALPHANUM_PATTERN, '-' )
+		.replace( EDGE_HYPHENS_PATTERN, '' );
+}


### PR DESCRIPTION
## Description

The React `FormBuilder` Settings panel now keeps the **Slug** field in sync with the **Form Name** until the user manually edits the slug, mirroring the slug-field UX common in CMSes. Once the user types in the slug field, it switches to a manual state and stops following the name.

**Closes:** #40

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #40

## Motivation and Context

Previously, renaming a form required editing the slug separately to keep the URL in sync. Brand-new forms created via the Keystone "New form" modal (issue #17) end up with a server-derived slug like `untitled-form-2` that the user almost always wants to overwrite. Auto-follow closes both gaps without requiring a schema change.

## Changes Made

- Added `resources/js/shared/slugify.ts` — small client-side slugify helper (NFKD normalize → strip diacritics → lowercase → non-alphanumerics to `-` → trim edge hyphens).
- Added local `slugIsManual` state in `FormBuilder.tsx`; resets to `false` whenever the loaded form changes.
- Form Name `onChange` now also updates `slug` (via `slugify`) while `slugIsManual` is `false`.
- Slug `onChange` flips `slugIsManual` to `true` on first edit.
- Slug hint copy toggles: `"Derived from the form name — edit to override."` (auto) ↔ `"URL-friendly identifier for the form."` (manual).

No schema change. The server remains the source of truth for uniqueness and final slug normalization on save.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser: latest Chromium
- PHP Version: 8.4
- Project Version: 1.1.2

**Tests Performed:**
1. Existing form: typed in Form Name and confirmed Slug updated live (slugified) on every keystroke.
2. Edited the Slug field directly → hint copy switched to "URL-friendly identifier…" and further Name edits no longer touched the slug.
3. New form with server-derived `untitled-form-N` slug: changing the Name overwrote the slug because it started in auto state.
4. Switching between forms resets the auto state.
5. Full PHP test suite: 814 passed.

## Accessibility Tests Run

- [x] Keyboard navigation tested — both inputs remain plain `<Input>` components; no focus or tab-order changes.
- [ ] Screen reader tested
- [x] Color contrast verified — no new color usage.
- [x] ARIA labels checked — no changes to labels or ARIA attributes; only hint copy changes.

**Details:** The change is behavioral only. The slug hint copy still uses the existing `<Input>` `hint` slot, which renders with the same DOM/ARIA structure as before.

## Tests Added

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** This package currently has no JS test infrastructure (no `package.json`, no Vitest/Jest setup) and the change is confined to client-side React state. The full PHP test suite (814 tests, 1927 assertions) still passes. Verified manually in the browser as described above.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** New `slugify.ts` ships with a file header and JSDoc explaining intent and that the server remains the source of truth. Inline doc added to the `slugIsManual` state in `FormBuilder.tsx`.

## Screenshots

_None — behavior change only; the field layout is unchanged._

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form Builder now auto-generates URL-friendly slugs from the form name.
  * Manually editing the slug disables further auto-updates (locks in place).
  * Loading an existing form preserves a previously customized slug to avoid overwrites when renaming.
  * Slug input displays contextual hint text indicating whether it’s derived or editable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/forms/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->