### PR TITLE
Release v1.1.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,7 +19,6 @@
 
 # Testing
 /tests                              export-ignore
-/database/factories                 export-ignore
 /database/migrations/testing        export-ignore
 /phpunit.xml                        export-ignore
 /phpcs.xml                          export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Database factories are now shipped in the published dist tarball. Previously `/database/factories` was marked `export-ignore` in `.gitattributes`, so installs via `composer require --prefer-dist` autoloaded `ArtisanPackUI\Forms\Database\Factories\*` from a directory that did not exist, causing `Class not found` errors in downstream test suites and seeders. ([#41](https://github.com/ArtisanPack-UI/forms/issues/41))
+
 ## [1.1.1] - 2026-05-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-05-27
+
+### Added
+
+- React `FormBuilder` Settings panel: the **Slug** field now auto-follows the **Form Name** until the user edits the slug directly, at which point it locks to a manual state and stops mirroring the name. On load, manual mode is derived from whether the persisted slug matches the slugified name, so existing custom slugs aren't clobbered. The field hint copy reflects the current state. ([#40](https://github.com/ArtisanPack-UI/forms/issues/40))
+
 ### Fixed
 
 - Database factories are now shipped in the published dist tarball. Previously `/database/factories` was marked `export-ignore` in `.gitattributes`, so installs via `composer require --prefer-dist` autoloaded `ArtisanPackUI\Forms\Database\Factories\*` from a directory that did not exist, causing `Class not found` errors in downstream test suites and seeders. ([#41](https://github.com/ArtisanPack-UI/forms/issues/41))
+- Resolved five categories of TypeScript errors surfaced when consumers `tsc`-compiled the published React components: dropped the no-longer-supported `size` prop on `<Input>`/`<Select>` in favor of `className="input-sm"`/`"select-sm"`; added an index signature to `FieldOption` so it satisfies `@artisanpack-ui/react`'s `SelectOption`/`RadioOption` shape; imported `JSX` from `react` (React 19) and narrowed the dynamic heading `Tag` to a `HeadingTag` union in `LayoutField`; converted `GenericConditionalLogic` at the boundary in `FieldEditor` and `NotificationEditor` so the broader `action: string` shape doesn't leak into the narrower `ConditionalLogic`/`NotificationConditionalLogic` setters; and moved `artisanpack-forms.d.ts` into `resources/js/types/` with updated `shared/*` imports so the path resolves consistently in source and in the published `js/vendor/artisanpack-forms/` layout. ([#39](https://github.com/ArtisanPack-UI/forms/issues/39), [#42](https://github.com/ArtisanPack-UI/forms/issues/42))
 
 ## [1.1.1] - 2026-05-26
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "A comprehensive form builder and management package for Laravel with drag-and-drop builder, submissions, notifications, file uploads, multi-step forms, conditional logic, and webhooks.",
   "type": "library",
   "license": "GPL-3.0-or-later",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\Forms\\": "src/",

--- a/resources/js/react/components/admin/ConditionalLogicEditor.tsx
+++ b/resources/js/react/components/admin/ConditionalLogicEditor.tsx
@@ -207,7 +207,7 @@ export function ConditionalLogicEditor( {
 						<Select
 							value={logic.action}
 							onChange={( e ) => handleActionChange( e.target.value )}
-							size="sm"
+							className="select-sm"
 							options={availableActions}
 							optionValue="value"
 							optionLabel="label"
@@ -216,7 +216,7 @@ export function ConditionalLogicEditor( {
 						<Select
 							value={logic.logic}
 							onChange={( e ) => handleLogicTypeChange( e.target.value )}
-							size="sm"
+							className="select-sm"
 							options={[
 								{ value: 'all', label: 'all' },
 								{ value: 'any', label: 'any' },
@@ -238,7 +238,7 @@ export function ConditionalLogicEditor( {
 									<Select
 										value={rule.field}
 										onChange={( e ) => handleUpdateRule( index, { field: e.target.value } )}
-										size="sm"
+										className="select-sm"
 										options={availableFields.map( ( f ) => ( {
 											value: f.uuid,
 											label: f.label || f.name,
@@ -253,7 +253,7 @@ export function ConditionalLogicEditor( {
 										onChange={( e ) => handleUpdateRule( index, {
 											operator: e.target.value as ConditionalOperator,
 										} )}
-										size="sm"
+										className="select-sm"
 										options={OPERATOR_DEFINITIONS.map( ( op ) => ( {
 											value: op.value,
 											label: op.label,
@@ -268,7 +268,7 @@ export function ConditionalLogicEditor( {
 											<Select
 												value={String( rule.value ?? '' )}
 												onChange={( e ) => handleUpdateRule( index, { value: e.target.value } )}
-												size="sm"
+												className="select-sm"
 												options={[
 													{ value: '', label: 'Select...' },
 													...fieldOptions.map( ( opt ) => ( {
@@ -285,7 +285,7 @@ export function ConditionalLogicEditor( {
 												value={String( rule.value ?? '' )}
 												onChange={( e ) => handleUpdateRule( index, { value: e.target.value } )}
 												placeholder="Value"
-												size="sm"
+												className="input-sm"
 											/>
 										)
 									)}

--- a/resources/js/react/components/admin/FieldEditor.tsx
+++ b/resources/js/react/components/admin/FieldEditor.tsx
@@ -16,6 +16,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Checkbox, Input, Select, Tabs, Textarea } from '@artisanpack-ui/react';
 
 import type {
+	ConditionalLogic,
 	FieldOption,
 	FieldType,
 	FieldWidth,
@@ -241,7 +242,9 @@ export function FieldEditor( {
 				content: (
 					<ConditionalLogicEditor
 						value={field.conditional_logic}
-						onChange={( logic ) => updateField( { conditional_logic: logic } )}
+						onChange={( logic ) => updateField( {
+							conditional_logic: logic as ConditionalLogic | null,
+						} )}
 						fields={allFields}
 						excludeFieldId={field.id}
 					/>

--- a/resources/js/react/components/admin/FieldPalette.tsx
+++ b/resources/js/react/components/admin/FieldPalette.tsx
@@ -145,11 +145,10 @@ export function FieldPalette( {
 			{externalSearch === undefined && (
 				<Input
 					type="search"
-					size="sm"
 					placeholder="Search fields..."
 					value={internalSearch}
 					onChange={( e ) => setInternalSearch( e.target.value )}
-					className="w-full"
+					className="input-sm w-full"
 				/>
 			)}
 

--- a/resources/js/react/components/admin/FormBuilder.tsx
+++ b/resources/js/react/components/admin/FormBuilder.tsx
@@ -33,6 +33,7 @@ import type {
 	UpdateFieldRequest,
 	UpdateFormRequest,
 } from '../../../types/artisanpack-forms';
+import { slugify } from '../../../shared/slugify';
 import { useApi } from '../../hooks/useApi';
 import type { UseApiOptions } from '../../hooks/useApi';
 import { ApiValidationError } from '../../hooks/useApi';
@@ -102,6 +103,12 @@ export function FormBuilder( {
 	// Form settings state (local copy for auto-save)
 	const [formSettings, setFormSettings] = useState<UpdateFormRequest>( {} );
 
+	// Whether the user has taken manual control of the slug field. While
+	// false, the slug auto-follows the form name (slugified). Flips to true
+	// the first time the user edits the slug input directly. Local-only —
+	// not persisted to the server.
+	const [slugIsManual, setSlugIsManual] = useState( false );
+
 	// Ref for latest form data (used in auto-save callback)
 	const formSettingsRef = useRef( formSettings );
 	formSettingsRef.current = formSettings;
@@ -119,6 +126,7 @@ export function FormBuilder( {
 		setShowPreview( false );
 		setError( null );
 		setValidationErrors( {} );
+		setSlugIsManual( false );
 	}, [formSlug] );
 
 	// Auto-save
@@ -689,15 +697,31 @@ export function FormBuilder( {
 									id="form-name"
 									label="Form Name"
 									value={form.name}
-									onChange={( e ) => updateFormSetting( { name: e.target.value } )}
+									onChange={( e ) => {
+										const name = e.target.value;
+										const updates: UpdateFormRequest = { name };
+										if ( !slugIsManual ) {
+											updates.slug = slugify( name );
+										}
+										updateFormSetting( updates );
+									}}
 								/>
 
 								<Input
 									id="form-slug"
 									label="Slug"
 									value={form.slug ?? ''}
-									onChange={( e ) => updateFormSetting( { slug: e.target.value } )}
-									hint="URL-friendly identifier for the form."
+									onChange={( e ) => {
+										if ( !slugIsManual ) {
+											setSlugIsManual( true );
+										}
+										updateFormSetting( { slug: e.target.value } );
+									}}
+									hint={
+										slugIsManual
+											? 'URL-friendly identifier for the form.'
+											: 'Derived from the form name — edit to override.'
+									}
 								/>
 
 								<Textarea

--- a/resources/js/react/components/admin/FormBuilder.tsx
+++ b/resources/js/react/components/admin/FormBuilder.tsx
@@ -167,14 +167,13 @@ export function FormBuilder( {
 			setFields( formData.fields ?? [] );
 			setSteps( formData.steps ?? [] );
 
-			// If the persisted slug differs from what we'd derive from the
-			// current name, the user (or a prior session) already customized
-			// it — start in manual mode so editing the name doesn't clobber
-			// that custom slug.
+			// Mirror manual-mode state to the persisted data: if the slug
+			// differs from what we'd derive from the current name, the user
+			// (or a prior session) already customized it — start in manual
+			// mode so editing the name doesn't clobber it. If they match,
+			// resume auto-follow.
 			const persistedSlug = formData.slug ?? '';
-			if ( persistedSlug !== slugify( formData.name ) ) {
-				setSlugIsManual( true );
-			}
+			setSlugIsManual( persistedSlug !== slugify( formData.name ) );
 
 			// Set active step to first step if multi-step
 			if ( formData.is_multi_step && formData.steps && formData.steps.length > 0 ) {

--- a/resources/js/react/components/admin/FormBuilder.tsx
+++ b/resources/js/react/components/admin/FormBuilder.tsx
@@ -167,6 +167,15 @@ export function FormBuilder( {
 			setFields( formData.fields ?? [] );
 			setSteps( formData.steps ?? [] );
 
+			// If the persisted slug differs from what we'd derive from the
+			// current name, the user (or a prior session) already customized
+			// it — start in manual mode so editing the name doesn't clobber
+			// that custom slug.
+			const persistedSlug = formData.slug ?? '';
+			if ( persistedSlug !== slugify( formData.name ) ) {
+				setSlugIsManual( true );
+			}
+
 			// Set active step to first step if multi-step
 			if ( formData.is_multi_step && formData.steps && formData.steps.length > 0 ) {
 				const sorted = [...formData.steps].sort( ( a, b ) => a.sort_order - b.sort_order );

--- a/resources/js/react/components/admin/NotificationEditor.tsx
+++ b/resources/js/react/components/admin/NotificationEditor.tsx
@@ -15,10 +15,10 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Alert, Button, Checkbox, Input, Loading, Select, Textarea } from '@artisanpack-ui/react';
 
 import type {
+	ConditionalLogic,
 	Form,
 	FormField,
 	FormNotification,
-	NotificationConditionalLogic,
 	NotificationType,
 	NotificationTypeInfo,
 	StoreNotificationRequest,
@@ -588,7 +588,7 @@ export function NotificationEditor( {
 							<ConditionalLogicEditor
 								value={selectedNotification.conditional_logic}
 								onChange={( logic ) => updateNotification( selectedNotification.id, {
-									conditional_logic: logic as NotificationConditionalLogic | null,
+									conditional_logic: logic as ConditionalLogic | null,
 								} )}
 								fields={fields}
 								actions={[

--- a/resources/js/react/components/admin/NotificationEditor.tsx
+++ b/resources/js/react/components/admin/NotificationEditor.tsx
@@ -18,6 +18,7 @@ import type {
 	Form,
 	FormField,
 	FormNotification,
+	NotificationConditionalLogic,
 	NotificationType,
 	NotificationTypeInfo,
 	StoreNotificationRequest,
@@ -587,7 +588,7 @@ export function NotificationEditor( {
 							<ConditionalLogicEditor
 								value={selectedNotification.conditional_logic}
 								onChange={( logic ) => updateNotification( selectedNotification.id, {
-									conditional_logic: logic,
+									conditional_logic: logic as NotificationConditionalLogic | null,
 								} )}
 								fields={fields}
 								actions={[

--- a/resources/js/react/components/admin/SubmissionsList.tsx
+++ b/resources/js/react/components/admin/SubmissionsList.tsx
@@ -353,8 +353,7 @@ export function SubmissionsList( {
 			<div className="flex flex-wrap items-center gap-3">
 				<Input
 					type="search"
-					size="sm"
-					className="w-64"
+					className="input-sm w-64"
 					placeholder="Search submissions..."
 					value={search}
 					onChange={( e ) => {
@@ -384,7 +383,7 @@ export function SubmissionsList( {
 				</div>
 
 				<Select
-					size="sm"
+					className="select-sm"
 					value={dateRange}
 					onChange={( e ) => {
 						setDateRange( e.target.value as SubmissionDateRange );

--- a/resources/js/react/components/fields/LayoutField.tsx
+++ b/resources/js/react/components/fields/LayoutField.tsx
@@ -9,7 +9,10 @@
  * @since      1.1.0
  */
 
+import type { JSX } from 'react';
 import type { FieldComponentProps } from './types';
+
+type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
 /**
  * Renders a heading element (h1-h6).
@@ -18,7 +21,7 @@ export function HeadingField( { field }: FieldComponentProps ) {
 	const level = field.field_config && 'level' in field.field_config
 		? Number( field.field_config.level )
 		: 2;
-	const Tag = `h${Math.min( Math.max( level, 1 ), 6 )}` as keyof JSX.IntrinsicElements;
+	const Tag = ( `h${Math.min( Math.max( level, 1 ), 6 )}` as HeadingTag ) satisfies keyof JSX.IntrinsicElements;
 
 	return (
 		<Tag className={`font-bold ${field.css_classes ?? ''}`}>

--- a/resources/js/react/components/fields/LayoutField.tsx
+++ b/resources/js/react/components/fields/LayoutField.tsx
@@ -18,10 +18,11 @@ type HeadingTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
  * Renders a heading element (h1-h6).
  */
 export function HeadingField( { field }: FieldComponentProps ) {
-	const level = field.field_config && 'level' in field.field_config
+	const rawLevel = field.field_config && 'level' in field.field_config
 		? Number( field.field_config.level )
 		: 2;
-	const Tag = ( `h${Math.min( Math.max( level, 1 ), 6 )}` as HeadingTag ) satisfies keyof JSX.IntrinsicElements;
+	const level = Number.isFinite( rawLevel ) ? Math.min( Math.max( rawLevel, 1 ), 6 ) : 2;
+	const Tag = ( `h${level}` as HeadingTag ) satisfies keyof JSX.IntrinsicElements;
 
 	return (
 		<Tag className={`font-bold ${field.css_classes ?? ''}`}>

--- a/resources/js/react/components/fields/LayoutField.tsx
+++ b/resources/js/react/components/fields/LayoutField.tsx
@@ -21,7 +21,7 @@ export function HeadingField( { field }: FieldComponentProps ) {
 	const rawLevel = field.field_config && 'level' in field.field_config
 		? Number( field.field_config.level )
 		: 2;
-	const level = Number.isFinite( rawLevel ) ? Math.min( Math.max( rawLevel, 1 ), 6 ) : 2;
+	const level = Number.isFinite( rawLevel ) ? Math.min( Math.max( Math.trunc( rawLevel ), 1 ), 6 ) : 2;
 	const Tag = ( `h${level}` as HeadingTag ) satisfies keyof JSX.IntrinsicElements;
 
 	return (

--- a/resources/js/shared/conditionalLogic.ts
+++ b/resources/js/shared/conditionalLogic.ts
@@ -15,7 +15,7 @@ import type {
 	ConditionalLogicRule,
 	ConditionalOperator,
 	FormField,
-} from '../../types/artisanpack-forms';
+} from '../types/artisanpack-forms';
 
 /**
  * Builds a mapping of field UUIDs to field names and vice versa.
@@ -306,7 +306,7 @@ export function evaluateFieldVisibility(
 	const action = logic.action ?? 'show';
 	const logicType = logic.logic ?? 'all';
 
-	const results = logic.rules.map( ( rule ) =>
+	const results = logic.rules.map( ( rule: ConditionalLogicRule ) =>
 		evaluateRule( rule, formData, uuidToName ),
 	);
 

--- a/resources/js/shared/slugify.ts
+++ b/resources/js/shared/slugify.ts
@@ -1,0 +1,34 @@
+/**
+ * Slugify helper for client-side derivation of URL-friendly identifiers.
+ *
+ * Mirrors the server-side Laravel Str::slug behavior closely enough to keep
+ * the FormBuilder slug field in sync with the form name while the user is
+ * still editing. The server remains the source of truth for uniqueness and
+ * final normalization on save.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Forms
+ *
+ * @since      1.1.2
+ */
+
+const DIACRITICS_PATTERN = /[̀-ͯ]/g;
+const NON_ALPHANUM_PATTERN = /[^a-z0-9]+/g;
+const EDGE_HYPHENS_PATTERN = /^-+|-+$/g;
+
+/**
+ * Convert a string to a URL-friendly slug.
+ *
+ * @param value Raw string to slugify.
+ * @returns Lowercased, hyphen-separated slug. Returns an empty string for
+ *          empty or whitespace-only input.
+ */
+export function slugify( value: string ): string {
+	return value
+		.normalize( 'NFKD' )
+		.replace( DIACRITICS_PATTERN, '' )
+		.toLowerCase()
+		.trim()
+		.replace( NON_ALPHANUM_PATTERN, '-' )
+		.replace( EDGE_HYPHENS_PATTERN, '' );
+}

--- a/resources/js/shared/validation.ts
+++ b/resources/js/shared/validation.ts
@@ -10,7 +10,7 @@
  * @since      1.1.0
  */
 
-import type { FormField, ValidationRules } from '../../types/artisanpack-forms';
+import type { FormField, ValidationRules } from '../types/artisanpack-forms';
 
 /** Layout field types that do not collect data. */
 const LAYOUT_FIELDS = new Set( ['heading', 'paragraph', 'divider', 'html'] );

--- a/resources/js/types/artisanpack-forms.d.ts
+++ b/resources/js/types/artisanpack-forms.d.ts
@@ -130,6 +130,7 @@ export interface ConditionalLogic {
 export interface FieldOption {
     label: string;
     value: string;
+    [key: string]: string;
 }
 
 /**

--- a/src/FormsServiceProvider.php
+++ b/src/FormsServiceProvider.php
@@ -358,7 +358,7 @@ class FormsServiceProvider extends ServiceProvider
     {
         if ( $this->app->runningInConsole() ) {
             $this->publishes( [
-                __DIR__ . '/../resources/types/artisanpack-forms.d.ts' => resource_path( 'types/artisanpack-forms.d.ts' ),
+                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'types/artisanpack-forms.d.ts' ),
             ], 'forms-types' );
         }
     }
@@ -377,9 +377,9 @@ class FormsServiceProvider extends ServiceProvider
     {
         if ( $this->app->runningInConsole() ) {
             $this->publishes( [
-                __DIR__ . '/../resources/js/react'                     => resource_path( 'js/vendor/artisanpack-forms/react' ),
-                __DIR__ . '/../resources/js/shared'                    => resource_path( 'js/vendor/artisanpack-forms/shared' ),
-                __DIR__ . '/../resources/types/artisanpack-forms.d.ts' => resource_path( 'js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts' ),
+                __DIR__ . '/../resources/js/react'                        => resource_path( 'js/vendor/artisanpack-forms/react' ),
+                __DIR__ . '/../resources/js/shared'                       => resource_path( 'js/vendor/artisanpack-forms/shared' ),
+                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts' ),
             ], 'forms-react' );
         }
     }
@@ -398,9 +398,9 @@ class FormsServiceProvider extends ServiceProvider
     {
         if ( $this->app->runningInConsole() ) {
             $this->publishes( [
-                __DIR__ . '/../resources/js/vue'                       => resource_path( 'js/vendor/artisanpack-forms/vue' ),
-                __DIR__ . '/../resources/js/shared'                    => resource_path( 'js/vendor/artisanpack-forms/shared' ),
-                __DIR__ . '/../resources/types/artisanpack-forms.d.ts' => resource_path( 'js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts' ),
+                __DIR__ . '/../resources/js/vue'                          => resource_path( 'js/vendor/artisanpack-forms/vue' ),
+                __DIR__ . '/../resources/js/shared'                       => resource_path( 'js/vendor/artisanpack-forms/shared' ),
+                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts' ),
             ], 'forms-vue' );
         }
     }

--- a/tests/Feature/TypeDefinitionsTest.php
+++ b/tests/Feature/TypeDefinitionsTest.php
@@ -19,7 +19,7 @@ describe( 'TypeScript Type Definitions', function (): void {
             // Find the source path key that ends with the expected file
             $matchingKeys = array_filter(
                 array_keys( $paths ),
-                fn ( $key ) => str_ends_with( $key, 'resources/types/artisanpack-forms.d.ts' ),
+                fn ( $key ) => str_ends_with( $key, 'resources/js/types/artisanpack-forms.d.ts' ),
             );
 
             expect( $matchingKeys )->not->toBeEmpty();
@@ -31,7 +31,7 @@ describe( 'TypeScript Type Definitions', function (): void {
         } );
 
         it( 'has the source type definitions file present', function (): void {
-            $sourcePath = __DIR__ . '/../../resources/types/artisanpack-forms.d.ts';
+            $sourcePath = __DIR__ . '/../../resources/js/types/artisanpack-forms.d.ts';
 
             expect( file_exists( $sourcePath ) )->toBeTrue();
         } );
@@ -40,7 +40,7 @@ describe( 'TypeScript Type Definitions', function (): void {
     describe( 'type definitions content', function (): void {
         beforeEach( function (): void {
             $this->content = file_get_contents(
-                __DIR__ . '/../../resources/types/artisanpack-forms.d.ts',
+                __DIR__ . '/../../resources/js/types/artisanpack-forms.d.ts',
             );
         } );
 


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.1.2
- **Release Date:** 2026-05-27
- **Release Type:** Patch
- **Release Branch:** `release/1.1.2`
- **Target Branch:** `main`

## Release Summary

Patch release rolling up three downstream-facing fixes and one builder UX improvement. The biggest items are unblocking the published dist tarball for consumers that hit `Class not found` on the factories, restoring a clean `tsc` compile for consumers of the React admin components, and tightening the FormBuilder slug field so renaming a form no longer requires a second manual edit.

## Changelog

### Added

- React `FormBuilder` Settings panel: the **Slug** field now auto-follows the **Form Name** until the user edits the slug directly, at which point it locks to a manual state and stops mirroring the name. On load, manual mode is derived from whether the persisted slug matches the slugified name, so existing custom slugs aren't clobbered. The field hint copy reflects the current state. (#40)

### Changed

- None.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Database factories are now shipped in the published dist tarball. Previously `/database/factories` was marked `export-ignore` in `.gitattributes`, so installs via `composer require --prefer-dist` autoloaded `ArtisanPackUI\Forms\Database\Factories\*` from a directory that did not exist, causing `Class not found` errors in downstream test suites and seeders. (#41)
- Resolved five categories of TypeScript errors surfaced when consumers `tsc`-compiled the published React components: dropped the no-longer-supported `size` prop on `<Input>`/`<Select>` in favor of `className="input-sm"`/`"select-sm"`; added an index signature to `FieldOption` so it satisfies `@artisanpack-ui/react`'s `SelectOption`/`RadioOption` shape; imported `JSX` from `react` (React 19) and narrowed the dynamic heading `Tag` to a `HeadingTag` union in `LayoutField`; converted `GenericConditionalLogic` at the boundary in `FieldEditor` and `NotificationEditor` so the broader `action: string` shape doesn't leak into the narrower `ConditionalLogic`/`NotificationConditionalLogic` setters; and moved `artisanpack-forms.d.ts` into `resources/js/types/` with updated `shared/*` imports so the path resolves consistently in source and in the published `js/vendor/artisanpack-forms/` layout. (#39, #42)

### Security

- None at the package level. Six advisories were reported by `composer audit` against transitive Symfony dependencies (`http-foundation`, `polyfill-intl-idn`, `routing`, and three against `yaml`). These ride along with the Laravel framework requirement and resolve when consuming apps pin patched Laravel/Symfony versions; no package-level constraint change is needed.

## Issues and Pull Requests

**Issues Fixed:**
- Closes #39
- Closes #40
- Closes #41
- Closes #42

**Related PRs:**
- #43 (factories in dist)
- #44 (React TS errors)
- #45 (slug auto-follow)

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

**Breaking changes:** _None._

**Migration guide:** _N/A._

## Testing Checklist

- [x] All automated tests passing (814 tests, 1927 assertions)
- [x] Manual testing completed (FormBuilder slug auto-follow verified in browser; consumer `tsc` validated against published React components)
- [x] Accessibility tests passing
- [ ] Performance tests passing (if applicable)
- [x] Security scan completed (`composer audit` — see Security section)
- [ ] Tested in staging environment
- [ ] Database migrations tested (no schema changes in this release)

**Testing notes:** No schema changes; no consumer-side migration required. The slug auto-follow change is purely client-side React state and has no server impact.

## Documentation Checklist

- [x] CHANGELOG updated
- [x] README updated (if needed) — no changes required
- [x] API documentation updated (if needed) — no API surface changes
- [ ] Migration guide written (if breaking changes)
- [x] Release notes written (this PR + CHANGELOG)
- [ ] Wiki updated (if applicable)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (`composer.json` → 1.1.2)
- [x] Git tag prepared: `v1.1.2`
- [x] Release branch created/updated: `release/1.1.2`
- [x] Dependencies updated and tested (`composer.lock` re-synced)
- [x] Build artifacts generated
- [ ] Deployment plan reviewed
- [ ] Rollback plan prepared
- [ ] Stakeholders notified

## Deployment

**Deployment steps:**
1. Merge this PR into `main`.
2. Tag `v1.1.2` on the merge commit and push the tag.
3. Packagist auto-syncs from the new tag.

**Rollback plan:**
1. If a regression surfaces, consumers can pin `^1.1.1` until a follow-up patch ships.
2. If necessary, retract the `v1.1.2` tag and publish a `v1.1.3` with the fix on top.

**Configuration changes:** _None._

**Environment variables:** _None._

## Post-Release Tasks

- [ ] Tag created: `v1.1.2`
- [ ] Release notes published
- [ ] Documentation deployed
- [ ] Announcement sent
- [ ] Monitoring verified
- [ ] Previous version support documented

## Notes

CodeRabbit CLI (`cr review --base main --prompt-only`) was run twice locally against the release branch prior to opening this PR; both passes reported `findings: 0`.

---

**Release Manager:** @ViewFromTheBox
**Reviewers Required:** @ViewFromTheBox

**For Reviewers:**
- Verify all checklist items completed
- Review changelog accuracy
- Confirm version numbers correct
- Check breaking changes documented
- Approve deployment plan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Form slug field now auto-follows the form name until manually edited, with contextual hint text.
  * Added client-side slug generation helper.

* **Bug Fixes**
  * Database factories are now included in the distributed package.
  * Resolved TypeScript typing and published component typings issues.
  * Improved type handling for conditional logic and heading-level validation.

* **Chores**
  * Refined admin component sizing/styling for consistency.
  * Relocated type definitions and updated asset publish targets.
  * Version bumped to 1.1.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/forms/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->