### PR TITLE
feat(ai): add spam, summary, classification, and smart-validation agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Four opt-in AI agents built on `artisanpack-ui/ai` (v1.0+): `SpamDetectionAgent` (`forms.spam_detection`), `SubmissionSummaryAgent` (`forms.submission_summary`), `ResponseClassificationAgent` (`forms.response_classification`), and `SmartFieldValidationAgent` (`forms.smart_validation`). Registered via `aiFeatures()` on `FormsServiceProvider` and shipped with matching Livewire trigger components (`forms::ai-spam-check`, `forms::ai-submission-summary`, `forms::ai-response-classifier`, `forms::ai-smart-field-validator`). Each agent no-ops when its feature toggle is off, so installs without the AI package are unaffected. ([#50](https://github.com/ArtisanPack-UI/forms/issues/50), [#51](https://github.com/ArtisanPack-UI/forms/issues/51), [#52](https://github.com/ArtisanPack-UI/forms/issues/52), [#53](https://github.com/ArtisanPack-UI/forms/issues/53))
+
 ## [1.1.3] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -178,6 +178,70 @@ Event::listen(FormSubmitted::class, function ($event) {
 });
 ```
 
+## 🤖 AI features
+
+The Forms package ships four opt-in AI agents that plug into the
+[artisanpack-ui/ai](https://github.com/ArtisanPack-UI/ai) feature registry.
+Install `artisanpack-ui/ai` (v1.0+) and configure credentials to enable them;
+each feature no-ops when its toggle is off, so upgrades are non-breaking.
+
+| Feature key                         | Agent                            | Default model      | What it does                                                                                     |
+|-------------------------------------|----------------------------------|--------------------|--------------------------------------------------------------------------------------------------|
+| `forms.spam_detection`              | `SpamDetectionAgent`             | `claude-haiku-4-5` | Score a single submission for spam. Returns `spam_score`, `verdict`, and `reasons`.              |
+| `forms.submission_summary`          | `SubmissionSummaryAgent`         | `claude-sonnet-4-6`| Periodic digest of submission themes, notable entries, and suggested follow-ups.                 |
+| `forms.response_classification`     | `ResponseClassificationAgent`    | `claude-haiku-4-5` | Categorize a submission against a caller-supplied set of labels; may propose a new one.           |
+| `forms.smart_validation`            | `SmartFieldValidationAgent`      | `claude-haiku-4-5` | Opt-in per-field semantic plausibility check that complements format validation.                  |
+
+Each agent is invoked the same way — construct it with `for()` and call `run()`:
+
+```php
+use ArtisanPackUI\Forms\Ai\Agents\SpamDetectionAgent;
+
+$result = SpamDetectionAgent::for([
+    'fields' => $submission->data_array,
+    'meta'   => [
+        'ip_country'          => $submission->ip_country,
+        'submission_speed_ms' => $submission->submission_speed_ms,
+    ],
+])->run();
+// [ 'spam_score' => int, 'verdict' => 'ham'|'suspicious'|'spam', 'reasons' => string[] ]
+```
+
+Each feature also ships a Livewire trigger component you can drop into the
+admin surface. Components no-op when the feature toggle is off:
+
+```blade
+<livewire:forms::ai-spam-check
+    :submission-id="$submission->id"
+    :fields="$submission->data_array"
+    :meta="[ 'ip_country' => $submission->ip_country ]"
+/>
+
+<livewire:forms::ai-submission-summary
+    form-name="Contact us"
+    window="weekly"
+    :submissions="$submissions"
+/>
+
+<livewire:forms::ai-response-classifier
+    :submission-id="$submission->id"
+    :fields="$submission->data_array"
+    :available-categories="[ 'support-request', 'sales-inquiry', 'feedback', 'bug-report' ]"
+/>
+
+<livewire:forms::ai-smart-field-validator
+    field-name="address"
+    field-label="Address"
+    field-kind="address"
+    :value="$address"
+    :context="[ 'city' => $city, 'state' => $state ]"
+/>
+```
+
+See the [AI RFC](https://github.com/ArtisanPack-UI/.github/discussions/8) for
+the shared registry, toggle, and credential story across ArtisanPack UI
+packages.
+
 ## 🔌 Extensibility
 
 Add custom field types using filter hooks:

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
   "require-dev": {
     "pestphp/pest": "^3.8",
     "pestphp/pest-plugin-laravel": "^3.2",
+    "artisanpack-ui/ai": "^1.0",
     "artisanpack-ui/code-style": "^1.1",
     "artisanpack-ui/code-style-pint": "^1.1",
     "laravel/pint": "^1.26",

--- a/resources/views/livewire/ai/response-classifier.blade.php
+++ b/resources/views/livewire/ai/response-classifier.blade.php
@@ -1,0 +1,57 @@
+<div class="forms-ai-classifier" data-feature="forms.response_classification">
+	@if ( ! $this->isEnabled )
+		<p class="forms-ai-classifier__disabled">
+			{{ __( 'AI response classification is currently disabled.' ) }}
+		</p>
+	@else
+		<button
+			type="button"
+			wire:click="classify"
+			wire:loading.attr="disabled"
+			wire:target="classify"
+			@disabled( $isLoading || [] === $fields || [] === $availableCategories )
+			class="forms-ai-classifier__button"
+		>
+			<span wire:loading.remove wire:target="classify">
+				{{ __( 'Classify submission' ) }}
+			</span>
+			<span wire:loading wire:target="classify">
+				{{ __( 'Classifying…' ) }}
+			</span>
+		</button>
+
+		@if ( null !== $error )
+			<p class="forms-ai-classifier__error" role="alert">
+				{{ $error }}
+			</p>
+		@endif
+
+		@if ( null !== $category )
+			<div class="forms-ai-classifier__result">
+				<p class="forms-ai-classifier__category">
+					<strong>{{ __( 'Suggested category:' ) }}</strong> {{ $category }}
+					@if ( null !== $confidence )
+						<span class="forms-ai-classifier__confidence">
+							({{ __( ':percent% confidence', ['percent' => (int) round( $confidence * 100 )] ) }})
+						</span>
+					@endif
+				</p>
+
+				@if ( null !== $suggestedNew )
+					<p class="forms-ai-classifier__suggested-new">
+						{{ __( 'Consider adding a new category:' ) }}
+						<code>{{ $suggestedNew }}</code>
+					</p>
+				@endif
+
+				<button
+					type="button"
+					wire:click="accept"
+					class="forms-ai-classifier__accept"
+				>
+					{{ __( 'Apply category' ) }}
+				</button>
+			</div>
+		@endif
+	@endif
+</div>

--- a/resources/views/livewire/ai/smart-field-validator.blade.php
+++ b/resources/views/livewire/ai/smart-field-validator.blade.php
@@ -1,0 +1,57 @@
+<div class="forms-ai-smart-validator" data-feature="forms.smart_validation">
+	@if ( ! $this->isEnabled )
+		<p class="forms-ai-smart-validator__disabled">
+			{{ __( 'AI smart validation is currently disabled.' ) }}
+		</p>
+	@else
+		<button
+			type="button"
+			wire:click="validateField"
+			wire:loading.attr="disabled"
+			wire:target="validateField"
+			@disabled( $isLoading || '' === trim( $value ) || '' === trim( $fieldKind ) )
+			class="forms-ai-smart-validator__button"
+		>
+			<span wire:loading.remove wire:target="validateField">
+				{{ __( 'Check this field' ) }}
+			</span>
+			<span wire:loading wire:target="validateField">
+				{{ __( 'Checking…' ) }}
+			</span>
+		</button>
+
+		@if ( null !== $error )
+			<p class="forms-ai-smart-validator__error" role="alert">
+				{{ $error }}
+			</p>
+		@endif
+
+		@if ( null !== $plausible )
+			<div
+				class="forms-ai-smart-validator__result"
+				data-plausible="{{ $plausible ? 'true' : 'false' }}"
+			>
+				<p class="forms-ai-smart-validator__verdict">
+					<strong>
+						{{ $plausible ? __( 'Looks plausible' ) : __( 'Doesn\'t look right' ) }}
+					</strong>
+					@if ( null !== $confidence )
+						<span class="forms-ai-smart-validator__confidence">
+							({{ __( ':percent% confidence', ['percent' => (int) round( $confidence * 100 )] ) }})
+						</span>
+					@endif
+				</p>
+
+				@if ( null !== $reason && '' !== $reason )
+					<p class="forms-ai-smart-validator__reason">{{ $reason }}</p>
+				@endif
+
+				@if ( null !== $suggestion && '' !== $suggestion )
+					<p class="forms-ai-smart-validator__suggestion">
+						{{ __( 'Suggestion:' ) }} {{ $suggestion }}
+					</p>
+				@endif
+			</div>
+		@endif
+	@endif
+</div>

--- a/resources/views/livewire/ai/spam-check.blade.php
+++ b/resources/views/livewire/ai/spam-check.blade.php
@@ -1,0 +1,49 @@
+<div class="forms-ai-spam-check" data-feature="forms.spam_detection">
+	@if ( ! $this->isEnabled )
+		<p class="forms-ai-spam-check__disabled">
+			{{ __( 'AI spam detection is currently disabled.' ) }}
+		</p>
+	@else
+		<button
+			type="button"
+			wire:click="check"
+			wire:loading.attr="disabled"
+			wire:target="check"
+			@disabled( $isLoading || [] === $fields )
+			class="forms-ai-spam-check__button"
+		>
+			<span wire:loading.remove wire:target="check">
+				{{ __( 'Score for spam' ) }}
+			</span>
+			<span wire:loading wire:target="check">
+				{{ __( 'Scoring…' ) }}
+			</span>
+		</button>
+
+		@if ( null !== $error )
+			<p class="forms-ai-spam-check__error" role="alert">
+				{{ $error }}
+			</p>
+		@endif
+
+		@if ( null !== $verdict && null !== $spamScore )
+			<div
+				class="forms-ai-spam-check__result"
+				data-verdict="{{ $verdict }}"
+			>
+				<p class="forms-ai-spam-check__verdict">
+					<strong>{{ __( 'Verdict:' ) }}</strong> {{ $verdict }}
+					<span class="forms-ai-spam-check__score">({{ $spamScore }}/100)</span>
+				</p>
+
+				@if ( ! empty( $reasons ) )
+					<ul class="forms-ai-spam-check__reasons">
+						@foreach ( $reasons as $index => $reason )
+							<li wire:key="spam-reason-{{ $index }}">{{ $reason }}</li>
+						@endforeach
+					</ul>
+				@endif
+			</div>
+		@endif
+	@endif
+</div>

--- a/resources/views/livewire/ai/submission-summary.blade.php
+++ b/resources/views/livewire/ai/submission-summary.blade.php
@@ -1,0 +1,81 @@
+<div class="forms-ai-summary" data-feature="forms.submission_summary">
+	@if ( ! $this->isEnabled )
+		<p class="forms-ai-summary__disabled">
+			{{ __( 'AI submission summaries are currently disabled.' ) }}
+		</p>
+	@else
+		<button
+			type="button"
+			wire:click="summarize"
+			wire:loading.attr="disabled"
+			wire:target="summarize"
+			@disabled( $isLoading || '' === trim( $formName ) )
+			class="forms-ai-summary__button"
+		>
+			<span wire:loading.remove wire:target="summarize">
+				{{ __( 'Summarize submissions' ) }}
+			</span>
+			<span wire:loading wire:target="summarize">
+				{{ __( 'Summarizing…' ) }}
+			</span>
+		</button>
+
+		@if ( null !== $error )
+			<p class="forms-ai-summary__error" role="alert">
+				{{ $error }}
+			</p>
+		@endif
+
+		@if ( null !== $headline )
+			<div class="forms-ai-summary__result">
+				<p class="forms-ai-summary__headline">{{ $headline }}</p>
+				<p class="forms-ai-summary__total">
+					{{ __( ':count submissions', ['count' => $totalCount] ) }}
+				</p>
+
+				@if ( ! empty( $themes ) )
+					<section class="forms-ai-summary__themes">
+						<h4>{{ __( 'Themes' ) }}</h4>
+						<ul>
+							@foreach ( $themes as $index => $theme )
+								<li wire:key="theme-{{ $index }}">
+									<strong>{{ $theme['title'] }}</strong>
+									<span>({{ $theme['count'] }})</span>
+									@if ( ! empty( $theme['examples'] ) )
+										<ul class="forms-ai-summary__examples">
+											@foreach ( $theme['examples'] as $exampleIndex => $example )
+												<li wire:key="theme-{{ $index }}-example-{{ $exampleIndex }}">{{ $example }}</li>
+											@endforeach
+										</ul>
+									@endif
+								</li>
+							@endforeach
+						</ul>
+					</section>
+				@endif
+
+				@if ( ! empty( $notable ) )
+					<section class="forms-ai-summary__notable">
+						<h4>{{ __( 'Notable' ) }}</h4>
+						<ul>
+							@foreach ( $notable as $index => $item )
+								<li wire:key="notable-{{ $index }}">{{ $item }}</li>
+							@endforeach
+						</ul>
+					</section>
+				@endif
+
+				@if ( ! empty( $suggestions ) )
+					<section class="forms-ai-summary__suggestions">
+						<h4>{{ __( 'Suggestions' ) }}</h4>
+						<ul>
+							@foreach ( $suggestions as $index => $item )
+								<li wire:key="suggestion-{{ $index }}">{{ $item }}</li>
+							@endforeach
+						</ul>
+					</section>
+				@endif
+			</div>
+		@endif
+	@endif
+</div>

--- a/src/Ai/Agents/ResponseClassificationAgent.php
+++ b/src/Ai/Agents/ResponseClassificationAgent.php
@@ -1,0 +1,286 @@
+<?php
+
+/**
+ * Response classification agent.
+ *
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.2.0
+ */
+
+declare(strict_types=1);
+
+namespace ArtisanPackUI\Forms\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Auto-categorize an incoming form submission against a caller-supplied set
+ * of category labels (e.g. `support request`, `sales inquiry`, `feedback`,
+ * `bug report`).
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'fields'              => array<string, mixed>,  // required — submitted field values
+ *   'available_categories' => string[],             // required — category slugs to choose from
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   category:       string,        // one of available_categories
+ *   confidence:     float(0..1),
+ *   suggested_new?: string         // present ONLY when confidence < 0.5 and none of the
+ *                                  // available categories fit; a slug the caller can add
+ * }
+ * ```
+ *
+ *
+ * @since      1.2.0
+ */
+class ResponseClassificationAgent extends ArtisanPackAgent
+{
+    /**
+     * Confidence threshold at which the model may suggest a new category.
+     *
+     * @since 1.2.0
+     *
+     * @var float
+     */
+    protected const NEW_CATEGORY_THRESHOLD = 0.5;
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'forms.response_classification';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/forms';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-haiku-4-5';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You categorize a single form submission by picking the best label from a caller-supplied list.
+
+Requirements:
+- `category` MUST be one of the labels in `available_categories` verbatim (same casing, same slug). Do NOT invent your own value here.
+- `confidence` is a float from 0.0 to 1.0. 1.0 means "obviously this label"; 0.0 means "guessing". Be honest — a coin flip is 0.5, not 0.8.
+- `suggested_new` is optional. Emit it ONLY when your `confidence` is below 0.5 and none of the available categories genuinely describe the submission; in that case propose ONE new category slug (kebab-case, 1-3 words, no punctuation) that would fit. Never propose a category that duplicates one already in the list.
+- Do NOT emit `suggested_new` when confidence is 0.5 or higher — a moderate-confidence match is still a match, not a new-category candidate.
+- If the submission is empty or the fields don't contain any content to classify, pick the closest available label with a low confidence (0.1-0.3) and skip `suggested_new`.
+
+Return a JSON object with keys: category (string), confidence (number), optional suggested_new (string).
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'additionalProperties' => false,
+            'required' => ['category', 'confidence'],
+            'properties' => [
+                'category' => ['type' => 'string'],
+                'confidence' => ['type' => 'number', 'minimum' => 0, 'maximum' => 1],
+                'suggested_new' => ['type' => 'string'],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute(Credentials $credentials, string $model, string $instructions): array
+    {
+        $normalized = $this->normalizeInput($this->input());
+
+        $prompter = app(AgentPrompter::class);
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage($normalized),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output' => $this->validateOutput($result['output'] ?? [], $normalized['available_categories']),
+            'input_tokens' => (int) ($result['input_tokens'] ?? 0),
+            'output_tokens' => (int) ($result['output_tokens'] ?? 0),
+        ];
+    }
+
+    /**
+     * Validate and shape-check the raw agent input.
+     *
+     * @since 1.2.0
+     *
+     * @param  mixed  $input  Raw agent input.
+     * @return array{ fields: array<string, mixed>, available_categories: array<int, string> }
+     */
+    protected function normalizeInput(mixed $input): array
+    {
+        if (! is_array($input)) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'input must be an array with `fields` and `available_categories` keys.',
+            );
+        }
+
+        $fields = $input['fields'] ?? null;
+
+        if (! is_array($fields) || $fields === []) {
+            throw FeatureError::forFeature($this->featureKey, '`fields` must be a non-empty array.');
+        }
+
+        $rawCategories = $input['available_categories'] ?? null;
+
+        if (! is_array($rawCategories) || $rawCategories === []) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                '`available_categories` must be a non-empty array of strings.',
+            );
+        }
+
+        $categories = [];
+
+        foreach ($rawCategories as $category) {
+            if (! is_string($category)) {
+                continue;
+            }
+
+            $trimmed = trim($category);
+
+            if ($trimmed !== '' && ! in_array($trimmed, $categories, true)) {
+                $categories[] = $trimmed;
+            }
+        }
+
+        if ($categories === []) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                '`available_categories` must contain at least one non-empty string.',
+            );
+        }
+
+        return [
+            'fields' => $fields,
+            'available_categories' => $categories,
+        ];
+    }
+
+    /**
+     * Assemble the structured message body for the prompter.
+     *
+     * @since 1.2.0
+     *
+     * @param  array{ fields: array<string, mixed>, available_categories: array<int, string> }  $normalized  Normalized input.
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage(array $normalized): array
+    {
+        return [
+            [
+                'type' => 'text',
+                'text' => 'Available categories: '.implode(', ', $normalized['available_categories']),
+            ],
+            [
+                'type' => 'text',
+                'text' => "Submitted fields (JSON):\n".json_encode(
+                    $normalized['fields'],
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * Enforce output invariants — category must be from the input list,
+     * confidence bounded [0, 1], suggested_new only when confidence is low.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<string, mixed>  $output  Decoded model output.
+     * @param  array<int, string>  $categories  Whitelist of allowed categories.
+     * @return array{ category: string, confidence: float, suggested_new?: string }
+     */
+    protected function validateOutput(array $output, array $categories): array
+    {
+        $category = isset($output['category']) && is_string($output['category'])
+            ? trim($output['category'])
+            : '';
+        $confidence = $this->clampConfidence($output['confidence'] ?? 0);
+
+        // If the model returned a category that isn't on the whitelist, fall
+        // back to the first available label at very low confidence rather
+        // than propagate an invalid selection to the caller.
+        if ($category === '' || ! in_array($category, $categories, true)) {
+            $category = $categories[0];
+            $confidence = min($confidence, 0.2);
+        }
+
+        $result = [
+            'category' => $category,
+            'confidence' => $confidence,
+        ];
+
+        if ($confidence < self::NEW_CATEGORY_THRESHOLD && isset($output['suggested_new']) && is_string($output['suggested_new'])) {
+            $suggested = $this->normalizeSlug($output['suggested_new']);
+
+            if ($suggested !== '' && ! in_array($suggested, $categories, true)) {
+                $result['suggested_new'] = $suggested;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Coerce a value into a float bounded to [0, 1].
+     *
+     * @since 1.2.0
+     *
+     * @param  mixed  $value  Raw confidence.
+     */
+    protected function clampConfidence(mixed $value): float
+    {
+        return max(0.0, min(1.0, (float) $value));
+    }
+
+    /**
+     * Normalize a proposed new category into a kebab-case slug.
+     *
+     * @since 1.2.0
+     *
+     * @param  string  $value  Raw suggestion.
+     */
+    protected function normalizeSlug(string $value): string
+    {
+        $lower = strtolower(trim($value));
+        $dashed = preg_replace('/[^a-z0-9]+/', '-', $lower);
+
+        return trim((string) $dashed, '-');
+    }
+}

--- a/src/Ai/Agents/SmartFieldValidationAgent.php
+++ b/src/Ai/Agents/SmartFieldValidationAgent.php
@@ -1,0 +1,259 @@
+<?php
+
+/**
+ * Smart field validation agent.
+ *
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.2.0
+ */
+
+declare(strict_types=1);
+
+namespace ArtisanPackUI\Forms\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Opt-in per-field semantic validation for a single form field.
+ *
+ * This is meant to complement, not replace, format validation (regex,
+ * length, required, etc.). The caller runs its usual validation first;
+ * this agent adds a semantic pass answering "does this look real for a
+ * field of this kind?"
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'field_label'   => string,          // required — human-readable label ("Company")
+ *   'field_kind'    => string,          // required — e.g. "address", "company_name", "full_name"
+ *   'value'         => string,          // required — the submitted value
+ *   'context'       => array<string, mixed>|null,  // optional — sibling fields for cross-checks
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   plausible: bool,
+ *   confidence: float(0..1),
+ *   reason:    string,
+ *   suggestion?: string
+ * }
+ * ```
+ *
+ *
+ * @since      1.2.0
+ */
+class SmartFieldValidationAgent extends ArtisanPackAgent
+{
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'forms.smart_validation';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/forms';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-haiku-4-5';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You judge whether a single form field value is plausible for its declared field kind. Format-level validation (required, length, regex) has already run. Focus on semantic plausibility.
+
+Examples of what to look for:
+- address: does the address look like a real place (real street pattern, real city/state combo where obvious)? Reject "123 Fake St", obvious jokes, mashed-together characters.
+- company_name: does it look like a real business name, not a random string or profanity? Common single-word brands ("Anthropic", "Stripe") are fine.
+- full_name: does it look like a plausible human name — not "asdfasdf", not a URL, not "TEST"? Names in any language, script, or with hyphens/apostrophes are all fine.
+- email: even when format is valid, flag values like "test@test.test" or role addresses that indicate the submitter didn't want to share a real one.
+- phone: flag obviously fake patterns (555-555-5555, 000-000-0000, sequential digits).
+
+Requirements:
+- `plausible` is a boolean.
+- `confidence` is a float 0.0-1.0. Be honest — a coin-flip case is 0.5.
+- `reason` is one short sentence explaining your judgment (<= 200 chars). NEVER emit "looks fine" or "not sure" — cite the specific signal.
+- `suggestion` is optional. Include ONLY when `plausible` is false AND you can offer a concrete fix a user would recognize (e.g. correct a typo, ask them to include a city). Never suggest a specific value the user didn't write (don't invent addresses, names, or companies).
+- If you don't have enough context to judge (e.g. an ambiguous string that could be legitimate), return `plausible: true` with a moderate confidence rather than rejecting.
+
+Return a JSON object with keys: plausible (boolean), confidence (number), reason (string), optional suggestion (string).
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'additionalProperties' => false,
+            'required' => ['plausible', 'confidence', 'reason'],
+            'properties' => [
+                'plausible' => ['type' => 'boolean'],
+                'confidence' => ['type' => 'number', 'minimum' => 0, 'maximum' => 1],
+                'reason' => ['type' => 'string', 'maxLength' => 200],
+                'suggestion' => ['type' => 'string'],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute(Credentials $credentials, string $model, string $instructions): array
+    {
+        $normalized = $this->normalizeInput($this->input());
+
+        $prompter = app(AgentPrompter::class);
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage($normalized),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output' => $this->validateOutput($result['output'] ?? []),
+            'input_tokens' => (int) ($result['input_tokens'] ?? 0),
+            'output_tokens' => (int) ($result['output_tokens'] ?? 0),
+        ];
+    }
+
+    /**
+     * Validate and shape-check the raw agent input.
+     *
+     * @since 1.2.0
+     *
+     * @param  mixed  $input  Raw agent input.
+     * @return array{ field_label: string, field_kind: string, value: string, context: array<string, mixed>|null }
+     */
+    protected function normalizeInput(mixed $input): array
+    {
+        if (! is_array($input)) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'input must be an array with `field_label`, `field_kind`, and `value` keys.',
+            );
+        }
+
+        $label = isset($input['field_label']) && is_string($input['field_label'])
+            ? trim($input['field_label'])
+            : '';
+        $kind = isset($input['field_kind']) && is_string($input['field_kind'])
+            ? trim($input['field_kind'])
+            : '';
+        $value = isset($input['value']) && is_string($input['value'])
+            ? trim($input['value'])
+            : '';
+
+        if ($label === '') {
+            throw FeatureError::forFeature($this->featureKey, '`field_label` must be a non-empty string.');
+        }
+
+        if ($kind === '') {
+            throw FeatureError::forFeature($this->featureKey, '`field_kind` must be a non-empty string.');
+        }
+
+        if ($value === '') {
+            throw FeatureError::forFeature($this->featureKey, '`value` must be a non-empty string.');
+        }
+
+        $context = null;
+
+        if (isset($input['context']) && is_array($input['context']) && $input['context'] !== []) {
+            $context = $input['context'];
+        }
+
+        return [
+            'field_label' => $label,
+            'field_kind' => $kind,
+            'value' => $value,
+            'context' => $context,
+        ];
+    }
+
+    /**
+     * Assemble the structured message body for the prompter.
+     *
+     * @since 1.2.0
+     *
+     * @param  array{ field_label: string, field_kind: string, value: string, context: array<string, mixed>|null }  $normalized  Normalized input.
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage(array $normalized): array
+    {
+        $parts = [
+            ['type' => 'text', 'text' => sprintf('Field label: %s', $normalized['field_label'])],
+            ['type' => 'text', 'text' => sprintf('Field kind: %s', $normalized['field_kind'])],
+            ['type' => 'text', 'text' => sprintf('Submitted value: %s', $normalized['value'])],
+        ];
+
+        if ($normalized['context'] !== null) {
+            $parts[] = [
+                'type' => 'text',
+                'text' => "Sibling fields (JSON) for cross-checks:\n".json_encode(
+                    $normalized['context'],
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+                ),
+            ];
+        }
+
+        return $parts;
+    }
+
+    /**
+     * Enforce output invariants — boolean plausibility, bounded confidence,
+     * trimmed reason, optional suggestion only when marked implausible.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<string, mixed>  $output  Decoded model output.
+     * @return array{ plausible: bool, confidence: float, reason: string, suggestion?: string }
+     */
+    protected function validateOutput(array $output): array
+    {
+        $plausible = (bool) ($output['plausible'] ?? true);
+        $confidence = max(0.0, min(1.0, (float) ($output['confidence'] ?? 0)));
+
+        $reason = isset($output['reason']) && is_string($output['reason'])
+            ? trim($output['reason'])
+            : '';
+
+        if (mb_strlen($reason) > 200) {
+            $reason = mb_substr($reason, 0, 200);
+        }
+
+        $result = [
+            'plausible' => $plausible,
+            'confidence' => $confidence,
+            'reason' => $reason,
+        ];
+
+        if (! $plausible && isset($output['suggestion']) && is_string($output['suggestion'])) {
+            $suggestion = trim($output['suggestion']);
+
+            if ($suggestion !== '') {
+                $result['suggestion'] = $suggestion;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Ai/Agents/SpamDetectionAgent.php
+++ b/src/Ai/Agents/SpamDetectionAgent.php
@@ -1,0 +1,305 @@
+<?php
+
+/**
+ * Spam detection agent.
+ *
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.2.0
+ */
+
+declare(strict_types=1);
+
+namespace ArtisanPackUI\Forms\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Semantic spam scoring for a form submission.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'fields' => array<string, mixed>,   // required — submitted field values
+ *   'meta'   => [
+ *     'ip_country'          => string|null,
+ *     'user_agent_class'    => string|null,
+ *     'submission_speed_ms' => int|null,
+ *   ],
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   spam_score: int(0..100),
+ *   verdict:    'ham'|'suspicious'|'spam',
+ *   reasons:    string[]
+ * }
+ * ```
+ *
+ *
+ * @since      1.2.0
+ */
+class SpamDetectionAgent extends ArtisanPackAgent
+{
+    /**
+     * Allowed verdict values, in order of severity.
+     *
+     * @since 1.2.0
+     *
+     * @var array<int, string>
+     */
+    protected const VERDICTS = ['ham', 'suspicious', 'spam'];
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'forms.spam_detection';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/forms';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-haiku-4-5';
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You score a single form submission for the likelihood that it is spam.
+
+You are the second line of defense: static checks (honeypot, rate limiting, CAPTCHA) have already run. Focus on semantic signals a static check can't see — copy-pasted marketing pitches, cryptocurrency and adult-content solicitations, keyword stuffing, gibberish, mismatched name/email/message content, off-topic body text, obvious link farms.
+
+Requirements:
+- `spam_score` is an integer 0-100. 0 means "clearly a real human message"; 100 means "obvious spam".
+- `verdict` MUST be one of `ham` (score 0-39), `suspicious` (score 40-74), or `spam` (score 75-100). Keep it consistent with the score.
+- `reasons` is 1-5 short sentences, each pointing at one concrete signal you observed (e.g. "message body is a marketing pitch unrelated to the form's purpose", "email domain and name look unrelated", "submission_speed_ms of 800 is faster than a human could type this message"). Never emit generic reasons like "looks like spam" or "not sure".
+- When the submission is clearly a real human message, return `verdict: ham`, a low score, and either an empty `reasons` array or a single sentence explaining what looked legitimate.
+- Do NOT flag a submission as spam just because it is short — only when the CONTENT signals spam.
+
+Return a JSON object with keys: spam_score (integer 0-100), verdict (string), reasons (array of strings).
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'additionalProperties' => false,
+            'required' => ['spam_score', 'verdict', 'reasons'],
+            'properties' => [
+                'spam_score' => ['type' => 'integer', 'minimum' => 0, 'maximum' => 100],
+                'verdict' => ['type' => 'string', 'enum' => self::VERDICTS],
+                'reasons' => [
+                    'type' => 'array',
+                    'maxItems' => 5,
+                    'items' => ['type' => 'string'],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute(Credentials $credentials, string $model, string $instructions): array
+    {
+        $normalized = $this->normalizeInput($this->input());
+
+        $prompter = app(AgentPrompter::class);
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage($normalized),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output' => $this->validateOutput($result['output'] ?? []),
+            'input_tokens' => (int) ($result['input_tokens'] ?? 0),
+            'output_tokens' => (int) ($result['output_tokens'] ?? 0),
+        ];
+    }
+
+    /**
+     * Validate and shape-check the raw agent input.
+     *
+     * @since 1.2.0
+     *
+     * @param  mixed  $input  Raw agent input.
+     * @return array{ fields: array<string, mixed>, meta: array<string, mixed> }
+     */
+    protected function normalizeInput(mixed $input): array
+    {
+        if (! is_array($input)) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'input must be an array with a `fields` key.',
+            );
+        }
+
+        $fields = $input['fields'] ?? null;
+
+        if (! is_array($fields) || $fields === []) {
+            throw FeatureError::forFeature($this->featureKey, '`fields` must be a non-empty array.');
+        }
+
+        $meta = is_array($input['meta'] ?? null) ? $input['meta'] : [];
+
+        return [
+            'fields' => $fields,
+            'meta' => $meta,
+        ];
+    }
+
+    /**
+     * Assemble the structured message body for the prompter.
+     *
+     * @since 1.2.0
+     *
+     * @param  array{ fields: array<string, mixed>, meta: array<string, mixed> }  $normalized  Normalized input.
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage(array $normalized): array
+    {
+        $parts = [
+            [
+                'type' => 'text',
+                'text' => "Submitted fields (JSON):\n".json_encode(
+                    $normalized['fields'],
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+                ),
+            ],
+        ];
+
+        if ($normalized['meta'] !== []) {
+            $parts[] = [
+                'type' => 'text',
+                'text' => "Submission metadata:\n".json_encode(
+                    $normalized['meta'],
+                    JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+                ),
+            ];
+        }
+
+        return $parts;
+    }
+
+    /**
+     * Enforce output invariants — score bounds, verdict enum, reason list.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<string, mixed>  $output  Decoded model output.
+     * @return array{ spam_score: int, verdict: string, reasons: array<int, string> }
+     */
+    protected function validateOutput(array $output): array
+    {
+        $score = $this->clampScore($output['spam_score'] ?? 0);
+        $verdict = $this->normalizeVerdict($output['verdict'] ?? null, $score);
+        $reasons = $this->stringList($output['reasons'] ?? []);
+
+        if (count($reasons) > 5) {
+            $reasons = array_slice($reasons, 0, 5);
+        }
+
+        return [
+            'spam_score' => $score,
+            'verdict' => $verdict,
+            'reasons' => $reasons,
+        ];
+    }
+
+    /**
+     * Coerce a value into an integer bounded to [0, 100].
+     *
+     * @since 1.2.0
+     *
+     * @param  mixed  $value  Raw score.
+     */
+    protected function clampScore(mixed $value): int
+    {
+        return max(0, min(100, (int) $value));
+    }
+
+    /**
+     * Normalize the verdict, falling back to a score-derived value when the
+     * model returned an out-of-vocabulary string.
+     *
+     * @since 1.2.0
+     *
+     * @param  mixed  $raw  Raw verdict from the model.
+     * @param  int  $score  Clamped spam score.
+     */
+    protected function normalizeVerdict(mixed $raw, int $score): string
+    {
+        if (is_string($raw)) {
+            $candidate = strtolower(trim($raw));
+
+            if (in_array($candidate, self::VERDICTS, true)) {
+                return $candidate;
+            }
+        }
+
+        if ($score >= 75) {
+            return 'spam';
+        }
+
+        if ($score >= 40) {
+            return 'suspicious';
+        }
+
+        return 'ham';
+    }
+
+    /**
+     * Filter a raw list into a clean array of non-empty strings.
+     *
+     * @since 1.2.0
+     *
+     * @param  mixed  $raw  Raw list from the model.
+     * @return array<int, string>
+     */
+    protected function stringList(mixed $raw): array
+    {
+        if (! is_array($raw)) {
+            return [];
+        }
+
+        $out = [];
+
+        foreach ($raw as $value) {
+            if (! is_string($value)) {
+                continue;
+            }
+
+            $trimmed = trim($value);
+
+            if ($trimmed === '') {
+                continue;
+            }
+
+            $out[] = $trimmed;
+        }
+
+        return $out;
+    }
+}

