### PR TITLE
Release v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Laravel 13 support. Updated `illuminate/support` constraint to `^11.0|^12.0|^13.0`. Laravel 13 is only selectable on PHP 8.3+ per L13's own `php` constraint. ([#47](https://github.com/ArtisanPack-UI/forms/issues/47))
+
+### Changed
+
+- Tightened the lower bound on `illuminate/support` from the previous overly-permissive `>=5.3` to `^11.0`. No practical impact for existing installs — the package's PHP `^8.2` floor and Livewire 3.6+ requirement already made Laravel 5.3–10.x unreachable.
+
 ## [1.1.2] - 2026-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3] - 2026-06-09
+
 ### Added
 
 - Laravel 13 support. Updated `illuminate/support` constraint to `^11.0|^12.0|^13.0`. Laravel 13 is only selectable on PHP 8.3+ per L13's own `php` constraint. ([#47](https://github.com/ArtisanPack-UI/forms/issues/47))

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ php artisan forms:prune-submissions --days=90
 ## 📦 Requirements
 
 - PHP 8.2 or higher
-- Laravel 11 or 12
+- Laravel 11, 12, or 13
 - Livewire 3.6+
 
 ## 🤝 Dependencies

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ php artisan forms:prune-submissions --days=90
 ## 📦 Requirements
 
 - PHP 8.2 or higher
-- Laravel 11, 12, or 13
+- Laravel 11, 12, or 13 (Laravel 13 requires PHP 8.3+)
 - Livewire 3.6+
 
 ## 🤝 Dependencies

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "illuminate/support": ">=5.3",
+    "illuminate/support": "^11.0|^12.0|^13.0",
     "artisanpack-ui/livewire-ui-components": "^2.0",
     "artisanpack-ui/security": "^1.0|^2.0",
     "artisanpack-ui/accessibility": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "A comprehensive form builder and management package for Laravel with drag-and-drop builder, submissions, notifications, file uploads, multi-step forms, conditional logic, and webhooks.",
   "type": "library",
   "license": "GPL-3.0-or-later",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\Forms\\": "src/",

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -14,7 +14,7 @@ ArtisanPack UI Forms is a comprehensive form builder and management package for 
 
 ### What Laravel versions are supported?
 
-The package supports Laravel 11 and Laravel 12.
+The package supports Laravel 11, 12, and 13. Laravel 13 requires PHP 8.3 or higher per Laravel's own constraint.
 
 ### Does it work with Livewire 3?
 


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.1.3
- **Release Date:** 2026-06-09
- **Release Type:** Patch
- **Release Branch:** `release/1.1.3`
- **Target Branch:** `main`

## Release Summary

Adds Laravel 13 to the supported framework range and tightens the previously overly-permissive `illuminate/support` lower bound. No code changes — constraint and documentation only.

## Changelog

### Added

- Laravel 13 support. Updated `illuminate/support` constraint to `^11.0|^12.0|^13.0`. Laravel 13 is only selectable on PHP 8.3+ per L13's own `php` constraint. (#47)

### Changed

- Tightened the lower bound on `illuminate/support` from the previous overly-permissive `>=5.3` to `^11.0`. No practical impact for existing installs — the package's PHP `^8.2` floor and Livewire 3.6+ requirement already made Laravel 5.3–10.x unreachable.

### Deprecated

- None

### Removed

- None

### Fixed

- None

### Security

- None

## Issues and Pull Requests

**Issues Fixed:**
- Closes #47

**Related PRs:**
- #48

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

The tightened lower bound on `illuminate/support` is technically a narrowing, but it has no practical effect: existing installs were already on Laravel 11/12 because the PHP `^8.2` floor and Livewire 3.6+ dependency made older Laravel versions unreachable.

## Testing Checklist

- [x] All automated tests passing (814 tests, 1927 assertions)
- [x] Manual testing completed
- [ ] Accessibility tests passing (N/A — no UI changes)
- [ ] Performance tests passing (N/A — no behavioral changes)
- [x] Security scan completed (`composer audit` — no advisories)
- [ ] Tested in staging environment
- [ ] Database migrations tested (N/A — no migrations)

**Testing notes:**

Constraint-only change. CI matrix work to exercise L11/12/13 in CI is tracked separately under the Laravel 13 support initiative.

## Documentation Checklist

- [x] CHANGELOG updated
- [x] README updated (Requirements section)
- [x] API documentation updated (no API changes; `docs/faq.md` supported-versions entry updated)
- [ ] Migration guide written (N/A — no breaking changes)
- [x] Release notes written

## Pre-Release Checklist

- [x] Version number updated in all necessary files (`composer.json` → 1.1.3)
- [ ] Git tag prepared: `v1.1.3` (post-merge)
- [x] Release branch created/updated: `release/1.1.3`
- [x] Dependencies updated and tested (lock file synced, no advisories)
- [ ] Build artifacts generated (N/A — library package)
- [ ] Deployment plan reviewed (N/A — Packagist release)
- [ ] Rollback plan prepared (revert merge + Packagist version delete if needed)
- [ ] Stakeholders notified

## Deployment

**Deployment steps:**
1. Merge this PR to `main`
2. Tag `v1.1.3` on `main`
3. Packagist auto-syncs the new tag

**Rollback plan:**
1. Delete `v1.1.3` tag on GitHub + Packagist
2. Revert the merge commit on `main`

**Configuration changes:**

- None

**Environment variables:**

- None

## Post-Release Tasks

- [ ] Tag created: `v1.1.3`
- [ ] Release notes published
- [ ] Documentation deployed
- [ ] Announcement sent
- [ ] Monitoring verified
- [ ] Previous version support documented

## Notes

Outdated dev dependencies (non-blocking, tracked for future):
- `orchestra/testbench` 10.11.0 → 11.x available
- `pestphp/pest` 3.8.6 → 4.x available
- `pestphp/pest-plugin-laravel` 3.2.0 → 4.x available

These are major dev-dep bumps and can be addressed in a follow-up.

---

**Release Manager:** @jacobmartella

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Laravel 13 support (requires PHP 8.3+)

* **Documentation**
  * Updated README and FAQ to list Laravel 11/12/13 support and PHP 8.3+ note for Laravel 13
  * Added changelog entry for release 1.1.3

* **Chores**
  * Released version 1.1.3
<!-- end of auto-generated comment: release notes by coderabbit.ai -->