### PR TITLE
enhancement: add Laravel 13 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Laravel 13 support. Updated `illuminate/support` constraint to `^11.0|^12.0|^13.0`. Laravel 13 is only selectable on PHP 8.3+ per L13's own `php` constraint. ([#47](https://github.com/ArtisanPack-UI/forms/issues/47))
+
+### Changed
+
+- Tightened the lower bound on `illuminate/support` from the previous overly-permissive `>=5.3` to `^11.0`. No practical impact for existing installs — the package's PHP `^8.2` floor and Livewire 3.6+ requirement already made Laravel 5.3–10.x unreachable.
+
 ## [1.1.2] - 2026-05-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ php artisan forms:prune-submissions --days=90
 ## 📦 Requirements
 
 - PHP 8.2 or higher
-- Laravel 11 or 12
+- Laravel 11, 12, or 13
 - Livewire 3.6+
 
 ## 🤝 Dependencies

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "illuminate/support": ">=5.3",
+    "illuminate/support": "^11.0|^12.0|^13.0",
     "artisanpack-ui/livewire-ui-components": "^2.0",
     "artisanpack-ui/security": "^1.0|^2.0",
     "artisanpack-ui/accessibility": "^2.1",


### PR DESCRIPTION
## Description

Adds Laravel 13 to the supported framework range by widening the `illuminate/support` constraint to `^11.0|^12.0|^13.0`. Laravel 13 is only selectable on PHP 8.3+ per L13's own `php` constraint, so the package's `^8.2` PHP floor is unchanged.

**Closes:** #47

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #47

## Motivation and Context

Laravel 13 was released and we want to support it without dropping currently-supported Laravel versions and without raising the PHP floor for users staying on older Laravel.

## Changes Made

- `composer.json` — `illuminate/support` constraint updated from `>=5.3` to `^11.0|^12.0|^13.0`
- `README.md` — supported-versions note updated to "Laravel 11, 12, or 13"
- `CHANGELOG.md` — Unreleased entry under Added (L13 support) and Changed (tightened lower bound; no practical impact because PHP `^8.2` + Livewire 3.6+ already made L5.3–10.x unreachable)

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4.3
- Project Version: 1.1.2 (branch off `release/1.1.3`)

**Tests Performed:**
1. `composer update` regenerated the lockfile cleanly
2. `./vendor/bin/pest` — 814 tests, 1927 assertions, all passing

## Accessibility Tests Run

N/A — dependency constraint change only, no UI changes.

## Tests Added

- [x] All tests passing

No new tests added — this is a `composer.json` constraint change with no behavioral impact. CI matrix work to exercise L11/12/13 separately is tracked under the Laravel 13 Updates/Upgrades project.

## Documentation

- [x] README updated
- [x] CHANGELOG updated

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Self-review completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Laravel 13 (PHP 8.3+ required).
  * Package now supports Laravel 11, 12, and 13.
  * Updated minimum supported Laravel version to 11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->