--- a/src/Ai/Agents/SubmissionSummaryAgent.php
+++ b/src/Ai/Agents/SubmissionSummaryAgent.php
@@ -1,0 +1,378 @@
+<?php
+
+/**
+ * Submission summary agent.
+ *
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.2.0
+ */
+
+declare(strict_types=1);
+
+namespace ArtisanPackUI\Forms\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+
+/**
+ * Periodic (daily/weekly) summary of what people are submitting to a form.
+ *
+ * The output is designed to be delivered as an email digest by the caller —
+ * the agent itself is delivery-agnostic; it produces a structured summary
+ * of trends the caller can render into any medium.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'form_name'   => string,                     // required
+ *   'window'      => string,                     // e.g. "daily" | "weekly" | "2026-07-01..2026-07-07"
+ *   'submissions' => array<int, array<string, mixed>>,  // required — normalized submissions
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   headline:      string,
+ *   total_count:   int,
+ *   themes:        [ { title: string, count: int, examples: string[] } ],
+ *   notable:       string[],
+ *   suggestions:   string[]
+ * }
+ * ```
+ *
+ *
+ * @since      1.2.0
+ */
+class SubmissionSummaryAgent extends ArtisanPackAgent
+{
+    /**
+     * Maximum submissions the agent will include in the prompt, to bound
+     * token spend on very high-volume forms.
+     *
+     * @since 1.2.0
+     *
+     * @var int
+     */
+    protected const SUBMISSION_LIMIT = 200;
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $featureKey = 'forms.submission_summary';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $package = 'artisanpack-ui/forms';
+
+    /**
+     * {@inheritDoc}
+     */
+    public string $defaultModel = 'claude-sonnet-4-6';
+
+    /**
+     * {@inheritDoc}
+     *
+     * Long-running summarization; stream by default per the AI RFC.
+     */
+    public bool $stream = true;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function instructions(): string
+    {
+        return <<<'PROMPT'
+You summarize what people submitted to a single form over a reporting window and surface trends the form owner should notice.
+
+Requirements:
+- `headline` is one short sentence (<= 140 chars) that captures the single most useful thing the owner should know this period (e.g. "37 requests this week — 60% asking about pricing tiers").
+- `total_count` MUST equal the number of submissions provided in the input, not an estimate.
+- `themes` groups submissions into 2-6 recurring themes. Each theme has a short human-readable title, a rounded count, and 1-3 short verbatim example phrases (redacted where necessary — never include emails, phone numbers, or full names). Every submission does NOT have to fit a theme.
+- `notable` is 0-5 sentences highlighting specific submissions or patterns the owner should follow up on (VIP-looking asks, angry customers, security or legal signals). Each entry MUST reference concrete detail from the submission (never "one submission was interesting").
+- `suggestions` is 0-3 short actionable ideas for the form owner grounded in the data (e.g. "add a pricing FAQ link — 4 of 12 submissions asked about it").
+- If the window contains 0 submissions, return `headline` explaining that, `total_count: 0`, and empty arrays for the other fields.
+- Do NOT fabricate submissions or themes that aren't supported by the provided data.
+
+Return a JSON object with keys: headline, total_count, themes, notable, suggestions.
+PROMPT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function outputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'additionalProperties' => false,
+            'required' => ['headline', 'total_count', 'themes', 'notable', 'suggestions'],
+            'properties' => [
+                'headline' => ['type' => 'string', 'maxLength' => 140],
+                'total_count' => ['type' => 'integer', 'minimum' => 0],
+                'themes' => [
+                    'type' => 'array',
+                    'maxItems' => 6,
+                    'items' => [
+                        'type' => 'object',
+                        'additionalProperties' => false,
+                        'required' => ['title', 'count', 'examples'],
+                        'properties' => [
+                            'title' => ['type' => 'string'],
+                            'count' => ['type' => 'integer', 'minimum' => 0],
+                            'examples' => [
+                                'type' => 'array',
+                                'maxItems' => 3,
+                                'items' => ['type' => 'string'],
+                            ],
+                        ],
+                    ],
+                ],
+                'notable' => [
+                    'type' => 'array',
+                    'maxItems' => 5,
+                    'items' => ['type' => 'string'],
+                ],
+                'suggestions' => [
+                    'type' => 'array',
+                    'maxItems' => 3,
+                    'items' => ['type' => 'string'],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function execute(Credentials $credentials, string $model, string $instructions): array
+    {
+        $normalized = $this->normalizeInput($this->input());
+
+        $prompter = app(AgentPrompter::class);
+
+        $result = $prompter->prompt(
+            credentials: $credentials,
+            model: $model,
+            instructions: $instructions,
+            message: $this->buildMessage($normalized),
+            outputSchema: $this->outputSchema(),
+        );
+
+        return [
+            'output' => $this->validateOutput($result['output'] ?? [], $normalized['total_count']),
+            'input_tokens' => (int) ($result['input_tokens'] ?? 0),
+            'output_tokens' => (int) ($result['output_tokens'] ?? 0),
+        ];
+    }
+
+    /**
+     * Validate and shape-check the raw agent input.
+     *
+     * @since 1.2.0
+     *
+     * @param  mixed  $input  Raw agent input.
+     * @return array{ form_name: string, window: string, submissions: array<int, array<string, mixed>>, total_count: int }
+     */
+    protected function normalizeInput(mixed $input): array
+    {
+        if (! is_array($input)) {
+            throw FeatureError::forFeature(
+                $this->featureKey,
+                'input must be an array with `form_name` and `submissions` keys.',
+            );
+        }
+
+        $formName = isset($input['form_name']) && is_string($input['form_name'])
+            ? trim($input['form_name'])
+            : '';
+
+        if ($formName === '') {
+            throw FeatureError::forFeature($this->featureKey, '`form_name` must be a non-empty string.');
+        }
+
+        $submissions = $input['submissions'] ?? null;
+
+        if (! is_array($submissions)) {
+            throw FeatureError::forFeature($this->featureKey, '`submissions` must be an array.');
+        }
+
+        $window = isset($input['window']) && is_string($input['window'])
+            ? trim($input['window'])
+            : 'weekly';
+
+        $total = count($submissions);
+
+        if ($total > self::SUBMISSION_LIMIT) {
+            $submissions = array_slice($submissions, 0, self::SUBMISSION_LIMIT);
+        }
+
+        return [
+            'form_name' => $formName,
+            'window' => $window === '' ? 'weekly' : $window,
+            'submissions' => array_values($submissions),
+            'total_count' => $total,
+        ];
+    }
+
+    /**
+     * Assemble the structured message body for the prompter.
+     *
+     * @since 1.2.0
+     *
+     * @param  array{ form_name: string, window: string, submissions: array<int, array<string, mixed>>, total_count: int }  $normalized  Normalized input.
+     * @return array<int, array<string, string>>
+     */
+    protected function buildMessage(array $normalized): array
+    {
+        $parts = [
+            ['type' => 'text', 'text' => sprintf('Form name: %s', $normalized['form_name'])],
+            ['type' => 'text', 'text' => sprintf('Reporting window: %s', $normalized['window'])],
+            ['type' => 'text', 'text' => sprintf('Total submissions in window: %d', $normalized['total_count'])],
+        ];
+
+        if ($normalized['total_count'] > count($normalized['submissions'])) {
+            $parts[] = [
+                'type' => 'text',
+                'text' => sprintf(
+                    'NOTE: only the first %d submissions are included below; use `total_count` as the true count.',
+                    count($normalized['submissions']),
+                ),
+            ];
+        }
+
+        $parts[] = [
+            'type' => 'text',
+            'text' => "Submissions (JSON array):\n".json_encode(
+                $normalized['submissions'],
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+            ),
+        ];
+
+        return $parts;
+    }
+
+    /**
+     * Enforce output invariants — force `total_count` to the input truth,
+     * clamp arrays, and trim strings.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<string, mixed>  $output  Decoded model output.
+     * @param  int  $inputTotal  Ground-truth submission count.
+     * @return array{ headline: string, total_count: int, themes: array<int, array{ title: string, count: int, examples: array<int, string> }>, notable: array<int, string>, suggestions: array<int, string> }
+     */
+    protected function validateOutput(array $output, int $inputTotal): array
+    {
+        $headline = isset($output['headline']) && is_string($output['headline'])
+            ? trim($output['headline'])
+            : '';
+
+        if (mb_strlen($headline) > 140) {
+            $headline = mb_substr($headline, 0, 140);
+        }
+
+        return [
+            'headline' => $headline,
+            'total_count' => $inputTotal,
+            'themes' => $this->normalizeThemes($output['themes'] ?? []),
+            'notable' => $this->clampList($this->stringList($output['notable'] ?? []), 5),
+            'suggestions' => $this->clampList($this->stringList($output['suggestions'] ?? []), 3),
+        ];
+    }
+
+    /**
+     * Normalize the themes array.
+     *
+     * @since 1.2.0
+     *
+     * @param  mixed  $raw  Raw themes from the model.
+     * @return array<int, array{ title: string, count: int, examples: array<int, string> }>
+     */
+    protected function normalizeThemes(mixed $raw): array
+    {
+        if (! is_array($raw)) {
+            return [];
+        }
+
+        $themes = [];
+
+        foreach ($raw as $theme) {
+            if (! is_array($theme)) {
+                continue;
+            }
+
+            $title = isset($theme['title']) ? trim((string) $theme['title']) : '';
+
+            if ($title === '') {
+                continue;
+            }
+
+            $themes[] = [
+                'title' => $title,
+                'count' => max(0, (int) ($theme['count'] ?? 0)),
+                'examples' => $this->clampList($this->stringList($theme['examples'] ?? []), 3),
+            ];
+        }
+
+        if (count($themes) > 6) {
+            $themes = array_slice($themes, 0, 6);
+        }
+
+        return $themes;
+    }
+
+    /**
+     * Clamp a list to a maximum length.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<int, string>  $list  Input list.
+     * @param  int  $max  Maximum length.
+     * @return array<int, string>
+     */
+    protected function clampList(array $list, int $max): array
+    {
+        return count($list) > $max ? array_slice($list, 0, $max) : $list;
+    }
+
+    /**
+     * Filter a raw list into a clean array of non-empty strings.
+     *
+     * @since 1.2.0
+     *
+     * @param  mixed  $raw  Raw list from the model.
+     * @return array<int, string>
+     */
+    protected function stringList(mixed $raw): array
+    {
+        if (! is_array($raw)) {
+            return [];
+        }
+
+        $out = [];
+
+        foreach ($raw as $value) {
+            if (! is_string($value)) {
+                continue;
+            }
+
+            $trimmed = trim($value);
+
+            if ($trimmed === '') {
+                continue;
+            }
+
+            $out[] = $trimmed;
+        }
+
+        return $out;
+    }
+}

--- a/src/FormsServiceProvider.php
+++ b/src/FormsServiceProvider.php
@@ -6,22 +6,29 @@
  * Bootstraps the Forms package by registering configuration, database migrations,
  * Livewire components, event listeners, and authorization policies.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @author     Jacob Martella <support@artisanpackui.dev>
  *
  * @since      1.0.0
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Forms;
 
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Forms\Ai\Agents\ResponseClassificationAgent;
+use ArtisanPackUI\Forms\Ai\Agents\SmartFieldValidationAgent;
+use ArtisanPackUI\Forms\Ai\Agents\SpamDetectionAgent;
+use ArtisanPackUI\Forms\Ai\Agents\SubmissionSummaryAgent;
 use ArtisanPackUI\Forms\Console\Commands\InstallFrontend;
 use ArtisanPackUI\Forms\Console\Commands\PruneFormSubmissions;
 use ArtisanPackUI\Forms\Events\FormSubmitted;
 use ArtisanPackUI\Forms\Listeners\SendWebhookOnSubmission;
+use ArtisanPackUI\Forms\Livewire\Ai\ResponseClassifier;
+use ArtisanPackUI\Forms\Livewire\Ai\SmartFieldValidator;
+use ArtisanPackUI\Forms\Livewire\Ai\SpamCheck;
+use ArtisanPackUI\Forms\Livewire\Ai\SubmissionSummary;
 use ArtisanPackUI\Forms\Livewire\FormBuilder;
 use ArtisanPackUI\Forms\Livewire\FormRenderer;
 use ArtisanPackUI\Forms\Livewire\FormsList;
@@ -51,8 +58,6 @@ use RuntimeException;
  * the main artisanpack.php config file following the ArtisanPack UI
  * package conventions.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @since      1.0.0
  */
@@ -66,51 +71,49 @@ class FormsServiceProvider extends ServiceProvider
      * Also registers all service classes as singletons in the container.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     public function register(): void
     {
         $this->mergeConfigFrom(
-            __DIR__ . '/../config/forms.php',
+            __DIR__.'/../config/forms.php',
             'artisanpack-forms-temp',
         );
 
-        $this->app->singleton( 'forms', function ( $app ) {
+        $this->app->singleton('forms', function ($app) {
             return new Forms;
-        } );
+        });
 
-        $this->app->singleton( FormService::class, function ( $app ) {
+        $this->app->singleton(FormService::class, function ($app) {
             return new FormService;
-        } );
+        });
 
-        $this->app->singleton( FieldService::class, function ( $app ) {
+        $this->app->singleton(FieldService::class, function ($app) {
             return new FieldService;
-        } );
+        });
 
-        $this->app->singleton( StepService::class, function ( $app ) {
+        $this->app->singleton(StepService::class, function ($app) {
             return new StepService;
-        } );
+        });
 
-        $this->app->singleton( ConditionalLogicService::class, function ( $app ) {
+        $this->app->singleton(ConditionalLogicService::class, function ($app) {
             return new ConditionalLogicService;
-        } );
+        });
 
-        $this->app->singleton( NotificationService::class, function ( $app ) {
-            return new NotificationService( $app->make( ConditionalLogicService::class ) );
-        } );
+        $this->app->singleton(NotificationService::class, function ($app) {
+            return new NotificationService($app->make(ConditionalLogicService::class));
+        });
 
-        $this->app->singleton( SubmissionService::class, function ( $app ) {
-            return new SubmissionService( $app->make( NotificationService::class ) );
-        } );
+        $this->app->singleton(SubmissionService::class, function ($app) {
+            return new SubmissionService($app->make(NotificationService::class));
+        });
 
-        $this->app->singleton( ExportService::class, function ( $app ) {
+        $this->app->singleton(ExportService::class, function ($app) {
             return new ExportService;
-        } );
+        });
 
-        $this->app->singleton( IntegrationService::class, function ( $app ) {
+        $this->app->singleton(IntegrationService::class, function ($app) {
             return new IntegrationService;
-        } );
+        });
     }
 
     /**
@@ -120,8 +123,6 @@ class FormsServiceProvider extends ServiceProvider
      * config array, loads database migrations, views, and routes.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     public function boot(): void
     {
@@ -132,9 +133,9 @@ class FormsServiceProvider extends ServiceProvider
         $this->registerEventListeners();
         $this->registerPolicies();
         $this->publishConfiguration();
-        $this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
-        $this->loadViewsFrom( __DIR__ . '/../resources/views', 'forms' );
-        $this->loadRoutesFrom( __DIR__ . '/../routes/web.php' );
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'forms');
+        $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
         $this->loadApiRoutes();
         $this->registerLivewireComponents();
         $this->publishViews();
@@ -150,15 +151,13 @@ class FormsServiceProvider extends ServiceProvider
      * take precedence over the package's default values.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     protected function mergeConfiguration(): void
     {
-        $packageDefaults = config( 'artisanpack-forms-temp', [] );
-        $userConfig      = config( 'artisanpack.forms', [] );
-        $mergedConfig    = array_replace_recursive( $packageDefaults, $userConfig );
-        config( ['artisanpack.forms' => $mergedConfig] );
+        $packageDefaults = config('artisanpack-forms-temp', []);
+        $userConfig = config('artisanpack.forms', []);
+        $mergedConfig = array_replace_recursive($packageDefaults, $userConfig);
+        config(['artisanpack.forms' => $mergedConfig]);
     }
 
     /**
@@ -171,29 +170,27 @@ class FormsServiceProvider extends ServiceProvider
      * @since 1.0.0
      *
      * @throws RuntimeException If the user model class is invalid.
-     *
-     * @return void
      */
     protected function validateUserModelConfiguration(): void
     {
         // Only validate if ownership restriction is enabled
-        if ( ! config( 'artisanpack.forms.authorization.restrict_by_owner', false ) ) {
+        if (! config('artisanpack.forms.authorization.restrict_by_owner', false)) {
             return;
         }
 
-        $userModel = config( 'artisanpack.forms.authorization.user_model', 'App\\Models\\User' );
+        $userModel = config('artisanpack.forms.authorization.user_model', 'App\\Models\\User');
 
-        if ( ! class_exists( $userModel ) ) {
+        if (! class_exists($userModel)) {
             throw new RuntimeException(
-                "The configured user model class '{$userModel}' does not exist. " .
-                'Please set a valid class in FORMS_USER_MODEL environment variable or ' .
+                "The configured user model class '{$userModel}' does not exist. ".
+                'Please set a valid class in FORMS_USER_MODEL environment variable or '.
                 'artisanpack.forms.authorization.user_model configuration.',
             );
         }
 
-        if ( ! is_subclass_of( $userModel, Model::class ) ) {
+        if (! is_subclass_of($userModel, Model::class)) {
             throw new RuntimeException(
-                "The configured user model class '{$userModel}' must extend " .
+                "The configured user model class '{$userModel}' must extend ".
                 'Illuminate\\Database\\Eloquent\\Model.',
             );
         }
@@ -206,17 +203,15 @@ class FormsServiceProvider extends ServiceProvider
      * if it hasn't already been defined by the user.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     protected function registerFilesystemDisk(): void
     {
-        $diskConfig = config( 'artisanpack.forms.disk_config', [] );
+        $diskConfig = config('artisanpack.forms.disk_config', []);
 
-        foreach ( $diskConfig as $diskName => $diskSettings ) {
+        foreach ($diskConfig as $diskName => $diskSettings) {
             // Only add the disk if it doesn't already exist
-            if ( null === config( "filesystems.disks.{$diskName}" ) ) {
-                config( ["filesystems.disks.{$diskName}" => $diskSettings] );
+            if (config("filesystems.disks.{$diskName}") === null) {
+                config(["filesystems.disks.{$diskName}" => $diskSettings]);
             }
         }
     }
@@ -227,16 +222,14 @@ class FormsServiceProvider extends ServiceProvider
      * Commands are only registered when running in the console environment.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     protected function registerCommands(): void
     {
-        if ( $this->app->runningInConsole() ) {
-            $this->commands( [
+        if ($this->app->runningInConsole()) {
+            $this->commands([
                 InstallFrontend::class,
                 PruneFormSubmissions::class,
-            ] );
+            ]);
         }
     }
 
@@ -246,12 +239,10 @@ class FormsServiceProvider extends ServiceProvider
      * Sets up listeners for form-related events such as submission webhooks.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     protected function registerEventListeners(): void
     {
-        Event::listen( FormSubmitted::class, SendWebhookOnSubmission::class );
+        Event::listen(FormSubmitted::class, SendWebhookOnSubmission::class);
     }
 
     /**
@@ -261,13 +252,11 @@ class FormsServiceProvider extends ServiceProvider
      * Laravel's Gate authorization system.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     protected function registerPolicies(): void
     {
-        Gate::policy( Models\Form::class, Policies\FormPolicy::class );
-        Gate::policy( Models\FormSubmission::class, Policies\SubmissionPolicy::class );
+        Gate::policy(Models\Form::class, Policies\FormPolicy::class);
+        Gate::policy(Models\FormSubmission::class, Policies\SubmissionPolicy::class);
     }
 
     /**
@@ -277,15 +266,13 @@ class FormsServiceProvider extends ServiceProvider
      * the unified ArtisanPack UI configuration structure.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     protected function publishConfiguration(): void
     {
-        if ( $this->app->runningInConsole() ) {
-            $this->publishes( [
-                __DIR__ . '/../config/forms.php' => config_path( 'artisanpack/forms.php' ),
-            ], 'artisanpack-package-config' );
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/forms.php' => config_path('artisanpack/forms.php'),
+            ], 'artisanpack-package-config');
         }
     }
 
@@ -295,19 +282,88 @@ class FormsServiceProvider extends ServiceProvider
      * Components are only registered if Livewire is available in the application.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     protected function registerLivewireComponents(): void
     {
-        if ( class_exists( Livewire::class ) ) {
-            Livewire::component( 'forms-list', FormsList::class );
-            Livewire::component( 'form-builder', FormBuilder::class );
-            Livewire::component( 'form-renderer', FormRenderer::class );
-            Livewire::component( 'notification-editor', NotificationEditor::class );
-            Livewire::component( 'submissions-list', SubmissionsList::class );
-            Livewire::component( 'submission-detail', SubmissionDetail::class );
+        if (! class_exists(Livewire::class)) {
+            return;
         }
+
+        Livewire::component('forms-list', FormsList::class);
+        Livewire::component('form-builder', FormBuilder::class);
+        Livewire::component('form-renderer', FormRenderer::class);
+        Livewire::component('notification-editor', NotificationEditor::class);
+        Livewire::component('submissions-list', SubmissionsList::class);
+        Livewire::component('submission-detail', SubmissionDetail::class);
+
+        // AI trigger components are only registered when artisanpack-ui/ai is
+        // installed, since each component's mount path constructs an agent
+        // that extends the ai package's ArtisanPackAgent base class.
+        if (! self::aiPackageAvailable()) {
+            return;
+        }
+
+        Livewire::component('forms::ai-spam-check', SpamCheck::class);
+        Livewire::component('forms::ai-submission-summary', SubmissionSummary::class);
+        Livewire::component('forms::ai-response-classifier', ResponseClassifier::class);
+        Livewire::component('forms::ai-smart-field-validator', SmartFieldValidator::class);
+    }
+
+    /**
+     * Declare AI features owned by this package.
+     *
+     * Auto-discovered by artisanpack-ui/ai when the ai package is installed.
+     * Each entry maps a fully-qualified feature key to the agent class that
+     * fulfills it, along with a human-readable label and description for the
+     * admin UI.
+     *
+     * @since 1.2.0
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function aiFeatures(): array
+    {
+        return [
+            'forms.spam_detection' => [
+                'agent' => SpamDetectionAgent::class,
+                'package' => 'artisanpack-ui/forms',
+                'label' => __('Spam detection'),
+                'description' => __('Semantic spam score, verdict, and reasons on top of existing honeypot and rate-limit checks.'),
+            ],
+            'forms.submission_summary' => [
+                'agent' => SubmissionSummaryAgent::class,
+                'package' => 'artisanpack-ui/forms',
+                'label' => __('Submission summary'),
+                'description' => __('Periodic digest of submission themes, notable entries, and suggested follow-ups.'),
+            ],
+            'forms.response_classification' => [
+                'agent' => ResponseClassificationAgent::class,
+                'package' => 'artisanpack-ui/forms',
+                'label' => __('Response classification'),
+                'description' => __('Auto-categorize incoming submissions against a caller-supplied set of labels.'),
+            ],
+            'forms.smart_validation' => [
+                'agent' => SmartFieldValidationAgent::class,
+                'package' => 'artisanpack-ui/forms',
+                'label' => __('Smart field validation'),
+                'description' => __('Opt-in semantic per-field plausibility check that complements format validation.'),
+            ],
+        ];
+    }
+
+    /**
+     * Whether the optional `artisanpack-ui/ai` package is installed.
+     *
+     * The AI Feature Suite (agents and Livewire trigger components) all
+     * extend or resolve from types owned by `artisanpack-ui/ai`. When that
+     * package is absent, this returns false and callers skip the AI-specific
+     * registration.
+     *
+     * @since 1.2.0
+     */
+    public static function aiPackageAvailable(): bool
+    {
+        return class_exists(ArtisanPackAgent::class);
     }
 
     /**
@@ -316,13 +372,11 @@ class FormsServiceProvider extends ServiceProvider
      * Only loads routes when the API is enabled in configuration.
      *
      * @since 1.1.0
-     *
-     * @return void
      */
     protected function loadApiRoutes(): void
     {
-        if ( config( 'artisanpack.forms.api.enabled', true ) ) {
-            $this->loadRoutesFrom( __DIR__ . '/../routes/api.php' );
+        if (config('artisanpack.forms.api.enabled', true)) {
+            $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
         }
     }
 
@@ -332,15 +386,13 @@ class FormsServiceProvider extends ServiceProvider
      * Views are published to resources/views/vendor/forms for customization.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     protected function publishViews(): void
     {
-        if ( $this->app->runningInConsole() ) {
-            $this->publishes( [
-                __DIR__ . '/../resources/views' => resource_path( 'views/vendor/forms' ),
-            ], 'artisanpack-forms-views' );
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../resources/views' => resource_path('views/vendor/forms'),
+            ], 'artisanpack-forms-views');
         }
     }
 
@@ -351,15 +403,13 @@ class FormsServiceProvider extends ServiceProvider
      * React, Vue, or other TypeScript-based frontend frameworks.
      *
      * @since 1.1.0
-     *
-     * @return void
      */
     protected function publishTypeDefinitions(): void
     {
-        if ( $this->app->runningInConsole() ) {
-            $this->publishes( [
-                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'types/artisanpack-forms.d.ts' ),
-            ], 'forms-types' );
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../resources/js/types/artisanpack-forms.d.ts' => resource_path('types/artisanpack-forms.d.ts'),
+            ], 'forms-types');
         }
     }
 
@@ -370,17 +420,15 @@ class FormsServiceProvider extends ServiceProvider
      * for use in React-based frontend applications.
      *
      * @since 1.1.0
-     *
-     * @return void
      */
     protected function publishReactComponents(): void
     {
-        if ( $this->app->runningInConsole() ) {
-            $this->publishes( [
-                __DIR__ . '/../resources/js/react'                        => resource_path( 'js/vendor/artisanpack-forms/react' ),
-                __DIR__ . '/../resources/js/shared'                       => resource_path( 'js/vendor/artisanpack-forms/shared' ),
-                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts' ),
-            ], 'forms-react' );
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../resources/js/react' => resource_path('js/vendor/artisanpack-forms/react'),
+                __DIR__.'/../resources/js/shared' => resource_path('js/vendor/artisanpack-forms/shared'),
+                __DIR__.'/../resources/js/types/artisanpack-forms.d.ts' => resource_path('js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts'),
+            ], 'forms-react');
         }
     }
 
@@ -391,17 +439,15 @@ class FormsServiceProvider extends ServiceProvider
      * for use in Vue-based frontend applications.
      *
      * @since 1.1.0
-     *
-     * @return void
      */
     protected function publishVueComponents(): void
     {
-        if ( $this->app->runningInConsole() ) {
-            $this->publishes( [
-                __DIR__ . '/../resources/js/vue'                          => resource_path( 'js/vendor/artisanpack-forms/vue' ),
-                __DIR__ . '/../resources/js/shared'                       => resource_path( 'js/vendor/artisanpack-forms/shared' ),
-                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts' ),
-            ], 'forms-vue' );
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../resources/js/vue' => resource_path('js/vendor/artisanpack-forms/vue'),
+                __DIR__.'/../resources/js/shared' => resource_path('js/vendor/artisanpack-forms/shared'),
+                __DIR__.'/../resources/js/types/artisanpack-forms.d.ts' => resource_path('js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts'),
+            ], 'forms-vue');
         }
     }
 }

--- a/src/Livewire/Ai/ResponseClassifier.php
+++ b/src/Livewire/Ai/ResponseClassifier.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * ResponseClassifier Livewire component.
+ *
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.2.0
+ */
+
+declare(strict_types=1);
+
+namespace ArtisanPackUI\Forms\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\Forms\Ai\Agents\ResponseClassificationAgent;
+use Illuminate\View\View;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger UI for the {@see ResponseClassificationAgent}.
+ *
+ * Mounts inside the submissions admin surface. Emits
+ * `forms-ai-category-selected` (payload: `[ 'submission_id' => int,
+ * 'category' => string, 'confidence' => float, 'suggested_new' => string|null ]`)
+ * when the user accepts a suggestion.
+ *
+ *
+ * @since      1.2.0
+ */
+class ResponseClassifier extends Component
+{
+    public int $submissionId = 0;
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $fields = [];
+
+    /**
+     * @var array<int, string>
+     */
+    public array $availableCategories = [];
+
+    public bool $isLoading = false;
+
+    public ?string $error = null;
+
+    public ?string $category = null;
+
+    public ?float $confidence = null;
+
+    public ?string $suggestedNew = null;
+
+    /**
+     * Mount the component with initial context from the containing surface.
+     *
+     * @since 1.2.0
+     *
+     * @param  int  $submissionId  Submission id (for the emitted event).
+     * @param  array<string, mixed>  $fields  Submitted field values.
+     * @param  array<int, string>  $availableCategories  Category labels to choose from.
+     */
+    public function mount(int $submissionId = 0, array $fields = [], array $availableCategories = []): void
+    {
+        $this->submissionId = $submissionId;
+        $this->fields = $fields;
+        $this->availableCategories = $availableCategories;
+    }
+
+    /**
+     * React to the parent surface updating the submission context.
+     *
+     * @since 1.2.0
+     *
+     * @param  array{ submission_id?: int, fields?: array<string, mixed>, available_categories?: array<int, string> }  $payload  New context.
+     */
+    #[On('forms-ai-classifier-context-updated')]
+    public function contextUpdated(array $payload): void
+    {
+        if (isset($payload['submission_id'])) {
+            $this->submissionId = (int) $payload['submission_id'];
+        }
+
+        if (isset($payload['fields']) && is_array($payload['fields'])) {
+            $this->fields = $payload['fields'];
+        }
+
+        if (isset($payload['available_categories']) && is_array($payload['available_categories'])) {
+            $this->availableCategories = $payload['available_categories'];
+        }
+    }
+
+    /**
+     * Run the agent and populate the classification fields or `$error`.
+     *
+     * @since 1.2.0
+     */
+    public function classify(): void
+    {
+        $this->error = null;
+        $this->category = null;
+        $this->confidence = null;
+        $this->suggestedNew = null;
+        $this->isLoading = true;
+
+        try {
+            $output = ResponseClassificationAgent::for([
+                'fields' => $this->fields,
+                'available_categories' => $this->availableCategories,
+            ])->run();
+
+            $this->category = (string) ($output['category'] ?? '');
+            $this->confidence = (float) ($output['confidence'] ?? 0);
+            $this->suggestedNew = isset($output['suggested_new']) ? (string) $output['suggested_new'] : null;
+        } catch (FeatureDisabledException $exception) {
+            $this->error = __('This AI feature is disabled.');
+        } catch (MissingCredentialsException $exception) {
+            $this->error = __('AI credentials are not configured.');
+        } catch (FeatureError $exception) {
+            $this->error = $exception->getMessage();
+        } catch (Throwable $exception) {
+            $this->error = __('The AI agent could not complete this request.');
+        } finally {
+            $this->isLoading = false;
+        }
+    }
+
+    /**
+     * Accept the suggestion and emit it back to the parent surface.
+     *
+     * @since 1.2.0
+     */
+    public function accept(): void
+    {
+        if ($this->category === null) {
+            return;
+        }
+
+        $this->dispatch(
+            'forms-ai-category-selected',
+            submission_id: $this->submissionId,
+            category: $this->category,
+            confidence: $this->confidence ?? 0.0,
+            suggested_new: $this->suggestedNew,
+        );
+    }
+
+    /**
+     * Determine whether this feature is enabled in the registry.
+     *
+     * @since 1.2.0
+     */
+    public function getIsEnabledProperty(): bool
+    {
+        $registry = app(FeatureRegistry::class);
+        $key = 'forms.response_classification';
+
+        if ($registry->get($key) === null) {
+            return false;
+        }
+
+        return $registry->isToggleOn($key);
+    }
+
+    /**
+     * Render the component view.
+     *
+     * @since 1.2.0
+     */
+    public function render(): View
+    {
+        return view('forms::livewire.ai.response-classifier');
+    }
+}

--- a/src/Livewire/Ai/SmartFieldValidator.php
+++ b/src/Livewire/Ai/SmartFieldValidator.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * SmartFieldValidator Livewire component.
+ *
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.2.0
+ */
+
+declare(strict_types=1);
+
+namespace ArtisanPackUI\Forms\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\Forms\Ai\Agents\SmartFieldValidationAgent;
+use Illuminate\View\View;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger UI for the {@see SmartFieldValidationAgent}.
+ *
+ * Mounts alongside a single form field to run an on-demand semantic check.
+ * Emits `forms-ai-field-verdict` (payload: `[ 'field_name' => string,
+ * 'plausible' => bool, 'confidence' => float, 'reason' => string ]`).
+ *
+ *
+ * @since      1.2.0
+ */
+class SmartFieldValidator extends Component
+{
+    public string $fieldName = '';
+
+    public string $fieldLabel = '';
+
+    public string $fieldKind = '';
+
+    public string $value = '';
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $context = [];
+
+    public bool $isLoading = false;
+
+    public ?string $error = null;
+
+    public ?bool $plausible = null;
+
+    public ?float $confidence = null;
+
+    public ?string $reason = null;
+
+    public ?string $suggestion = null;
+
+    /**
+     * Mount the component with initial context from the containing surface.
+     *
+     * @since 1.2.0
+     *
+     * @param  string  $fieldName  Field name (for the emitted event).
+     * @param  string  $fieldLabel  Human-readable label.
+     * @param  string  $fieldKind  Field kind (address, company_name, etc.).
+     * @param  string  $value  Current field value.
+     * @param  array<string, mixed>  $context  Sibling fields for cross-checks.
+     */
+    public function mount(
+        string $fieldName = '',
+        string $fieldLabel = '',
+        string $fieldKind = '',
+        string $value = '',
+        array $context = [],
+    ): void {
+        $this->fieldName = $fieldName;
+        $this->fieldLabel = $fieldLabel;
+        $this->fieldKind = $fieldKind;
+        $this->value = $value;
+        $this->context = $context;
+    }
+
+    /**
+     * React to the parent surface updating the field context.
+     *
+     * @since 1.2.0
+     *
+     * @param  array{ field_name?: string, field_label?: string, field_kind?: string, value?: string, context?: array<string, mixed> }  $payload  New context.
+     */
+    #[On('forms-ai-field-context-updated')]
+    public function contextUpdated(array $payload): void
+    {
+        if (isset($payload['field_name'])) {
+            $this->fieldName = (string) $payload['field_name'];
+        }
+
+        if (isset($payload['field_label'])) {
+            $this->fieldLabel = (string) $payload['field_label'];
+        }
+
+        if (isset($payload['field_kind'])) {
+            $this->fieldKind = (string) $payload['field_kind'];
+        }
+
+        if (isset($payload['value'])) {
+            $this->value = (string) $payload['value'];
+        }
+
+        if (isset($payload['context']) && is_array($payload['context'])) {
+            $this->context = $payload['context'];
+        }
+    }
+
+    /**
+     * Run the agent and populate the verdict fields or `$error`.
+     *
+     * @since 1.2.0
+     */
+    public function validateField(): void
+    {
+        $this->error = null;
+        $this->plausible = null;
+        $this->confidence = null;
+        $this->reason = null;
+        $this->suggestion = null;
+        $this->isLoading = true;
+
+        try {
+            $output = SmartFieldValidationAgent::for([
+                'field_label' => $this->fieldLabel,
+                'field_kind' => $this->fieldKind,
+                'value' => $this->value,
+                'context' => $this->context === [] ? null : $this->context,
+            ])->run();
+
+            $this->plausible = (bool) ($output['plausible'] ?? true);
+            $this->confidence = (float) ($output['confidence'] ?? 0);
+            $this->reason = (string) ($output['reason'] ?? '');
+            $this->suggestion = isset($output['suggestion']) ? (string) $output['suggestion'] : null;
+
+            $this->dispatch(
+                'forms-ai-field-verdict',
+                field_name: $this->fieldName,
+                plausible: $this->plausible,
+                confidence: $this->confidence,
+                reason: $this->reason,
+            );
+        } catch (FeatureDisabledException $exception) {
+            $this->error = __('This AI feature is disabled.');
+        } catch (MissingCredentialsException $exception) {
+            $this->error = __('AI credentials are not configured.');
+        } catch (FeatureError $exception) {
+            $this->error = $exception->getMessage();
+        } catch (Throwable $exception) {
+            $this->error = __('The AI agent could not complete this request.');
+        } finally {
+            $this->isLoading = false;
+        }
+    }
+
+    /**
+     * Determine whether this feature is enabled in the registry.
+     *
+     * @since 1.2.0
+     */
+    public function getIsEnabledProperty(): bool
+    {
+        $registry = app(FeatureRegistry::class);
+        $key = 'forms.smart_validation';
+
+        if ($registry->get($key) === null) {
+            return false;
+        }
+
+        return $registry->isToggleOn($key);
+    }
+
+    /**
+     * Render the component view.
+     *
+     * @since 1.2.0
+     */
+    public function render(): View
+    {
+        return view('forms::livewire.ai.smart-field-validator');
+    }
+}

--- a/src/Livewire/Ai/SpamCheck.php
+++ b/src/Livewire/Ai/SpamCheck.php
@@ -1,0 +1,171 @@
+<?php
+
+/**
+ * SpamCheck Livewire component.
+ *
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.2.0
+ */
+
+declare(strict_types=1);
+
+namespace ArtisanPackUI\Forms\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\Forms\Ai\Agents\SpamDetectionAgent;
+use Illuminate\View\View;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger UI for the {@see SpamDetectionAgent}.
+ *
+ * Mounts inside the submissions admin surface to score a single submission
+ * on demand. Emits `forms-ai-spam-verdict` (payload:
+ * `[ 'submission_id' => int, 'verdict' => string, 'spam_score' => int ]`)
+ * when a run completes so the parent list can update its filters.
+ *
+ *
+ * @since      1.2.0
+ */
+class SpamCheck extends Component
+{
+    public int $submissionId = 0;
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $fields = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    public array $meta = [];
+
+    public bool $isLoading = false;
+
+    public ?string $error = null;
+
+    public ?int $spamScore = null;
+
+    public ?string $verdict = null;
+
+    /**
+     * @var array<int, string>
+     */
+    public array $reasons = [];
+
+    /**
+     * Mount the component with initial context from the containing surface.
+     *
+     * @since 1.2.0
+     *
+     * @param  int  $submissionId  Submission id (for the emitted event).
+     * @param  array<string, mixed>  $fields  Submitted field values.
+     * @param  array<string, mixed>  $meta  Submission metadata (ip_country, etc.).
+     */
+    public function mount(int $submissionId = 0, array $fields = [], array $meta = []): void
+    {
+        $this->submissionId = $submissionId;
+        $this->fields = $fields;
+        $this->meta = $meta;
+    }
+
+    /**
+     * React to the parent surface updating the submission context.
+     *
+     * @since 1.2.0
+     *
+     * @param  array{ submission_id?: int, fields?: array<string, mixed>, meta?: array<string, mixed> }  $payload  New context.
+     */
+    #[On('forms-ai-submission-updated')]
+    public function submissionUpdated(array $payload): void
+    {
+        if (isset($payload['submission_id'])) {
+            $this->submissionId = (int) $payload['submission_id'];
+        }
+
+        if (isset($payload['fields']) && is_array($payload['fields'])) {
+            $this->fields = $payload['fields'];
+        }
+
+        if (isset($payload['meta']) && is_array($payload['meta'])) {
+            $this->meta = $payload['meta'];
+        }
+    }
+
+    /**
+     * Run the agent and populate the verdict fields or `$error`.
+     *
+     * @since 1.2.0
+     */
+    public function check(): void
+    {
+        $this->error = null;
+        $this->spamScore = null;
+        $this->verdict = null;
+        $this->reasons = [];
+        $this->isLoading = true;
+
+        try {
+            $output = SpamDetectionAgent::for([
+                'fields' => $this->fields,
+                'meta' => $this->meta,
+            ])->run();
+
+            $this->spamScore = (int) ($output['spam_score'] ?? 0);
+            $this->verdict = (string) ($output['verdict'] ?? 'ham');
+            $this->reasons = $output['reasons'] ?? [];
+
+            $this->dispatch(
+                'forms-ai-spam-verdict',
+                submission_id: $this->submissionId,
+                verdict: $this->verdict,
+                spam_score: $this->spamScore,
+            );
+        } catch (FeatureDisabledException $exception) {
+            $this->error = __('This AI feature is disabled.');
+        } catch (MissingCredentialsException $exception) {
+            $this->error = __('AI credentials are not configured.');
+        } catch (FeatureError $exception) {
+            $this->error = $exception->getMessage();
+        } catch (Throwable $exception) {
+            $this->error = __('The AI agent could not complete this request.');
+        } finally {
+            $this->isLoading = false;
+        }
+    }
+
+    /**
+     * Determine whether this feature is enabled in the registry.
+     *
+     * @since 1.2.0
+     */
+    public function getIsEnabledProperty(): bool
+    {
+        $registry = app(FeatureRegistry::class);
+        $key = 'forms.spam_detection';
+
+        if ($registry->get($key) === null) {
+            return false;
+        }
+
+        return $registry->isToggleOn($key);
+    }
+
+    /**
+     * Render the component view.
+     *
+     * @since 1.2.0
+     */
+    public function render(): View
+    {
+        return view('forms::livewire.ai.spam-check');
+    }
+}

--- a/src/Livewire/Ai/SubmissionSummary.php
+++ b/src/Livewire/Ai/SubmissionSummary.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * SubmissionSummary Livewire component.
+ *
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.2.0
+ */
+
+declare(strict_types=1);
+
+namespace ArtisanPackUI\Forms\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\Forms\Ai\Agents\SubmissionSummaryAgent;
+use Illuminate\View\View;
+use Livewire\Attributes\On;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger UI for the {@see SubmissionSummaryAgent}.
+ *
+ * Mounts inside the forms admin surface to generate an on-demand summary of
+ * submissions for a chosen window. Emits `forms-ai-summary-ready` when a run
+ * completes so a parent can offer a "Send digest email" action against the
+ * generated summary.
+ *
+ *
+ * @since      1.2.0
+ */
+class SubmissionSummary extends Component
+{
+    public string $formName = '';
+
+    public string $window = 'weekly';
+
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    public array $submissions = [];
+
+    public bool $isLoading = false;
+
+    public ?string $error = null;
+
+    public ?string $headline = null;
+
+    public int $totalCount = 0;
+
+    /**
+     * @var array<int, array{ title: string, count: int, examples: array<int, string> }>
+     */
+    public array $themes = [];
+
+    /**
+     * @var array<int, string>
+     */
+    public array $notable = [];
+
+    /**
+     * @var array<int, string>
+     */
+    public array $suggestions = [];
+
+    /**
+     * Mount the component with initial context from the containing surface.
+     *
+     * @since 1.2.0
+     *
+     * @param  string  $formName  Form name.
+     * @param  string  $window  Reporting window (daily/weekly/range).
+     * @param  array<int, array<string, mixed>>  $submissions  Normalized submissions.
+     */
+    public function mount(string $formName = '', string $window = 'weekly', array $submissions = []): void
+    {
+        $this->formName = $formName;
+        $this->window = $window === '' ? 'weekly' : $window;
+        $this->submissions = $submissions;
+    }
+
+    /**
+     * React to the parent surface updating the summary context.
+     *
+     * @since 1.2.0
+     *
+     * @param  array{ form_name?: string, window?: string, submissions?: array<int, array<string, mixed>> }  $payload  New context.
+     */
+    #[On('forms-ai-summary-context-updated')]
+    public function contextUpdated(array $payload): void
+    {
+        if (isset($payload['form_name'])) {
+            $this->formName = (string) $payload['form_name'];
+        }
+
+        if (isset($payload['window']) && trim((string) $payload['window']) !== '') {
+            $this->window = (string) $payload['window'];
+        }
+
+        if (isset($payload['submissions']) && is_array($payload['submissions'])) {
+            $this->submissions = $payload['submissions'];
+        }
+    }
+
+    /**
+     * Run the agent and populate the summary fields or `$error`.
+     *
+     * @since 1.2.0
+     */
+    public function summarize(): void
+    {
+        $this->error = null;
+        $this->headline = null;
+        $this->totalCount = 0;
+        $this->themes = [];
+        $this->notable = [];
+        $this->suggestions = [];
+        $this->isLoading = true;
+
+        try {
+            $output = SubmissionSummaryAgent::for([
+                'form_name' => $this->formName,
+                'window' => $this->window,
+                'submissions' => $this->submissions,
+            ])->run();
+
+            $this->headline = (string) ($output['headline'] ?? '');
+            $this->totalCount = (int) ($output['total_count'] ?? 0);
+            $this->themes = $output['themes'] ?? [];
+            $this->notable = $output['notable'] ?? [];
+            $this->suggestions = $output['suggestions'] ?? [];
+
+            $this->dispatch(
+                'forms-ai-summary-ready',
+                form_name: $this->formName,
+                window: $this->window,
+                headline: $this->headline,
+                total_count: $this->totalCount,
+            );
+        } catch (FeatureDisabledException $exception) {
+            $this->error = __('This AI feature is disabled.');
+        } catch (MissingCredentialsException $exception) {
+            $this->error = __('AI credentials are not configured.');
+        } catch (FeatureError $exception) {
+            $this->error = $exception->getMessage();
+        } catch (Throwable $exception) {
+            $this->error = __('The AI agent could not complete this request.');
+        } finally {
+            $this->isLoading = false;
+        }
+    }
+
+    /**
+     * Determine whether this feature is enabled in the registry.
+     *
+     * @since 1.2.0
+     */
+    public function getIsEnabledProperty(): bool
+    {
+        $registry = app(FeatureRegistry::class);
+        $key = 'forms.submission_summary';
+
+        if ($registry->get($key) === null) {
+            return false;
+        }
+
+        return $registry->isToggleOn($key);
+    }
+
+    /**
+     * Render the component view.
+     *
+     * @since 1.2.0
+     */
+    public function render(): View
+    {
+        return view('forms::livewire.ai.submission-summary');
+    }
+}

--- a/tests/Feature/Ai/AiAgentTestSetup.php
+++ b/tests/Feature/Ai/AiAgentTestSetup.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Shared setup helpers for Forms AI agent tests.
+ *
+ *
+ * @since      1.2.0
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Contracts\CredentialResolver;
+use ArtisanPackUI\Ai\Credentials\ChainedCredentialResolver;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use Illuminate\Foundation\Application;
+use Tests\Support\FakeAgentPrompter;
+
+/**
+ * Registers a fake prompter and stub credentials for the four Forms AI
+ * features so agents can run without hitting the network.
+ *
+ *
+ * @since      1.2.0
+ */
+class AiAgentTestSetup
+{
+    /**
+     * Prepare the container so agents can run against a fake prompter.
+     *
+     * @since 1.2.0
+     *
+     * @param  Application  $app  Application instance.
+     * @return FakeAgentPrompter The bound fake prompter.
+     */
+    public static function bootstrap($app): FakeAgentPrompter
+    {
+        /** @var ChainedCredentialResolver $resolver */
+        $resolver = $app->make(CredentialResolver::class);
+        $resolver->setOverride(
+            new Credentials(provider: 'anthropic', apiKey: 'sk-test', defaultModel: 'claude-haiku-4-5'),
+        );
+        $resolver->useStore(fn () => null);
+
+        $prompter = new FakeAgentPrompter;
+        $app->instance(AgentPrompter::class, $prompter);
+
+        foreach (
+            [
+                'forms.spam_detection',
+                'forms.submission_summary',
+                'forms.response_classification',
+                'forms.smart_validation',
+            ] as $key
+        ) {
+            $app['config']->set("artisanpack.ai.features.{$key}.enabled", true);
+        }
+
+        return $prompter;
+    }
+}

--- a/tests/Feature/Ai/FeatureRegistryTest.php
+++ b/tests/Feature/Ai/FeatureRegistryTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Forms\Ai\Agents\ResponseClassificationAgent;
+use ArtisanPackUI\Forms\Ai\Agents\SmartFieldValidationAgent;
+use ArtisanPackUI\Forms\Ai\Agents\SpamDetectionAgent;
+use ArtisanPackUI\Forms\Ai\Agents\SubmissionSummaryAgent;
+use ArtisanPackUI\Forms\FormsServiceProvider;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach(function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap($this->app);
+});
+
+it('registers all four Forms AI features on the FormsServiceProvider', function (): void {
+    $provider = $this->app->make(FormsServiceProvider::class, ['app' => $this->app]);
+
+    $features = $provider->aiFeatures();
+
+    expect(array_keys($features))->toBe([
+        'forms.spam_detection',
+        'forms.submission_summary',
+        'forms.response_classification',
+        'forms.smart_validation',
+    ]);
+
+    expect($features['forms.spam_detection']['agent'])->toBe(SpamDetectionAgent::class);
+    expect($features['forms.submission_summary']['agent'])->toBe(SubmissionSummaryAgent::class);
+    expect($features['forms.response_classification']['agent'])->toBe(ResponseClassificationAgent::class);
+    expect($features['forms.smart_validation']['agent'])->toBe(SmartFieldValidationAgent::class);
+
+    foreach ($features as $definition) {
+        expect($definition['package'])->toBe('artisanpack-ui/forms');
+    }
+});
+
+it('refuses to run the spam agent when the feature toggle is off', function (): void {
+    $registry = $this->app->make(FeatureRegistry::class);
+    $registry->register(
+        'forms.spam_detection',
+        SpamDetectionAgent::class,
+        ['package' => 'artisanpack-ui/forms'],
+    );
+    $registry->disable('forms.spam_detection');
+
+    expect(fn () => SpamDetectionAgent::for([
+        'fields' => ['message' => 'hi'],
+    ])->run())
+        ->toThrow(FeatureDisabledException::class);
+});
+
+it('refuses to run the submission summary agent when the feature toggle is off', function (): void {
+    $registry = $this->app->make(FeatureRegistry::class);
+    $registry->register(
+        'forms.submission_summary',
+        SubmissionSummaryAgent::class,
+        ['package' => 'artisanpack-ui/forms'],
+    );
+    $registry->disable('forms.submission_summary');
+
+    expect(fn () => SubmissionSummaryAgent::for([
+        'form_name' => 'Contact us',
+        'submissions' => [],
+    ])->run())
+        ->toThrow(FeatureDisabledException::class);
+});
+
+it('refuses to run the classifier agent when the feature toggle is off', function (): void {
+    $registry = $this->app->make(FeatureRegistry::class);
+    $registry->register(
+        'forms.response_classification',
+        ResponseClassificationAgent::class,
+        ['package' => 'artisanpack-ui/forms'],
+    );
+    $registry->disable('forms.response_classification');
+
+    expect(fn () => ResponseClassificationAgent::for([
+        'fields' => ['message' => 'hi'],
+        'available_categories' => ['support-request'],
+    ])->run())
+        ->toThrow(FeatureDisabledException::class);
+});
+
+it('refuses to run the smart validator agent when the feature toggle is off', function (): void {
+    $registry = $this->app->make(FeatureRegistry::class);
+    $registry->register(
+        'forms.smart_validation',
+        SmartFieldValidationAgent::class,
+        ['package' => 'artisanpack-ui/forms'],
+    );
+    $registry->disable('forms.smart_validation');
+
+    expect(fn () => SmartFieldValidationAgent::for([
+        'field_label' => 'Company',
+        'field_kind' => 'company_name',
+        'value' => 'Anthropic',
+    ])->run())
+        ->toThrow(FeatureDisabledException::class);
+});

--- a/tests/Feature/Ai/ResponseClassificationAgentTest.php
+++ b/tests/Feature/Ai/ResponseClassificationAgentTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Forms\Ai\Agents\ResponseClassificationAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach(function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap($this->app);
+});
+
+it('returns the shaped category when the prompter responds', function (): void {
+    $this->prompter->queue([
+        'category' => 'support-request',
+        'confidence' => 0.9,
+    ]);
+
+    $result = ResponseClassificationAgent::for([
+        'fields' => ['message' => 'my login is broken'],
+        'available_categories' => ['support-request', 'sales-inquiry', 'feedback'],
+    ])->run();
+
+    expect($result['category'])->toBe('support-request');
+    expect($result['confidence'])->toBe(0.9);
+    expect($result)->not->toHaveKey('suggested_new');
+});
+
+it('falls back to the first available category when the model returns an unknown label', function (): void {
+    $this->prompter->queue([
+        'category' => 'made-up',
+        'confidence' => 0.8,
+    ]);
+
+    $result = ResponseClassificationAgent::for([
+        'fields' => ['message' => 'hi'],
+        'available_categories' => ['support-request', 'sales-inquiry'],
+    ])->run();
+
+    expect($result['category'])->toBe('support-request');
+    expect($result['confidence'])->toBeLessThanOrEqual(0.2);
+});
+
+it('clamps confidence to the [0, 1] interval', function (): void {
+    $this->prompter->queue([
+        'category' => 'support-request',
+        'confidence' => 2.5,
+    ]);
+
+    $result = ResponseClassificationAgent::for([
+        'fields' => ['message' => 'hi'],
+        'available_categories' => ['support-request', 'sales-inquiry'],
+    ])->run();
+
+    expect($result['confidence'])->toBe(1.0);
+});
+
+it('accepts a suggested_new only below the confidence threshold', function (): void {
+    $this->prompter->queue([
+        'category' => 'support-request',
+        'confidence' => 0.3,
+        'suggested_new' => 'partnership-request',
+    ]);
+
+    $result = ResponseClassificationAgent::for([
+        'fields' => ['message' => 'we want to co-brand something'],
+        'available_categories' => ['support-request', 'sales-inquiry'],
+    ])->run();
+
+    expect($result)->toHaveKey('suggested_new');
+    expect($result['suggested_new'])->toBe('partnership-request');
+});
+
+it('strips suggested_new when confidence is at or above the threshold', function (): void {
+    $this->prompter->queue([
+        'category' => 'support-request',
+        'confidence' => 0.7,
+        'suggested_new' => 'partnership-request',
+    ]);
+
+    $result = ResponseClassificationAgent::for([
+        'fields' => ['message' => 'login broken'],
+        'available_categories' => ['support-request', 'sales-inquiry'],
+    ])->run();
+
+    expect($result)->not->toHaveKey('suggested_new');
+});
+
+it('strips suggested_new when it duplicates an existing category', function (): void {
+    $this->prompter->queue([
+        'category' => 'support-request',
+        'confidence' => 0.3,
+        'suggested_new' => 'Sales Inquiry',
+    ]);
+
+    $result = ResponseClassificationAgent::for([
+        'fields' => ['message' => 'hi'],
+        'available_categories' => ['support-request', 'sales-inquiry'],
+    ])->run();
+
+    expect($result)->not->toHaveKey('suggested_new');
+});
+
+it('normalizes a proposed new-category label into a kebab-case slug', function (): void {
+    $this->prompter->queue([
+        'category' => 'support-request',
+        'confidence' => 0.2,
+        'suggested_new' => 'Partnership Opportunities!',
+    ]);
+
+    $result = ResponseClassificationAgent::for([
+        'fields' => ['message' => 'hi'],
+        'available_categories' => ['support-request', 'sales-inquiry'],
+    ])->run();
+
+    expect($result['suggested_new'])->toBe('partnership-opportunities');
+});
+
+it('raises FeatureError when available_categories is empty', function (): void {
+    expect(fn () => ResponseClassificationAgent::for([
+        'fields' => ['message' => 'hi'],
+        'available_categories' => [],
+    ])->run())
+        ->toThrow(FeatureError::class);
+});
+
+it('raises FeatureError when fields is missing', function (): void {
+    expect(fn () => ResponseClassificationAgent::for([
+        'available_categories' => ['support-request'],
+    ])->run())
+        ->toThrow(FeatureError::class);
+});
+
+it('dedupes available_categories in the prompter message', function (): void {
+    $this->prompter->queue([
+        'category' => 'support-request',
+        'confidence' => 0.9,
+    ]);
+
+    ResponseClassificationAgent::for([
+        'fields' => ['message' => 'help'],
+        'available_categories' => ['support-request', 'support-request', 'sales-inquiry'],
+    ])->run();
+
+    $parts = collect($this->prompter->calls[0]['message'])->pluck('text');
+    $categoriesLine = $parts->first(fn (string $text): bool => str_starts_with($text, 'Available categories:'));
+    expect(substr_count((string) $categoriesLine, 'support-request'))->toBe(1);
+});

--- a/tests/Feature/Ai/SmartFieldValidationAgentTest.php
+++ b/tests/Feature/Ai/SmartFieldValidationAgentTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Forms\Ai\Agents\SmartFieldValidationAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach(function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap($this->app);
+});
+
+it('returns the shaped verdict when the prompter responds', function (): void {
+    $this->prompter->queue([
+        'plausible' => true,
+        'confidence' => 0.85,
+        'reason' => 'looks like a real business name',
+    ]);
+
+    $result = SmartFieldValidationAgent::for([
+        'field_label' => 'Company',
+        'field_kind' => 'company_name',
+        'value' => 'Anthropic',
+    ])->run();
+
+    expect($result['plausible'])->toBeTrue();
+    expect($result['confidence'])->toBe(0.85);
+    expect($result['reason'])->toBe('looks like a real business name');
+    expect($result)->not->toHaveKey('suggestion');
+});
+
+it('clamps confidence to the [0, 1] interval', function (): void {
+    $this->prompter->queue([
+        'plausible' => true,
+        'confidence' => -0.4,
+        'reason' => 'unclear',
+    ]);
+
+    $result = SmartFieldValidationAgent::for([
+        'field_label' => 'Company',
+        'field_kind' => 'company_name',
+        'value' => 'Acme',
+    ])->run();
+
+    expect($result['confidence'])->toBe(0.0);
+});
+
+it('truncates an oversize reason down to 200 characters', function (): void {
+    $long = str_repeat('x', 500);
+
+    $this->prompter->queue([
+        'plausible' => false,
+        'confidence' => 0.3,
+        'reason' => $long,
+    ]);
+
+    $result = SmartFieldValidationAgent::for([
+        'field_label' => 'Address',
+        'field_kind' => 'address',
+        'value' => '123 Fake St',
+    ])->run();
+
+    expect(mb_strlen($result['reason']))->toBe(200);
+});
+
+it('keeps a suggestion when the value is implausible', function (): void {
+    $this->prompter->queue([
+        'plausible' => false,
+        'confidence' => 0.2,
+        'reason' => 'looks like a placeholder',
+        'suggestion' => 'add a city and state',
+    ]);
+
+    $result = SmartFieldValidationAgent::for([
+        'field_label' => 'Address',
+        'field_kind' => 'address',
+        'value' => '123 Fake St',
+    ])->run();
+
+    expect($result)->toHaveKey('suggestion');
+    expect($result['suggestion'])->toBe('add a city and state');
+});
+
+it('strips a suggestion when the value is plausible', function (): void {
+    $this->prompter->queue([
+        'plausible' => true,
+        'confidence' => 0.9,
+        'reason' => 'looks fine',
+        'suggestion' => 'no fix needed',
+    ]);
+
+    $result = SmartFieldValidationAgent::for([
+        'field_label' => 'Company',
+        'field_kind' => 'company_name',
+        'value' => 'Anthropic',
+    ])->run();
+
+    expect($result)->not->toHaveKey('suggestion');
+});
+
+it('raises FeatureError when required input is missing', function (): void {
+    expect(fn () => SmartFieldValidationAgent::for([
+        'field_label' => 'Address',
+        'field_kind' => 'address',
+        // Missing value
+    ])->run())
+        ->toThrow(FeatureError::class);
+
+    expect(fn () => SmartFieldValidationAgent::for([
+        'field_kind' => 'address',
+        'value' => '123 Main St',
+        // Missing field_label
+    ])->run())
+        ->toThrow(FeatureError::class);
+});
+
+it('includes the sibling context in the prompter message when supplied', function (): void {
+    $this->prompter->queue([
+        'plausible' => true,
+        'confidence' => 0.9,
+        'reason' => 'sibling city matches address',
+    ]);
+
+    SmartFieldValidationAgent::for([
+        'field_label' => 'Address',
+        'field_kind' => 'address',
+        'value' => '1 Infinite Loop',
+        'context' => ['city' => 'Cupertino', 'state' => 'CA'],
+    ])->run();
+
+    $parts = collect($this->prompter->calls[0]['message'])->pluck('text');
+    expect($parts->contains(fn (string $text): bool => str_contains($text, 'Cupertino')))
+        ->toBeTrue();
+});

--- a/tests/Feature/Ai/SpamDetectionAgentTest.php
+++ b/tests/Feature/Ai/SpamDetectionAgentTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Forms\Ai\Agents\SpamDetectionAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach(function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap($this->app);
+});
+
+it('returns the shaped verdict when the prompter responds', function (): void {
+    $this->prompter->queue([
+        'spam_score' => 82,
+        'verdict' => 'spam',
+        'reasons' => ['message body is a marketing pitch unrelated to the form purpose'],
+    ]);
+
+    $result = SpamDetectionAgent::for([
+        'fields' => ['name' => 'Bob', 'message' => 'Buy cheap watches now!'],
+        'meta' => ['ip_country' => 'RU', 'submission_speed_ms' => 400],
+    ])->run();
+
+    expect($result['spam_score'])->toBe(82);
+    expect($result['verdict'])->toBe('spam');
+    expect($result['reasons'])->toHaveCount(1);
+});
+
+it('clamps out-of-range scores back into [0, 100]', function (): void {
+    $this->prompter->queue([
+        'spam_score' => 250,
+        'verdict' => 'spam',
+        'reasons' => [],
+    ]);
+
+    $result = SpamDetectionAgent::for([
+        'fields' => ['message' => 'hi'],
+    ])->run();
+
+    expect($result['spam_score'])->toBe(100);
+});
+
+it('derives a verdict from the score when the model returns an unknown label', function (): void {
+    $this->prompter->queue([
+        'spam_score' => 20,
+        'verdict' => 'nope',
+        'reasons' => [],
+    ]);
+
+    $result = SpamDetectionAgent::for([
+        'fields' => ['message' => 'hello there'],
+    ])->run();
+
+    expect($result['verdict'])->toBe('ham');
+});
+
+it('trims the reasons list to five entries', function (): void {
+    $this->prompter->queue([
+        'spam_score' => 60,
+        'verdict' => 'suspicious',
+        'reasons' => ['one', 'two', 'three', 'four', 'five', 'six', 'seven'],
+    ]);
+
+    $result = SpamDetectionAgent::for([
+        'fields' => ['message' => 'hey'],
+    ])->run();
+
+    expect($result['reasons'])->toHaveCount(5);
+});
+
+it('drops non-string reasons and blank entries', function (): void {
+    $this->prompter->queue([
+        'spam_score' => 50,
+        'verdict' => 'suspicious',
+        'reasons' => ['valid reason', '', '   ', 123, ['nested'], 'another valid one'],
+    ]);
+
+    $result = SpamDetectionAgent::for([
+        'fields' => ['message' => 'hey'],
+    ])->run();
+
+    expect($result['reasons'])->toBe(['valid reason', 'another valid one']);
+});
+
+it('raises FeatureError when fields is missing or empty', function (): void {
+    expect(fn () => SpamDetectionAgent::for([])->run())
+        ->toThrow(FeatureError::class);
+
+    expect(fn () => SpamDetectionAgent::for(['fields' => []])->run())
+        ->toThrow(FeatureError::class);
+});
+
+it('includes the submission metadata in the prompter message when supplied', function (): void {
+    $this->prompter->queue([
+        'spam_score' => 5,
+        'verdict' => 'ham',
+        'reasons' => [],
+    ]);
+
+    SpamDetectionAgent::for([
+        'fields' => ['message' => 'legit customer question'],
+        'meta' => ['ip_country' => 'US', 'submission_speed_ms' => 4500],
+    ])->run();
+
+    $parts = collect($this->prompter->calls[0]['message'])->pluck('text');
+    expect($parts->contains(fn (string $text): bool => str_contains($text, 'ip_country')))
+        ->toBeTrue();
+    expect($parts->contains(fn (string $text): bool => str_contains($text, 'submission_speed_ms')))
+        ->toBeTrue();
+});

--- a/tests/Feature/Ai/SubmissionSummaryAgentTest.php
+++ b/tests/Feature/Ai/SubmissionSummaryAgentTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Forms\Ai\Agents\SubmissionSummaryAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach(function (): void {
+    $this->prompter = AiAgentTestSetup::bootstrap($this->app);
+});
+
+it('returns the shaped summary when the prompter responds', function (): void {
+    $this->prompter->queue([
+        'headline' => '3 submissions this week, mostly pricing questions.',
+        'total_count' => 3,
+        'themes' => [
+            ['title' => 'Pricing questions', 'count' => 2, 'examples' => ['What does the pro tier include?']],
+        ],
+        'notable' => ['One submission flagged an accessibility bug in the pricing page.'],
+        'suggestions' => ['Link a pricing FAQ from the form intro.'],
+    ]);
+
+    $result = SubmissionSummaryAgent::for([
+        'form_name' => 'Contact us',
+        'window' => 'weekly',
+        'submissions' => [
+            ['message' => 'How much is pro?'],
+            ['message' => 'Pricing tiers?'],
+            ['message' => 'Bug: pricing page keyboard nav broken'],
+        ],
+    ])->run();
+
+    expect($result['headline'])->toStartWith('3 submissions this week');
+    expect($result['total_count'])->toBe(3);
+    expect($result['themes'])->toHaveCount(1);
+    expect($result['themes'][0]['title'])->toBe('Pricing questions');
+    expect($result['suggestions'])->toHaveCount(1);
+});
+
+it('overrides the model total_count with the true input count', function (): void {
+    $this->prompter->queue([
+        'headline' => 'lots of submissions',
+        'total_count' => 999,
+        'themes' => [],
+        'notable' => [],
+        'suggestions' => [],
+    ]);
+
+    $result = SubmissionSummaryAgent::for([
+        'form_name' => 'Contact us',
+        'submissions' => [
+            ['message' => 'a'],
+            ['message' => 'b'],
+        ],
+    ])->run();
+
+    expect($result['total_count'])->toBe(2);
+});
+
+it('truncates an oversize headline down to 140 chars', function (): void {
+    $long = str_repeat('x', 200);
+
+    $this->prompter->queue([
+        'headline' => $long,
+        'total_count' => 0,
+        'themes' => [],
+        'notable' => [],
+        'suggestions' => [],
+    ]);
+
+    $result = SubmissionSummaryAgent::for([
+        'form_name' => 'Contact us',
+        'submissions' => [],
+    ])->run();
+
+    expect(mb_strlen($result['headline']))->toBe(140);
+});
+
+it('clamps themes to 6, notable to 5, and suggestions to 3', function (): void {
+    $this->prompter->queue([
+        'headline' => 'headline',
+        'total_count' => 10,
+        'themes' => array_map(
+            static fn (int $i): array => ['title' => "Theme {$i}", 'count' => 1, 'examples' => []],
+            range(1, 10),
+        ),
+        'notable' => array_map(static fn (int $i): string => "notable {$i}", range(1, 8)),
+        'suggestions' => array_map(static fn (int $i): string => "suggestion {$i}", range(1, 6)),
+    ]);
+
+    $result = SubmissionSummaryAgent::for([
+        'form_name' => 'Contact us',
+        'submissions' => [['x' => 1]],
+    ])->run();
+
+    expect($result['themes'])->toHaveCount(6);
+    expect($result['notable'])->toHaveCount(5);
+    expect($result['suggestions'])->toHaveCount(3);
+});
+
+it('drops themes with empty titles', function (): void {
+    $this->prompter->queue([
+        'headline' => 'headline',
+        'total_count' => 1,
+        'themes' => [
+            ['title' => '', 'count' => 3, 'examples' => []],
+            ['title' => 'Real theme', 'count' => 4, 'examples' => ['example']],
+        ],
+        'notable' => [],
+        'suggestions' => [],
+    ]);
+
+    $result = SubmissionSummaryAgent::for([
+        'form_name' => 'Contact us',
+        'submissions' => [['x' => 1]],
+    ])->run();
+
+    expect($result['themes'])->toHaveCount(1);
+    expect($result['themes'][0]['title'])->toBe('Real theme');
+});
+
+it('notes when the submission list was truncated in the prompt', function (): void {
+    $this->prompter->queue([
+        'headline' => 'headline',
+        'total_count' => 500,
+        'themes' => [],
+        'notable' => [],
+        'suggestions' => [],
+    ]);
+
+    $submissions = array_map(
+        static fn (int $i): array => ['message' => "sub {$i}"],
+        range(1, 500),
+    );
+
+    SubmissionSummaryAgent::for([
+        'form_name' => 'Contact us',
+        'submissions' => $submissions,
+    ])->run();
+
+    $parts = collect($this->prompter->calls[0]['message'])->pluck('text');
+    expect($parts->contains(fn (string $text): bool => str_contains($text, 'Total submissions in window: 500')))
+        ->toBeTrue();
+    expect($parts->contains(fn (string $text): bool => str_contains($text, 'only the first 200')))
+        ->toBeTrue();
+});
+
+it('raises FeatureError when form_name is missing', function (): void {
+    expect(fn () => SubmissionSummaryAgent::for(['submissions' => []])->run())
+        ->toThrow(FeatureError::class);
+});
+
+it('raises FeatureError when submissions is not an array', function (): void {
+    expect(fn () => SubmissionSummaryAgent::for(['form_name' => 'Contact', 'submissions' => 'nope'])->run())
+        ->toThrow(FeatureError::class);
+});

--- a/tests/Support/FakeAgentPrompter.php
+++ b/tests/Support/FakeAgentPrompter.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Test fake for the AgentPrompter contract.
+ *
+ *
+ * @since      1.2.0
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+
+/**
+ * Records every prompter call and returns queued responses in order.
+ *
+ *
+ * @since      1.2.0
+ */
+final class FakeAgentPrompter implements AgentPrompter
+{
+    /**
+     * Recorded calls, in invocation order.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    public array $calls = [];
+
+    /**
+     * Queued responses (FIFO).
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    private array $queue = [];
+
+    /**
+     * Push a canned response onto the queue.
+     *
+     * @since 1.2.0
+     *
+     * @param  array<string, mixed>  $output  Structured output body.
+     * @param  int  $inputTokens  Reported input tokens.
+     * @param  int  $outputTokens  Reported output tokens.
+     */
+    public function queue(array $output, int $inputTokens = 100, int $outputTokens = 50): void
+    {
+        $this->queue[] = [
+            'output' => $output,
+            'input_tokens' => $inputTokens,
+            'output_tokens' => $outputTokens,
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function prompt(
+        Credentials $credentials,
+        string $model,
+        string $instructions,
+        string|array $message,
+        array $outputSchema,
+    ): array {
+        $this->calls[] = [
+            'credentials' => $credentials,
+            'model' => $model,
+            'instructions' => $instructions,
+            'message' => $message,
+            'output_schema' => $outputSchema,
+        ];
+
+        if ($this->queue === []) {
+            return [
+                'output' => [],
+                'input_tokens' => 0,
+                'output_tokens' => 0,
+            ];
+        }
+
+        return array_shift($this->queue);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,13 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace Tests;
 
+use ArtisanPackUI\Ai\AiServiceProvider;
 use ArtisanPackUI\Forms\FormsServiceProvider;
+use Illuminate\Foundation\Application;
+use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Blade;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
@@ -26,24 +29,24 @@ abstract class TestCase extends BaseTestCase
         parent::setUp();
 
         // Register stub components for testing (replaces artisanpack-ui/livewire-ui-components)
-        Blade::component( 'artisanpack-icon', Stubs\IconStub::class );
-        Blade::component( 'artisanpack-button', Stubs\ButtonStub::class );
-        Blade::component( 'artisanpack-input', Stubs\InputStub::class );
-        Blade::component( 'artisanpack-textarea', Stubs\TextareaStub::class );
-        Blade::component( 'artisanpack-select', Stubs\SelectStub::class );
-        Blade::component( 'artisanpack-badge', Stubs\BadgeStub::class );
-        Blade::component( 'artisanpack-alert', Stubs\AlertStub::class );
-        Blade::component( 'artisanpack-card', Stubs\CardStub::class );
-        Blade::component( 'artisanpack-checkbox', Stubs\CheckboxStub::class );
-        Blade::component( 'artisanpack-collapse', Stubs\CollapseStub::class );
-        Blade::component( 'artisanpack-dropdown', Stubs\DropdownStub::class );
-        Blade::component( 'artisanpack-form', Stubs\FormStub::class );
-        Blade::component( 'artisanpack-menu', Stubs\MenuStub::class );
-        Blade::component( 'artisanpack-menu-item', Stubs\MenuItemStub::class );
-        Blade::component( 'artisanpack-tabs', Stubs\TabsStub::class );
-        Blade::component( 'artisanpack-tab', Stubs\TabStub::class );
-        Blade::component( 'artisanpack-toggle', Stubs\ToggleStub::class );
-        Blade::component( 'artisanpack-breadcrumbs', Stubs\BreadcrumbsStub::class );
+        Blade::component('artisanpack-icon', Stubs\IconStub::class);
+        Blade::component('artisanpack-button', Stubs\ButtonStub::class);
+        Blade::component('artisanpack-input', Stubs\InputStub::class);
+        Blade::component('artisanpack-textarea', Stubs\TextareaStub::class);
+        Blade::component('artisanpack-select', Stubs\SelectStub::class);
+        Blade::component('artisanpack-badge', Stubs\BadgeStub::class);
+        Blade::component('artisanpack-alert', Stubs\AlertStub::class);
+        Blade::component('artisanpack-card', Stubs\CardStub::class);
+        Blade::component('artisanpack-checkbox', Stubs\CheckboxStub::class);
+        Blade::component('artisanpack-collapse', Stubs\CollapseStub::class);
+        Blade::component('artisanpack-dropdown', Stubs\DropdownStub::class);
+        Blade::component('artisanpack-form', Stubs\FormStub::class);
+        Blade::component('artisanpack-menu', Stubs\MenuStub::class);
+        Blade::component('artisanpack-menu-item', Stubs\MenuItemStub::class);
+        Blade::component('artisanpack-tabs', Stubs\TabsStub::class);
+        Blade::component('artisanpack-tab', Stubs\TabStub::class);
+        Blade::component('artisanpack-toggle', Stubs\ToggleStub::class);
+        Blade::component('artisanpack-breadcrumbs', Stubs\BreadcrumbsStub::class);
     }
 
     /**
@@ -51,16 +54,21 @@ abstract class TestCase extends BaseTestCase
      *
      * @since 1.0.0
      *
-     * @param  \Illuminate\Foundation\Application  $app  The application instance.
-     *
+     * @param  Application  $app  The application instance.
      * @return array<int, class-string> Array of service provider class names.
      */
-    protected function getPackageProviders( $app ): array
+    protected function getPackageProviders($app): array
     {
-        return [
-            LivewireServiceProvider::class,
-            FormsServiceProvider::class,
-        ];
+        $providers = [LivewireServiceProvider::class];
+
+        // AI provider is optional — only register when artisanpack-ui/ai is installed.
+        if (class_exists(AiServiceProvider::class)) {
+            $providers[] = AiServiceProvider::class;
+        }
+
+        $providers[] = FormsServiceProvider::class;
+
+        return $providers;
     }
 
     /**
@@ -68,37 +76,37 @@ abstract class TestCase extends BaseTestCase
      *
      * @since 1.0.0
      *
-     * @param  \Illuminate\Foundation\Application  $app  The application instance.
+     * @param  Application  $app  The application instance.
      */
-    protected function defineEnvironment( $app ): void
+    protected function defineEnvironment($app): void
     {
         // Setup app key for encryption
-        $app['config']->set( 'app.key', 'base64:' . base64_encode( random_bytes( 32 ) ) );
+        $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
 
         // Setup default database to use sqlite :memory:
-        $app['config']->set( 'database.default', 'testbench' );
-        $app['config']->set( 'database.connections.testbench', [
-            'driver'                  => 'sqlite',
-            'database'                => ':memory:',
-            'prefix'                  => '',
+        $app['config']->set('database.default', 'testbench');
+        $app['config']->set('database.connections.testbench', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
             'foreign_key_constraints' => true,
-        ] );
+        ]);
 
         // Override API middleware for testing (Sanctum not available in package tests)
-        $app['config']->set( 'artisanpack.forms.api.middleware', ['api', 'auth'] );
+        $app['config']->set('artisanpack.forms.api.middleware', ['api', 'auth']);
 
         // Setup filesystem
-        $app['config']->set( 'filesystems.default', 'local' );
-        $app['config']->set( 'filesystems.disks.local', [
+        $app['config']->set('filesystems.default', 'local');
+        $app['config']->set('filesystems.disks.local', [
             'driver' => 'local',
-            'root'   => storage_path( 'app' ),
-        ] );
+            'root' => storage_path('app'),
+        ]);
 
         // Add test stub views path
-        $app['config']->set( 'view.paths', array_merge(
-            $app['config']->get( 'view.paths', [] ),
-            [__DIR__ . '/views'],
-        ) );
+        $app['config']->set('view.paths', array_merge(
+            $app['config']->get('view.paths', []),
+            [__DIR__.'/views'],
+        ));
     }
 
     /**
@@ -106,12 +114,12 @@ abstract class TestCase extends BaseTestCase
      *
      * @since 1.0.0
      *
-     * @param  \Illuminate\Routing\Router  $router  The router instance.
+     * @param  Router  $router  The router instance.
      */
-    protected function defineRoutes( $router ): void
+    protected function defineRoutes($router): void
     {
         // Define a stub login route for authentication testing
-        $router->get( '/login', fn () => 'Login Page' )->name( 'login' );
+        $router->get('/login', fn () => 'Login Page')->name('login');
     }
 
     /**
@@ -122,9 +130,9 @@ abstract class TestCase extends BaseTestCase
     protected function defineDatabaseMigrations(): void
     {
         // Load testing migrations (users table - only for tests)
-        $this->loadMigrationsFrom( __DIR__ . '/../database/migrations/testing' );
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations/testing');
 
         // Load main package migrations (forms tables - will run in consuming apps)
-        $this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
     }
 }


### PR DESCRIPTION
## Description

Wire the Forms package into `artisanpack-ui/ai` with four opt-in AI agents. Each agent extends the base `ArtisanPackAgent` from the AI package, is registered via `aiFeatures()` on `FormsServiceProvider`, and ships a matching Livewire trigger component. When the AI package is not installed, the trigger components are skipped and everything else works unchanged.

**Closes:** #50, #51, #52, #53

## Type of Change

- [x] New feature (adds new functionality)

## Related Issues

- Closes #50 — SpamDetectionAgent
- Closes #51 — SubmissionSummaryAgent
- Closes #52 — ResponseClassificationAgent
- Closes #53 — SmartFieldValidationAgent

## Motivation and Context

The Forms v1.2 milestone bundles four AI features from the [AI RFC](https://github.com/ArtisanPack-UI/.github/discussions/8). Each agent is opt-in per the RFC: the toggle must be on, credentials must be configured, and the agent no-ops otherwise. This keeps upgrades safe for existing installs.

## Changes Made

- `SpamDetectionAgent` (`forms.spam_detection`, `claude-haiku-4-5`) — scores a submission and returns `{ spam_score, verdict, reasons }`. Runs after static checks, doesn't replace them.
- `SubmissionSummaryAgent` (`forms.submission_summary`, `claude-sonnet-4-6`) — periodic digest returning `{ headline, total_count, themes, notable, suggestions }`. Streams by default. Truncates to first 200 submissions in the prompt to bound token spend, but returns the true `total_count`.
- `ResponseClassificationAgent` (`forms.response_classification`, `claude-haiku-4-5`) — categorizes a submission against a caller-supplied whitelist. Falls back to the first available category with low confidence when the model returns an unknown label; may propose a new kebab-case slug when confidence < 0.5.
- `SmartFieldValidationAgent` (`forms.smart_validation`, `claude-haiku-4-5`) — per-field semantic plausibility check that complements format validation.
- Livewire trigger components (`forms::ai-spam-check`, `forms::ai-submission-summary`, `forms::ai-response-classifier`, `forms::ai-smart-field-validator`) — each emits a well-typed event when a run completes and no-ops when the feature toggle is off.
- `aiFeatures()` method on `FormsServiceProvider` auto-registers all four with the AI feature registry when `artisanpack-ui/ai` is installed.
- `artisanpack-ui/ai ^1.0` added as a **dev dependency** — installs without the AI package continue to work.
- Documented all four agents in the README under a new "AI features" section.

## Framework surfaces

React and Vue trigger components are intentionally out of scope for this PR — the four features are Livewire-first and don't require a JS-only trigger UI (they run on the server against saved submissions). This decision was scoped with the issue author before starting.

## How Has This Been Tested?

**Testing Environment:**
- PHP 8.4.3
- Laravel 12.62
- Livewire 3.6

**Tests Performed:**
1. `./vendor/bin/pest tests/Feature/Ai` — 37 tests, 67 assertions, all passing
2. `./vendor/bin/pest --compact` — 851 tests, 1994 assertions, all passing
3. `./vendor/bin/pint --dirty` — clean

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:**

- `SpamDetectionAgentTest` (7 tests) — happy path, score clamping, verdict fallback, reasons list normalization, input validation.
- `SubmissionSummaryAgentTest` (8 tests) — happy path, `total_count` truth-enforcement, headline truncation, array clamps, theme filtering, prompt truncation notice, input validation.
- `ResponseClassificationAgentTest` (10 tests) — happy path, unknown-label fallback, confidence clamping, `suggested_new` gating on threshold, slug normalization, dedup in prompt, input validation.
- `SmartFieldValidationAgentTest` (7 tests) — happy path, confidence clamping, reason truncation, suggestion gating on plausibility, input validation.
- `FeatureRegistryTest` (5 tests) — verifies `aiFeatures()` shape and that each agent throws `FeatureDisabledException` when its toggle is off.
- `Tests\Support\FakeAgentPrompter` and `Tests\Feature\Ai\AiAgentTestSetup` provide the shared prompter fake and container bootstrap so tests never touch the network.

## Documentation

- [x] Inline code documentation added
- [x] README updated

**Documentation details:**

- Added an "AI features" section to `README.md` with feature table and Blade usage examples for each Livewire trigger component.
- Added an "Unreleased" entry to `CHANGELOG.md` covering all four issues.
- All new classes carry full PHPDoc (file header, class summary, method docs).

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Code passes all tests (851/851)
- [x] Code has been linted (`pint --dirty` clean)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional AI-assisted tools for spam detection, submission summaries, response classification, and smart field validation.
  * Introduced new admin-facing interactive components for reviewing and applying AI results.
  * Added support for enabling these AI features only when the AI package is available.

* **Documentation**
  * Expanded the README and changelog with AI feature usage and integration details.

* **Tests**
  * Added coverage for AI feature registration, toggle behavior, and agent output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->