### PR TITLE
Release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Six new `ap.forms.*` hooks for the Wave 5 cross-package standardization ([#58](https://github.com/ArtisanPack-UI/forms/issues/58)):
+  - `ap.forms.beforeValidate` action — fires from `FormRequest::prepareForValidation()` just before Laravel validates a package form request. Payload: `(FormRequest $request)`.
+  - `ap.forms.validated` action — fires from `FormRequest::passedValidation()` after validation succeeds. Payload: `(FormRequest $request, array $validated)`.
+  - `ap.forms.fieldRender` filter — pipes each field's rendered HTML through subscribers before it's echoed in the form-renderer view. Payload: `(string $html, FormField $field)`.
+  - `ap.forms.integrationRegistered` action — fires from `IntegrationService::registerIntegration($slug, $config)` so ecosystem packages can observe every integration registration. Payload: `(string $slug, array $config)`.
+  - `ap.forms.notificationSubject` filter — mutates outgoing notification email subjects. Payload: `(string $subject, FormNotification $notification, FormSubmission $submission)`. Both `notificationSubject` and `notificationBody` fire AFTER the legacy `notificationMessage` filter (which stays for back-compat), on the already-parsed template.
+  - `ap.forms.notificationBody` filter — mutates outgoing notification email bodies. Payload: `(string $body, FormNotification $notification, FormSubmission $submission)`.
+- `Support\FiresValidationHooks` trait applied to `StoreFormRequest`, `UpdateFormRequest`, and `SubmitFormApiRequest` wiring the two validation-lifecycle hooks above.
+- `Support\FieldRenderer::render()` helper used by the form renderer view to render each field partial and pipe the HTML through `ap.forms.fieldRender`.
+- `IntegrationService::registerIntegration(string $slug, array $config = [])` for integration packages to announce themselves during their service provider boot.
+
+### Changed
+
+- Bumped the `artisanpack-ui/hooks` constraint to `^1.3` and dropped every `function_exists('applyFilters' | 'doAction')` guard across `src/`. Hooks 1.3 is now a hard runtime requirement — the 15+ pre-existing guarded sites and the six new Wave 5 sites all call the hook helpers directly.
+
 ### Deprecated
 
 - All 18 hooks previously shipped under `forms.*` / snake_case names have been renamed to the ecosystem-standard `ap.forms.*` camelCase convention (Wave 2 of the cross-package hooks standardization). Existing subscribers continue firing via deprecation aliases registered in `Support\HookAliases`, emitting an info-level `HookDeprecations` log entry per unique resolution. **Aliases will be removed in the next major version — migrate subscribers to the new names before then.** Full rename map is documented in the README. Requires `artisanpack-ui/hooks: ^1.2` (deprecation logging is a no-op on 1.2.x and active on 1.3.0+). ([#57](https://github.com/ArtisanPack-UI/forms/issues/57))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-21
+
 ### Added
 
 - Six new `ap.forms.*` hooks for the Wave 5 cross-package standardization ([#58](https://github.com/ArtisanPack-UI/forms/issues/58)):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- All 18 hooks previously shipped under `forms.*` / snake_case names have been renamed to the ecosystem-standard `ap.forms.*` camelCase convention (Wave 2 of the cross-package hooks standardization). Existing subscribers continue firing via deprecation aliases registered in `Support\HookAliases`, emitting an info-level `HookDeprecations` log entry per unique resolution. **Aliases will be removed in the next major version — migrate subscribers to the new names before then.** Full rename map is documented in the README. Requires `artisanpack-ui/hooks: ^1.2` (deprecation logging is a no-op on 1.2.x and active on 1.3.0+). ([#57](https://github.com/ArtisanPack-UI/forms/issues/57))
+
 ## [1.2.0] - 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -289,6 +289,44 @@ listed below.
 | `forms.notification.sent`        | `ap.forms.notification.sent`       |
 | `forms.notification_message`     | `ap.forms.notificationMessage`     |
 
+### Additional hooks
+
+The following hooks have no legacy alias — they were introduced under the
+canonical `ap.forms.*` convention.
+
+| Hook                              | Type   | Payload                                            |
+|-----------------------------------|--------|----------------------------------------------------|
+| `ap.forms.beforeValidate`         | action | `(FormRequest $request)`                           |
+| `ap.forms.validated`              | action | `(FormRequest $request, array $validated)`         |
+| `ap.forms.fieldRender`            | filter | `(string $html, FormField $field)`                 |
+| `ap.forms.integrationRegistered`  | action | `(string $slug, array $config)`                    |
+| `ap.forms.notificationSubject`    | filter | `(string $subject, FormNotification $notification, FormSubmission $submission)` |
+| `ap.forms.notificationBody`       | filter | `(string $body, FormNotification $notification, FormSubmission $submission)` |
+
+Examples:
+
+```php
+use ArtisanPackUI\Forms\Services\IntegrationService;
+use function addAction;
+use function addFilter;
+
+// Wrap every rendered field in a diagnostic marker
+addFilter('ap.forms.fieldRender', function (string $html, $field): string {
+    return '<div data-field="' . $field->name . '">' . $html . '</div>';
+});
+
+// Observe integration registration from a third-party package
+addAction('ap.forms.integrationRegistered', function (string $slug, array $config): void {
+    logger()->info("forms integration registered: {$slug}", $config);
+});
+
+// Register your own integration from your service provider boot()
+app(IntegrationService::class)->registerIntegration('mailchimp', [
+    'label' => 'Mailchimp',
+    'icon'  => 'o-envelope',
+]);
+```
+
 ## 🤝 Contributing
 
 Contributions are welcome! To contribute:

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Add custom field types using filter hooks:
 ```php
 use function addFilter;
 
-addFilter('forms.field_types', function (array $types) {
+addFilter('ap.forms.fieldTypes', function (array $types) {
     $types['my-custom-field'] = [
         'label' => 'My Custom Field',
         'view' => 'my-package::fields.custom',
@@ -258,6 +258,36 @@ addFilter('forms.field_types', function (array $types) {
     return $types;
 });
 ```
+
+### Hook naming
+
+All package hooks use the `ap.forms.*` camelCase convention shared across the
+ArtisanPack UI ecosystem. Hooks previously shipped under `forms.*` / snake_case
+names remain registered as deprecation aliases (via `Support\HookAliases`), so
+existing subscribers keep firing but emit an info-level deprecation log. The
+aliases will be removed in the next major version — migrate to the new names
+listed below.
+
+| Old (deprecated)                 | New (canonical)                    |
+|----------------------------------|------------------------------------|
+| `forms.field_types`              | `ap.forms.fieldTypes`              |
+| `forms.field_categories`         | `ap.forms.fieldCategories`         |
+| `forms.validation_rules`         | `ap.forms.validationRules`         |
+| `forms.form.created`             | `ap.forms.form.created`            |
+| `forms.form.updated`             | `ap.forms.form.updated`            |
+| `forms.form.deleted`             | `ap.forms.form.deleted`            |
+| `forms.submission.created`       | `ap.forms.submission.created`      |
+| `forms.submission.updated`       | `ap.forms.submission.updated`      |
+| `forms.submission.deleted`       | `ap.forms.submission.deleted`      |
+| `forms.webhook_payload`          | `ap.forms.webhookPayload`          |
+| `forms.settings_tabs`            | `ap.forms.settingsTabs`            |
+| `forms.submission_data`          | `ap.forms.submissionData`          |
+| `forms.export_headers`           | `ap.forms.exportHeaders`           |
+| `forms.export_data`              | `ap.forms.exportData`              |
+| `forms.notification_recipients`  | `ap.forms.notificationRecipients`  |
+| `forms.notification.before_send` | `ap.forms.notification.beforeSend` |
+| `forms.notification.sent`        | `ap.forms.notification.sent`       |
+| `forms.notification_message`     | `ap.forms.notificationMessage`     |
 
 ## 🤝 Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "artisanpack-ui/livewire-ui-components": "^2.0",
     "artisanpack-ui/security": "^1.0|^2.0",
     "artisanpack-ui/accessibility": "^2.1",
-    "artisanpack-ui/hooks": "^1.2",
+    "artisanpack-ui/hooks": "^1.3",
     "livewire/livewire": "^3.6.4|^4.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "A comprehensive form builder and management package for Laravel with drag-and-drop builder, submissions, notifications, file uploads, multi-step forms, conditional logic, and webhooks.",
   "type": "library",
   "license": "GPL-3.0-or-later",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "autoload": {
     "psr-4": {
       "ArtisanPackUI\\Forms\\": "src/",

--- a/config/forms.php
+++ b/config/forms.php
@@ -24,9 +24,9 @@ return [
     */
 
     'admin' => [
-        'prefix' => env('FORMS_ADMIN_PREFIX', 'admin/forms'),
+        'prefix'     => env( 'FORMS_ADMIN_PREFIX', 'admin/forms' ),
         'middleware' => ['web', 'auth'],
-        'per_page' => 15,
+        'per_page'   => 15,
     ],
 
     /*
@@ -41,10 +41,10 @@ return [
     */
 
     'api' => [
-        'enabled' => env('FORMS_API_ENABLED', true),
-        'prefix' => env('FORMS_API_PREFIX', 'api/v1/forms'),
+        'enabled'    => env( 'FORMS_API_ENABLED', true ),
+        'prefix'     => env( 'FORMS_API_PREFIX', 'api/v1/forms' ),
         'middleware' => ['api', 'auth:sanctum'],
-        'per_page' => 15,
+        'per_page'   => 15,
     ],
 
     /*
@@ -59,9 +59,9 @@ return [
     */
 
     'uploads' => [
-        'disk' => env('FORMS_UPLOADS_DISK', 'form-uploads'),
-        'directory' => env('FORMS_UPLOADS_DIRECTORY', 'uploads'),
-        'max_size' => env('FORMS_UPLOADS_MAX_SIZE', 10240), // KB (10MB default)
+        'disk'          => env( 'FORMS_UPLOADS_DISK', 'form-uploads' ),
+        'directory'     => env( 'FORMS_UPLOADS_DIRECTORY', 'uploads' ),
+        'max_size'      => env( 'FORMS_UPLOADS_MAX_SIZE', 10240 ), // KB (10MB default)
         'allowed_mimes' => [
             'application/pdf',
             'application/msword',
@@ -89,8 +89,8 @@ return [
     */
 
     'submissions' => [
-        'store_submissions' => true,
-        'retention_days' => env('FORMS_RETENTION_DAYS', null), // null = keep forever
+        'store_submissions'        => true,
+        'retention_days'           => env( 'FORMS_RETENTION_DAYS', null ), // null = keep forever
         'submission_number_format' => 'FORM-{year}-{sequence}',
     ],
 
@@ -107,13 +107,13 @@ return [
 
     'spam_protection' => [
         'honeypot' => [
-            'enabled' => true,
+            'enabled'    => true,
             'field_name' => 'website_url',
         ],
         'rate_limit' => [
-            'enabled' => true,
+            'enabled'  => true,
             'attempts' => 5,
-            'decay' => 60, // seconds
+            'decay'    => 60, // seconds
         ],
     ],
 
@@ -129,10 +129,10 @@ return [
     */
 
     'notifications' => [
-        'from_name' => env('FORMS_FROM_NAME'),
-        'from_email' => env('FORMS_FROM_EMAIL'),
-        'queue' => env('FORMS_NOTIFICATION_QUEUE', 'default'),
-        'show_ip_in_emails' => env('FORMS_SHOW_IP_IN_EMAILS', true),
+        'from_name'         => env( 'FORMS_FROM_NAME' ),
+        'from_email'        => env( 'FORMS_FROM_EMAIL' ),
+        'queue'             => env( 'FORMS_NOTIFICATION_QUEUE', 'default' ),
+        'show_ip_in_emails' => env( 'FORMS_SHOW_IP_IN_EMAILS', true ),
     ],
 
     /*
@@ -145,10 +145,10 @@ return [
     */
 
     'display' => [
-        'label_position' => 'above', // 'above', 'beside', 'hidden'
+        'label_position'          => 'above', // 'above', 'beside', 'hidden'
         'show_required_indicator' => true,
-        'required_indicator' => '*',
-        'error_display' => 'below', // 'below', 'tooltip', 'summary'
+        'required_indicator'      => '*',
+        'error_display'           => 'below', // 'below', 'tooltip', 'summary'
     ],
 
     /*
@@ -163,12 +163,12 @@ return [
     */
 
     'webhooks' => [
-        'enabled' => env('FORMS_WEBHOOKS_ENABLED', false),
-        'url' => env('FORMS_WEBHOOK_URL'),
-        'secret' => env('FORMS_WEBHOOK_SECRET'),
-        'queue' => env('FORMS_WEBHOOK_QUEUE', 'default'),
-        'timeout' => env('FORMS_WEBHOOK_TIMEOUT', 30),
-        'retry_times' => 3,
+        'enabled'       => env( 'FORMS_WEBHOOKS_ENABLED', false ),
+        'url'           => env( 'FORMS_WEBHOOK_URL' ),
+        'secret'        => env( 'FORMS_WEBHOOK_SECRET' ),
+        'queue'         => env( 'FORMS_WEBHOOK_QUEUE', 'default' ),
+        'timeout'       => env( 'FORMS_WEBHOOK_TIMEOUT', 30 ),
+        'retry_times'   => 3,
         'retry_backoff' => [10, 60, 300], // seconds
     ],
 
@@ -202,18 +202,18 @@ return [
         // Submission metadata settings (what gets stored in the database)
         'submission' => [
             // Include IP address in submission metadata
-            'include_ip' => env('FORMS_INCLUDE_IP', true),
+            'include_ip' => env( 'FORMS_INCLUDE_IP', true ),
 
             // Anonymize IP addresses by masking the last octet (e.g., 192.168.1.x becomes 192.168.1.0)
-            'anonymize_ip' => env('FORMS_ANONYMIZE_IP', false),
+            'anonymize_ip' => env( 'FORMS_ANONYMIZE_IP', false ),
 
             // Include user agent in submission metadata
-            'include_user_agent' => env('FORMS_INCLUDE_USER_AGENT', true),
+            'include_user_agent' => env( 'FORMS_INCLUDE_USER_AGENT', true ),
         ],
 
         // Webhook/Export settings (what gets sent externally) - defaults to false for privacy
-        'include_ip_address' => env('FORMS_INCLUDE_IP_ADDRESS', false),
-        'include_user_agent' => env('FORMS_WEBHOOK_INCLUDE_USER_AGENT', false),
+        'include_ip_address' => env( 'FORMS_INCLUDE_IP_ADDRESS', false ),
+        'include_user_agent' => env( 'FORMS_WEBHOOK_INCLUDE_USER_AGENT', false ),
     ],
 
     /*
@@ -229,11 +229,11 @@ return [
     'export' => [
         // Localize export headers (e.g., "Submission ID" vs English literals)
         // When false, headers use stable English strings for machine processing
-        'localize_headers' => env('FORMS_EXPORT_LOCALIZE_HEADERS', false),
+        'localize_headers' => env( 'FORMS_EXPORT_LOCALIZE_HEADERS', false ),
 
         // Localize boolean values in exports (e.g., "Yes"/"No" vs 1/0)
         // When false, booleans export as 1/0 for consistent machine parsing
-        'localize_booleans' => env('FORMS_EXPORT_LOCALIZE_BOOLEANS', false),
+        'localize_booleans' => env( 'FORMS_EXPORT_LOCALIZE_BOOLEANS', false ),
     ],
 
     /*
@@ -249,7 +249,7 @@ return [
 
     'security' => [
         // Enable logging of security events (honeypot, rate limiting, invalid files)
-        'logging_enabled' => env('FORMS_SECURITY_LOGGING', true),
+        'logging_enabled' => env( 'FORMS_SECURITY_LOGGING', true ),
     ],
 
     /*
@@ -273,13 +273,13 @@ return [
 
     'authorization' => [
         // Enable ownership-based access control (recommended for multi-user apps)
-        'restrict_by_owner' => env('FORMS_RESTRICT_BY_OWNER', false),
+        'restrict_by_owner' => env( 'FORMS_RESTRICT_BY_OWNER', false ),
 
         // Allow users with is_admin attribute to bypass ownership checks
-        'allow_admin_bypass' => env('FORMS_ALLOW_ADMIN_BYPASS', true),
+        'allow_admin_bypass' => env( 'FORMS_ALLOW_ADMIN_BYPASS', true ),
 
         // The user model class for ownership relationships
-        'user_model' => env('FORMS_USER_MODEL', 'App\\Models\\User'),
+        'user_model' => env( 'FORMS_USER_MODEL', 'App\\Models\\User' ),
     ],
 
     /*
@@ -295,8 +295,8 @@ return [
 
     'disk_config' => [
         'form-uploads' => [
-            'driver' => 'local',
-            'root' => storage_path('app/form-uploads'),
+            'driver'     => 'local',
+            'root'       => storage_path( 'app/form-uploads'),
             'visibility' => 'private',
         ],
     ],

--- a/config/forms.php
+++ b/config/forms.php
@@ -296,7 +296,7 @@ return [
     'disk_config' => [
         'form-uploads' => [
             'driver'     => 'local',
-            'root'       => storage_path( 'app/form-uploads'),
+            'root'       => storage_path( 'app/form-uploads' ),
             'visibility' => 'private',
         ],
     ],

--- a/config/forms.php
+++ b/config/forms.php
@@ -6,8 +6,6 @@
  * Defines all settings for the Forms package including storage, submissions,
  * spam protection, notification defaults, privacy settings, and authorization.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @author     Jacob Martella <support@artisanpackui.dev>
  *
@@ -26,9 +24,9 @@ return [
     */
 
     'admin' => [
-        'prefix'     => env( 'FORMS_ADMIN_PREFIX', 'admin/forms' ),
+        'prefix' => env('FORMS_ADMIN_PREFIX', 'admin/forms'),
         'middleware' => ['web', 'auth'],
-        'per_page'   => 15,
+        'per_page' => 15,
     ],
 
     /*
@@ -43,10 +41,10 @@ return [
     */
 
     'api' => [
-        'enabled'    => env( 'FORMS_API_ENABLED', true ),
-        'prefix'     => env( 'FORMS_API_PREFIX', 'api/v1/forms' ),
+        'enabled' => env('FORMS_API_ENABLED', true),
+        'prefix' => env('FORMS_API_PREFIX', 'api/v1/forms'),
         'middleware' => ['api', 'auth:sanctum'],
-        'per_page'   => 15,
+        'per_page' => 15,
     ],
 
     /*
@@ -61,9 +59,9 @@ return [
     */
 
     'uploads' => [
-        'disk'          => env( 'FORMS_UPLOADS_DISK', 'form-uploads' ),
-        'directory'     => env( 'FORMS_UPLOADS_DIRECTORY', 'uploads' ),
-        'max_size'      => env( 'FORMS_UPLOADS_MAX_SIZE', 10240 ), // KB (10MB default)
+        'disk' => env('FORMS_UPLOADS_DISK', 'form-uploads'),
+        'directory' => env('FORMS_UPLOADS_DIRECTORY', 'uploads'),
+        'max_size' => env('FORMS_UPLOADS_MAX_SIZE', 10240), // KB (10MB default)
         'allowed_mimes' => [
             'application/pdf',
             'application/msword',
@@ -91,8 +89,8 @@ return [
     */
 
     'submissions' => [
-        'store_submissions'        => true,
-        'retention_days'           => env( 'FORMS_RETENTION_DAYS', null ), // null = keep forever
+        'store_submissions' => true,
+        'retention_days' => env('FORMS_RETENTION_DAYS', null), // null = keep forever
         'submission_number_format' => 'FORM-{year}-{sequence}',
     ],
 
@@ -109,13 +107,13 @@ return [
 
     'spam_protection' => [
         'honeypot' => [
-            'enabled'    => true,
+            'enabled' => true,
             'field_name' => 'website_url',
         ],
         'rate_limit' => [
-            'enabled'  => true,
+            'enabled' => true,
             'attempts' => 5,
-            'decay'    => 60, // seconds
+            'decay' => 60, // seconds
         ],
     ],
 
@@ -131,10 +129,10 @@ return [
     */
 
     'notifications' => [
-        'from_name'         => env( 'FORMS_FROM_NAME' ),
-        'from_email'        => env( 'FORMS_FROM_EMAIL' ),
-        'queue'             => env( 'FORMS_NOTIFICATION_QUEUE', 'default' ),
-        'show_ip_in_emails' => env( 'FORMS_SHOW_IP_IN_EMAILS', true ),
+        'from_name' => env('FORMS_FROM_NAME'),
+        'from_email' => env('FORMS_FROM_EMAIL'),
+        'queue' => env('FORMS_NOTIFICATION_QUEUE', 'default'),
+        'show_ip_in_emails' => env('FORMS_SHOW_IP_IN_EMAILS', true),
     ],
 
     /*
@@ -147,10 +145,10 @@ return [
     */
 
     'display' => [
-        'label_position'          => 'above', // 'above', 'beside', 'hidden'
+        'label_position' => 'above', // 'above', 'beside', 'hidden'
         'show_required_indicator' => true,
-        'required_indicator'      => '*',
-        'error_display'           => 'below', // 'below', 'tooltip', 'summary'
+        'required_indicator' => '*',
+        'error_display' => 'below', // 'below', 'tooltip', 'summary'
     ],
 
     /*
@@ -165,12 +163,12 @@ return [
     */
 
     'webhooks' => [
-        'enabled'       => env( 'FORMS_WEBHOOKS_ENABLED', false ),
-        'url'           => env( 'FORMS_WEBHOOK_URL' ),
-        'secret'        => env( 'FORMS_WEBHOOK_SECRET' ),
-        'queue'         => env( 'FORMS_WEBHOOK_QUEUE', 'default' ),
-        'timeout'       => env( 'FORMS_WEBHOOK_TIMEOUT', 30 ),
-        'retry_times'   => 3,
+        'enabled' => env('FORMS_WEBHOOKS_ENABLED', false),
+        'url' => env('FORMS_WEBHOOK_URL'),
+        'secret' => env('FORMS_WEBHOOK_SECRET'),
+        'queue' => env('FORMS_WEBHOOK_QUEUE', 'default'),
+        'timeout' => env('FORMS_WEBHOOK_TIMEOUT', 30),
+        'retry_times' => 3,
         'retry_backoff' => [10, 60, 300], // seconds
     ],
 
@@ -180,7 +178,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | Configure settings for third-party integrations. Integration packages
-    | can register their own settings via the 'forms.settings_tabs' filter hook.
+    | can register their own settings via the 'ap.forms.settingsTabs' filter hook.
     |
     */
 
@@ -204,18 +202,18 @@ return [
         // Submission metadata settings (what gets stored in the database)
         'submission' => [
             // Include IP address in submission metadata
-            'include_ip' => env( 'FORMS_INCLUDE_IP', true ),
+            'include_ip' => env('FORMS_INCLUDE_IP', true),
 
             // Anonymize IP addresses by masking the last octet (e.g., 192.168.1.x becomes 192.168.1.0)
-            'anonymize_ip' => env( 'FORMS_ANONYMIZE_IP', false ),
+            'anonymize_ip' => env('FORMS_ANONYMIZE_IP', false),
 
             // Include user agent in submission metadata
-            'include_user_agent' => env( 'FORMS_INCLUDE_USER_AGENT', true ),
+            'include_user_agent' => env('FORMS_INCLUDE_USER_AGENT', true),
         ],
 
         // Webhook/Export settings (what gets sent externally) - defaults to false for privacy
-        'include_ip_address' => env( 'FORMS_INCLUDE_IP_ADDRESS', false ),
-        'include_user_agent' => env( 'FORMS_WEBHOOK_INCLUDE_USER_AGENT', false ),
+        'include_ip_address' => env('FORMS_INCLUDE_IP_ADDRESS', false),
+        'include_user_agent' => env('FORMS_WEBHOOK_INCLUDE_USER_AGENT', false),
     ],
 
     /*
@@ -231,11 +229,11 @@ return [
     'export' => [
         // Localize export headers (e.g., "Submission ID" vs English literals)
         // When false, headers use stable English strings for machine processing
-        'localize_headers' => env( 'FORMS_EXPORT_LOCALIZE_HEADERS', false ),
+        'localize_headers' => env('FORMS_EXPORT_LOCALIZE_HEADERS', false),
 
         // Localize boolean values in exports (e.g., "Yes"/"No" vs 1/0)
         // When false, booleans export as 1/0 for consistent machine parsing
-        'localize_booleans' => env( 'FORMS_EXPORT_LOCALIZE_BOOLEANS', false ),
+        'localize_booleans' => env('FORMS_EXPORT_LOCALIZE_BOOLEANS', false),
     ],
 
     /*
@@ -251,7 +249,7 @@ return [
 
     'security' => [
         // Enable logging of security events (honeypot, rate limiting, invalid files)
-        'logging_enabled' => env( 'FORMS_SECURITY_LOGGING', true ),
+        'logging_enabled' => env('FORMS_SECURITY_LOGGING', true),
     ],
 
     /*
@@ -275,13 +273,13 @@ return [
 
     'authorization' => [
         // Enable ownership-based access control (recommended for multi-user apps)
-        'restrict_by_owner' => env( 'FORMS_RESTRICT_BY_OWNER', false ),
+        'restrict_by_owner' => env('FORMS_RESTRICT_BY_OWNER', false),
 
         // Allow users with is_admin attribute to bypass ownership checks
-        'allow_admin_bypass' => env( 'FORMS_ALLOW_ADMIN_BYPASS', true ),
+        'allow_admin_bypass' => env('FORMS_ALLOW_ADMIN_BYPASS', true),
 
         // The user model class for ownership relationships
-        'user_model' => env( 'FORMS_USER_MODEL', 'App\\Models\\User' ),
+        'user_model' => env('FORMS_USER_MODEL', 'App\\Models\\User'),
     ],
 
     /*
@@ -297,8 +295,8 @@ return [
 
     'disk_config' => [
         'form-uploads' => [
-            'driver'     => 'local',
-            'root'       => storage_path( 'app/form-uploads' ),
+            'driver' => 'local',
+            'root' => storage_path('app/form-uploads'),
             'visibility' => 'private',
         ],
     ],

--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -36,13 +36,13 @@ Customize behavior at runtime:
 use function addFilter;
 
 // Modify validation rules
-addFilter('forms.validation_rules', function ($rules, $form) {
+addFilter('ap.forms.validationRules', function ($rules, $form) {
     $rules['email'] = 'required|email|unique:users,email';
     return $rules;
 });
 
 // Modify webhook payload
-addFilter('forms.webhook_payload', function ($payload, $form, $submission) {
+addFilter('ap.forms.webhookPayload', function ($payload, $form, $submission) {
     $payload['custom_field'] = 'value';
     return $payload;
 });
@@ -55,7 +55,7 @@ Register custom field types:
 ```php
 use function addFilter;
 
-addFilter('forms.field_types', function ($types) {
+addFilter('ap.forms.fieldTypes', function ($types) {
     $types['color-picker'] = [
         'label' => 'Color Picker',
         'icon' => 'palette',

--- a/docs/advanced/customization.md
+++ b/docs/advanced/customization.md
@@ -96,7 +96,7 @@ use function addFilter;
 
 public function boot(): void
 {
-    addFilter('forms.field_types', function ($types) {
+    addFilter('ap.forms.fieldTypes', function ($types) {
         $types['color-picker'] = [
             'label' => 'Color Picker',
             'icon' => 'palette',
@@ -144,12 +144,12 @@ public function boot(): void
 
 | Filter | Arguments | Description |
 |--------|-----------|-------------|
-| `forms.field_types` | `$types` | Modify available field types |
-| `forms.validation_rules` | `$rules, $form` | Modify validation rules |
-| `forms.notification_message` | `$message, $notification, $submission` | Modify notification content |
-| `forms.webhook_payload` | `$payload, $form, $submission` | Modify webhook data |
+| `ap.forms.fieldTypes` | `$types` | Modify available field types |
+| `ap.forms.validationRules` | `$rules, $form` | Modify validation rules |
+| `ap.forms.notificationMessage` | `$message, $notification, $submission` | Modify notification content |
+| `ap.forms.webhookPayload` | `$payload, $form, $submission` | Modify webhook data |
 | `forms.spam_check` | `$isSpam, $form, $data` | Custom spam detection |
-| `forms.settings_tabs` | `$tabs, $form` | Add admin settings tabs |
+| `ap.forms.settingsTabs` | `$tabs, $form` | Add admin settings tabs |
 
 ### Examples
 
@@ -157,7 +157,7 @@ public function boot(): void
 use function addFilter;
 
 // Add custom validation
-addFilter('forms.validation_rules', function ($rules, $form) {
+addFilter('ap.forms.validationRules', function ($rules, $form) {
     if ($form->slug === 'job-application') {
         $rules['formData.resume'] = 'required|mimes:pdf,doc,docx|max:5120';
     }
@@ -165,7 +165,7 @@ addFilter('forms.validation_rules', function ($rules, $form) {
 });
 
 // Modify notification
-addFilter('forms.notification_message', function ($message, $notification, $submission) {
+addFilter('ap.forms.notificationMessage', function ($message, $notification, $submission) {
     return $message . "\n\n---\nProcessed by MyApp v" . config('app.version');
 });
 

--- a/docs/advanced/customization.md
+++ b/docs/advanced/customization.md
@@ -146,10 +146,21 @@ public function boot(): void
 |--------|-----------|-------------|
 | `ap.forms.fieldTypes` | `$types` | Modify available field types |
 | `ap.forms.validationRules` | `$rules, $form` | Modify validation rules |
-| `ap.forms.notificationMessage` | `$message, $notification, $submission` | Modify notification content |
+| `ap.forms.fieldRender` | `$html, $field` | Modify the rendered HTML of a single field before it's echoed by the form renderer |
+| `ap.forms.notificationMessage` | `$message, $notification, $submission` | Modify notification content (legacy; still runs before `notificationSubject` / `notificationBody`) |
+| `ap.forms.notificationSubject` | `$subject, $notification, $submission` | Modify outgoing notification email subject |
+| `ap.forms.notificationBody` | `$body, $notification, $submission` | Modify outgoing notification email body |
 | `ap.forms.webhookPayload` | `$payload, $form, $submission` | Modify webhook data |
 | `forms.spam_check` | `$isSpam, $form, $data` | Custom spam detection |
 | `ap.forms.settingsTabs` | `$tabs, $form` | Add admin settings tabs |
+
+### Available Actions
+
+| Action | Arguments | Description |
+|--------|-----------|-------------|
+| `ap.forms.beforeValidate` | `$request` | Fires from a package `FormRequest::prepareForValidation()` just before Laravel validates the request |
+| `ap.forms.validated` | `$request, $validated` | Fires from `FormRequest::passedValidation()` after validation succeeds |
+| `ap.forms.integrationRegistered` | `$slug, $config` | Fires when `IntegrationService::registerIntegration()` registers an integration so ecosystem packages can observe registrations |
 
 ### Examples
 

--- a/docs/advanced/spam-protection.md
+++ b/docs/advanced/spam-protection.md
@@ -169,7 +169,7 @@ RECAPTCHA_SECRET_KEY=your-secret-key
 ```php
 use function addFilter;
 
-addFilter('forms.validation_rules', function ($rules, $form) {
+addFilter('ap.forms.validationRules', function ($rules, $form) {
     if ($form->settings['recaptcha_enabled'] ?? false) {
         $rules['g-recaptcha-response'] = 'required|recaptcha';
     }

--- a/docs/advanced/webhooks.md
+++ b/docs/advanced/webhooks.md
@@ -98,7 +98,7 @@ Use filters to modify the payload:
 ```php
 use function addFilter;
 
-addFilter('forms.webhook_payload', function ($payload, $form, $submission) {
+addFilter('ap.forms.webhookPayload', function ($payload, $form, $submission) {
     // Add custom data
     $payload['custom'] = [
         'campaign' => $submission->getMetadata('utm_campaign'),
@@ -283,7 +283,7 @@ FORMS_WEBHOOK_URL=https://hook.us1.make.com/xxxxx
 ### Custom API
 
 ```php
-addFilter('forms.webhook_payload', function ($payload, $form, $submission) {
+addFilter('ap.forms.webhookPayload', function ($payload, $form, $submission) {
     // Transform to API-specific format
     return [
         'api_key' => config('services.my_api.key'),

--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -169,18 +169,18 @@ Extend functionality using filter hooks:
 use function addFilter;
 
 // Modify validation rules
-addFilter('forms.validation_rules', function ($rules, $form) {
+addFilter('ap.forms.validationRules', function ($rules, $form) {
     // Add custom rules
     return $rules;
 });
 
 // Modify notification message
-addFilter('forms.notification_message', function ($message, $notification, $submission) {
+addFilter('ap.forms.notificationMessage', function ($message, $notification, $submission) {
     return $message;
 });
 
 // Modify webhook payload
-addFilter('forms.webhook_payload', function ($payload, $form, $submission) {
+addFilter('ap.forms.webhookPayload', function ($payload, $form, $submission) {
     $payload['custom'] = 'data';
     return $payload;
 });

--- a/docs/api/jobs.md
+++ b/docs/api/jobs.md
@@ -183,7 +183,7 @@ Use filters to modify the webhook payload:
 ```php
 use function addFilter;
 
-addFilter('forms.webhook_payload', function ($payload, $form, $submission) {
+addFilter('ap.forms.webhookPayload', function ($payload, $form, $submission) {
     // Add custom data
     $payload['custom'] = [
         'source' => 'website',

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -98,7 +98,7 @@ The package includes 20+ field types including text, email, textarea, select, ch
 Yes, use the filter hook:
 
 ```php
-addFilter('forms.field_types', function ($types) {
+addFilter('ap.forms.fieldTypes', function ($types) {
     $types['my-field'] = [
         'label' => 'My Custom Field',
         'view' => 'my-package::fields.my-field',

--- a/docs/usage/notifications.md
+++ b/docs/usage/notifications.md
@@ -237,7 +237,7 @@ Use filter hooks to customize:
 use function addFilter;
 
 // Modify the message
-addFilter('forms.notification_message', function ($message, $notification, $submission) {
+addFilter('ap.forms.notificationMessage', function ($message, $notification, $submission) {
     // Add tracking pixel
     return $message . '<img src="https://example.com/track/' . $submission->id . '">';
 });

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -143,12 +143,12 @@ Use filter hooks to customize behavior:
 use function addFilter;
 
 // Customize notification message
-addFilter('forms.notification_message', function ($message, $notification, $submission) {
+addFilter('ap.forms.notificationMessage', function ($message, $notification, $submission) {
     return $message . "\n\nProcessed at: " . now()->format('Y-m-d H:i:s');
 });
 
 // Add custom validation
-addFilter('forms.validation_rules', function ($rules, $form) {
+addFilter('ap.forms.validationRules', function ($rules, $form) {
     // Add custom rules
     $rules['email'] = 'required|email|ends_with:@company.com';
     return $rules;

--- a/resources/views/livewire/form-renderer.blade.php
+++ b/resources/views/livewire/form-renderer.blade.php
@@ -156,11 +156,11 @@
                                     :aria-hidden="!visible"
                                     :inert="!visible"
                                 >
-                                    @include('forms::components.fields.' . $field->type, [
-                                        'field' => $field,
-                                        'value' => $formData[$field->name] ?? null,
-                                        'error' => $errors->first('formData.' . $field->name),
-                                    ])
+                                    {!! \ArtisanPackUI\Forms\Support\FieldRenderer::render(
+                                        $field,
+                                        $formData[$field->name] ?? null,
+                                        $errors->first('formData.' . $field->name),
+                                    ) !!}
                                 </div>
                             @endforeach
                         </div>
@@ -251,11 +251,11 @@
                             :aria-hidden="!visible"
                             :inert="!visible"
                         >
-                            @include('forms::components.fields.' . $field->type, [
-                                'field' => $field,
-                                'value' => $formData[$field->name] ?? null,
-                                'error' => $errors->first('formData.' . $field->name),
-                            ])
+                            {!! \ArtisanPackUI\Forms\Support\FieldRenderer::render(
+                                $field,
+                                $formData[$field->name] ?? null,
+                                $errors->first('formData.' . $field->name),
+                            ) !!}
                         </div>
                     @endforeach
                 </div>

--- a/src/Config/FieldTypes.php
+++ b/src/Config/FieldTypes.php
@@ -6,15 +6,13 @@
  * Defines all available field types with their metadata, categories,
  * icons, validation options, and default values for the form builder.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @author     Jacob Martella <support@artisanpackui.dev>
  *
  * @since      1.0.0
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Forms\Config;
 
@@ -24,8 +22,6 @@ namespace ArtisanPackUI\Forms\Config;
  * Provides static methods and constants for retrieving field type
  * definitions, categories, and metadata used throughout the form builder.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @since      1.0.0
  */
@@ -39,10 +35,10 @@ class FieldTypes
      * @var array<string, array<string>>
      */
     public const CATEGORY_FIELDS = [
-        'basic'    => ['text', 'email', 'phone', 'number', 'url', 'textarea', 'hidden'],
-        'choice'   => ['select', 'radio', 'checkbox', 'checkbox_group', 'select_multiple'],
+        'basic' => ['text', 'email', 'phone', 'number', 'url', 'textarea', 'hidden'],
+        'choice' => ['select', 'radio', 'checkbox', 'checkbox_group', 'select_multiple'],
         'advanced' => ['file', 'date', 'time'],
-        'layout'   => ['heading', 'paragraph', 'divider', 'html'],
+        'layout' => ['heading', 'paragraph', 'divider', 'html'],
     ];
 
     /**
@@ -61,160 +57,160 @@ class FieldTypes
      */
     public const TYPE_METADATA = [
         'text' => [
-            'icon'                   => 'o-document-text',
-            'category'               => 'basic',
-            'has_options'            => false,
-            'supports_placeholder'   => true,
+            'icon' => 'o-document-text',
+            'category' => 'basic',
+            'has_options' => false,
+            'supports_placeholder' => true,
             'supports_default_value' => true,
-            'validation_options'     => ['min', 'max', 'pattern'],
+            'validation_options' => ['min', 'max', 'pattern'],
         ],
         'email' => [
-            'icon'                   => 'o-envelope',
-            'category'               => 'basic',
-            'has_options'            => false,
-            'supports_placeholder'   => true,
+            'icon' => 'o-envelope',
+            'category' => 'basic',
+            'has_options' => false,
+            'supports_placeholder' => true,
             'supports_default_value' => true,
-            'validation_options'     => ['min', 'max'],
+            'validation_options' => ['min', 'max'],
         ],
         'number' => [
-            'icon'                   => 'o-hashtag',
-            'category'               => 'basic',
-            'has_options'            => false,
-            'supports_placeholder'   => true,
+            'icon' => 'o-hashtag',
+            'category' => 'basic',
+            'has_options' => false,
+            'supports_placeholder' => true,
             'supports_default_value' => true,
-            'validation_options'     => ['min', 'max', 'step'],
+            'validation_options' => ['min', 'max', 'step'],
         ],
         'url' => [
-            'icon'                   => 'o-link',
-            'category'               => 'basic',
-            'has_options'            => false,
-            'supports_placeholder'   => true,
+            'icon' => 'o-link',
+            'category' => 'basic',
+            'has_options' => false,
+            'supports_placeholder' => true,
             'supports_default_value' => true,
-            'validation_options'     => ['min', 'max'],
+            'validation_options' => ['min', 'max'],
         ],
         'textarea' => [
-            'icon'                   => 'o-bars-3-bottom-left',
-            'category'               => 'basic',
-            'has_options'            => false,
-            'supports_placeholder'   => true,
+            'icon' => 'o-bars-3-bottom-left',
+            'category' => 'basic',
+            'has_options' => false,
+            'supports_placeholder' => true,
             'supports_default_value' => true,
-            'validation_options'     => ['min', 'max'],
+            'validation_options' => ['min', 'max'],
         ],
         'hidden' => [
-            'icon'                   => 'o-eye-slash',
-            'category'               => 'basic',
-            'has_options'            => false,
-            'supports_placeholder'   => false,
+            'icon' => 'o-eye-slash',
+            'category' => 'basic',
+            'has_options' => false,
+            'supports_placeholder' => false,
             'supports_default_value' => true,
-            'validation_options'     => [],
+            'validation_options' => [],
         ],
         'select' => [
-            'icon'                   => 'o-chevron-down',
-            'category'               => 'choice',
-            'has_options'            => true,
-            'supports_placeholder'   => true,
+            'icon' => 'o-chevron-down',
+            'category' => 'choice',
+            'has_options' => true,
+            'supports_placeholder' => true,
             'supports_default_value' => true,
-            'validation_options'     => [],
+            'validation_options' => [],
         ],
         'radio' => [
-            'icon'                   => 'o-stop-circle',
-            'category'               => 'choice',
-            'has_options'            => true,
-            'supports_placeholder'   => false,
+            'icon' => 'o-stop-circle',
+            'category' => 'choice',
+            'has_options' => true,
+            'supports_placeholder' => false,
             'supports_default_value' => true,
-            'validation_options'     => [],
+            'validation_options' => [],
         ],
         'checkbox' => [
-            'icon'                   => 'o-check-circle',
-            'category'               => 'choice',
-            'has_options'            => false,
-            'supports_placeholder'   => false,
+            'icon' => 'o-check-circle',
+            'category' => 'choice',
+            'has_options' => false,
+            'supports_placeholder' => false,
             'supports_default_value' => true,
-            'validation_options'     => [],
+            'validation_options' => [],
         ],
         'checkbox_group' => [
-            'icon'                   => 'o-list-bullet',
-            'category'               => 'choice',
-            'has_options'            => true,
-            'supports_placeholder'   => false,
+            'icon' => 'o-list-bullet',
+            'category' => 'choice',
+            'has_options' => true,
+            'supports_placeholder' => false,
             'supports_default_value' => false,
-            'validation_options'     => ['min', 'max'],
+            'validation_options' => ['min', 'max'],
         ],
         'select_multiple' => [
-            'icon'                   => 'o-queue-list',
-            'category'               => 'choice',
-            'has_options'            => true,
-            'supports_placeholder'   => false,
+            'icon' => 'o-queue-list',
+            'category' => 'choice',
+            'has_options' => true,
+            'supports_placeholder' => false,
             'supports_default_value' => false,
-            'validation_options'     => ['min', 'max'],
+            'validation_options' => ['min', 'max'],
         ],
         'file' => [
-            'icon'                   => 'o-paper-clip',
-            'category'               => 'advanced',
-            'has_options'            => false,
-            'supports_placeholder'   => false,
+            'icon' => 'o-paper-clip',
+            'category' => 'advanced',
+            'has_options' => false,
+            'supports_placeholder' => false,
             'supports_default_value' => false,
-            'validation_options'     => ['max_size', 'allowed_types'],
+            'validation_options' => ['max_size', 'allowed_types'],
         ],
         'date' => [
-            'icon'                   => 'o-calendar',
-            'category'               => 'advanced',
-            'has_options'            => false,
-            'supports_placeholder'   => false,
+            'icon' => 'o-calendar',
+            'category' => 'advanced',
+            'has_options' => false,
+            'supports_placeholder' => false,
             'supports_default_value' => true,
-            'validation_options'     => ['min_date', 'max_date'],
+            'validation_options' => ['min_date', 'max_date'],
         ],
         'phone' => [
-            'icon'                   => 'o-phone',
-            'category'               => 'basic',
-            'has_options'            => false,
-            'supports_placeholder'   => true,
+            'icon' => 'o-phone',
+            'category' => 'basic',
+            'has_options' => false,
+            'supports_placeholder' => true,
             'supports_default_value' => true,
-            'validation_options'     => ['pattern'],
+            'validation_options' => ['pattern'],
         ],
         'time' => [
-            'icon'                   => 'o-clock',
-            'category'               => 'advanced',
-            'has_options'            => false,
-            'supports_placeholder'   => false,
+            'icon' => 'o-clock',
+            'category' => 'advanced',
+            'has_options' => false,
+            'supports_placeholder' => false,
             'supports_default_value' => true,
-            'validation_options'     => ['min_time', 'max_time'],
+            'validation_options' => ['min_time', 'max_time'],
         ],
         'heading' => [
-            'icon'                   => 'o-h1',
-            'category'               => 'layout',
-            'has_options'            => false,
-            'supports_placeholder'   => false,
+            'icon' => 'o-h1',
+            'category' => 'layout',
+            'has_options' => false,
+            'supports_placeholder' => false,
             'supports_default_value' => false,
-            'is_layout'              => true,
-            'validation_options'     => [],
+            'is_layout' => true,
+            'validation_options' => [],
         ],
         'paragraph' => [
-            'icon'                   => 'o-document-text',
-            'category'               => 'layout',
-            'has_options'            => false,
-            'supports_placeholder'   => false,
+            'icon' => 'o-document-text',
+            'category' => 'layout',
+            'has_options' => false,
+            'supports_placeholder' => false,
             'supports_default_value' => false,
-            'is_layout'              => true,
-            'validation_options'     => [],
+            'is_layout' => true,
+            'validation_options' => [],
         ],
         'divider' => [
-            'icon'                   => 'o-minus',
-            'category'               => 'layout',
-            'has_options'            => false,
-            'supports_placeholder'   => false,
+            'icon' => 'o-minus',
+            'category' => 'layout',
+            'has_options' => false,
+            'supports_placeholder' => false,
             'supports_default_value' => false,
-            'is_layout'              => true,
-            'validation_options'     => [],
+            'is_layout' => true,
+            'validation_options' => [],
         ],
         'html' => [
-            'icon'                   => 'o-code-bracket',
-            'category'               => 'layout',
-            'has_options'            => false,
-            'supports_placeholder'   => false,
+            'icon' => 'o-code-bracket',
+            'category' => 'layout',
+            'has_options' => false,
+            'supports_placeholder' => false,
             'supports_default_value' => false,
-            'is_layout'              => true,
-            'validation_options'     => [],
+            'is_layout' => true,
+            'validation_options' => [],
         ],
     ];
 
@@ -226,9 +222,9 @@ class FieldTypes
      * @var array<string, string>
      */
     public const WIDTH_CLASSES = [
-        'full'       => 'w-full',
-        'half'       => 'w-1/2',
-        'third'      => 'w-1/3',
+        'full' => 'w-full',
+        'half' => 'w-1/2',
+        'third' => 'w-1/3',
         'two-thirds' => 'w-2/3',
     ];
 
@@ -243,19 +239,19 @@ class FieldTypes
     {
         return [
             'basic' => [
-                'label'  => __( 'Basic Fields' ),
+                'label' => __('Basic Fields'),
                 'fields' => self::CATEGORY_FIELDS['basic'],
             ],
             'choice' => [
-                'label'  => __( 'Choice Fields' ),
+                'label' => __('Choice Fields'),
                 'fields' => self::CATEGORY_FIELDS['choice'],
             ],
             'advanced' => [
-                'label'  => __( 'Advanced Fields' ),
+                'label' => __('Advanced Fields'),
                 'fields' => self::CATEGORY_FIELDS['advanced'],
             ],
             'layout' => [
-                'label'  => __( 'Layout Elements' ),
+                'label' => __('Layout Elements'),
                 'fields' => self::CATEGORY_FIELDS['layout'],
             ],
         ];
@@ -271,158 +267,158 @@ class FieldTypes
     public static function types(): array
     {
         return [
-            'text' => array_merge( self::TYPE_METADATA['text'], [
-                'label'    => __( 'Text Input' ),
+            'text' => array_merge(self::TYPE_METADATA['text'], [
+                'label' => __('Text Input'),
                 'defaults' => [
-                    'label'       => __( 'Text Field' ),
+                    'label' => __('Text Field'),
                     'placeholder' => '',
                 ],
-            ] ),
-            'email' => array_merge( self::TYPE_METADATA['email'], [
-                'label'    => __( 'Email' ),
+            ]),
+            'email' => array_merge(self::TYPE_METADATA['email'], [
+                'label' => __('Email'),
                 'defaults' => [
-                    'label'       => __( 'Email Address' ),
-                    'placeholder' => __( 'you@example.com' ),
+                    'label' => __('Email Address'),
+                    'placeholder' => __('you@example.com'),
                 ],
-            ] ),
-            'number' => array_merge( self::TYPE_METADATA['number'], [
-                'label'    => __( 'Number' ),
+            ]),
+            'number' => array_merge(self::TYPE_METADATA['number'], [
+                'label' => __('Number'),
                 'defaults' => [
-                    'label'       => __( 'Number' ),
+                    'label' => __('Number'),
                     'placeholder' => '',
                 ],
-            ] ),
-            'url' => array_merge( self::TYPE_METADATA['url'], [
-                'label'    => __( 'URL' ),
+            ]),
+            'url' => array_merge(self::TYPE_METADATA['url'], [
+                'label' => __('URL'),
                 'defaults' => [
-                    'label'       => __( 'Website URL' ),
+                    'label' => __('Website URL'),
                     'placeholder' => 'https://example.com',
                 ],
-            ] ),
-            'textarea' => array_merge( self::TYPE_METADATA['textarea'], [
-                'label'    => __( 'Text Area' ),
+            ]),
+            'textarea' => array_merge(self::TYPE_METADATA['textarea'], [
+                'label' => __('Text Area'),
                 'defaults' => [
-                    'label'        => __( 'Message' ),
-                    'placeholder'  => '',
+                    'label' => __('Message'),
+                    'placeholder' => '',
                     'field_config' => ['rows' => 4],
                 ],
-            ] ),
-            'hidden' => array_merge( self::TYPE_METADATA['hidden'], [
-                'label'    => __( 'Hidden Field' ),
+            ]),
+            'hidden' => array_merge(self::TYPE_METADATA['hidden'], [
+                'label' => __('Hidden Field'),
                 'defaults' => [
-                    'label' => __( 'Hidden Field' ),
+                    'label' => __('Hidden Field'),
                 ],
-            ] ),
-            'select' => array_merge( self::TYPE_METADATA['select'], [
-                'label'    => __( 'Dropdown Select' ),
+            ]),
+            'select' => array_merge(self::TYPE_METADATA['select'], [
+                'label' => __('Dropdown Select'),
                 'defaults' => [
-                    'label'        => __( 'Select an Option' ),
-                    'placeholder'  => __( 'Choose...' ),
+                    'label' => __('Select an Option'),
+                    'placeholder' => __('Choose...'),
                     'field_config' => [
                         'options' => [],
                     ],
                 ],
-            ] ),
-            'radio' => array_merge( self::TYPE_METADATA['radio'], [
-                'label'    => __( 'Radio Buttons' ),
+            ]),
+            'radio' => array_merge(self::TYPE_METADATA['radio'], [
+                'label' => __('Radio Buttons'),
                 'defaults' => [
-                    'label'        => __( 'Choose One' ),
+                    'label' => __('Choose One'),
                     'field_config' => [
                         'options' => [],
                     ],
                 ],
-            ] ),
-            'checkbox' => array_merge( self::TYPE_METADATA['checkbox'], [
-                'label'    => __( 'Single Checkbox' ),
+            ]),
+            'checkbox' => array_merge(self::TYPE_METADATA['checkbox'], [
+                'label' => __('Single Checkbox'),
                 'defaults' => [
-                    'label' => __( 'I agree to the terms' ),
+                    'label' => __('I agree to the terms'),
                 ],
-            ] ),
-            'checkbox_group' => array_merge( self::TYPE_METADATA['checkbox_group'], [
-                'label'    => __( 'Checkbox Group' ),
+            ]),
+            'checkbox_group' => array_merge(self::TYPE_METADATA['checkbox_group'], [
+                'label' => __('Checkbox Group'),
                 'defaults' => [
-                    'label'        => __( 'Select Options' ),
+                    'label' => __('Select Options'),
                     'field_config' => [
                         'options' => [],
                     ],
                 ],
-            ] ),
-            'select_multiple' => array_merge( self::TYPE_METADATA['select_multiple'], [
-                'label'    => __( 'Multi-Select' ),
+            ]),
+            'select_multiple' => array_merge(self::TYPE_METADATA['select_multiple'], [
+                'label' => __('Multi-Select'),
                 'defaults' => [
-                    'label'        => __( 'Select Multiple Options' ),
+                    'label' => __('Select Multiple Options'),
                     'field_config' => [
                         'options' => [],
                     ],
                 ],
-            ] ),
-            'file' => array_merge( self::TYPE_METADATA['file'], [
-                'label'    => __( 'File Upload' ),
+            ]),
+            'file' => array_merge(self::TYPE_METADATA['file'], [
+                'label' => __('File Upload'),
                 'defaults' => [
-                    'label'        => __( 'Upload File' ),
+                    'label' => __('Upload File'),
                     'field_config' => [
-                        'max_size'      => 5120,
+                        'max_size' => 5120,
                         'allowed_types' => ['pdf', 'doc', 'docx', 'jpg', 'png'],
                     ],
                 ],
-            ] ),
-            'date' => array_merge( self::TYPE_METADATA['date'], [
-                'label'    => __( 'Date Picker' ),
+            ]),
+            'date' => array_merge(self::TYPE_METADATA['date'], [
+                'label' => __('Date Picker'),
                 'defaults' => [
-                    'label' => __( 'Select Date' ),
+                    'label' => __('Select Date'),
                 ],
-            ] ),
-            'phone' => array_merge( self::TYPE_METADATA['phone'], [
-                'label'    => __( 'Phone Number' ),
+            ]),
+            'phone' => array_merge(self::TYPE_METADATA['phone'], [
+                'label' => __('Phone Number'),
                 'defaults' => [
-                    'label'       => __( 'Phone Number' ),
+                    'label' => __('Phone Number'),
                     'placeholder' => '(123) 456-7890',
                 ],
-            ] ),
-            'time' => array_merge( self::TYPE_METADATA['time'], [
-                'label'    => __( 'Time Picker' ),
+            ]),
+            'time' => array_merge(self::TYPE_METADATA['time'], [
+                'label' => __('Time Picker'),
                 'defaults' => [
-                    'label'        => __( 'Select Time' ),
+                    'label' => __('Select Time'),
                     'field_config' => [
                         'step' => 60,
                     ],
                 ],
-            ] ),
-            'heading' => array_merge( self::TYPE_METADATA['heading'], [
-                'label'    => __( 'Heading' ),
+            ]),
+            'heading' => array_merge(self::TYPE_METADATA['heading'], [
+                'label' => __('Heading'),
                 'defaults' => [
-                    'label'        => __( 'Section Heading' ),
+                    'label' => __('Section Heading'),
                     'field_config' => [
                         'level' => 'h3',
                     ],
                 ],
-            ] ),
-            'paragraph' => array_merge( self::TYPE_METADATA['paragraph'], [
-                'label'    => __( 'Paragraph Text' ),
+            ]),
+            'paragraph' => array_merge(self::TYPE_METADATA['paragraph'], [
+                'label' => __('Paragraph Text'),
                 'defaults' => [
-                    'label'     => __( 'Information' ),
-                    'help_text' => __( 'Add descriptive text here.' ),
+                    'label' => __('Information'),
+                    'help_text' => __('Add descriptive text here.'),
                 ],
-            ] ),
-            'divider' => array_merge( self::TYPE_METADATA['divider'], [
-                'label'    => __( 'Divider' ),
+            ]),
+            'divider' => array_merge(self::TYPE_METADATA['divider'], [
+                'label' => __('Divider'),
                 'defaults' => [
-                    'label'        => __( 'Divider' ),
+                    'label' => __('Divider'),
                     'field_config' => [
-                        'style'   => 'solid',
+                        'style' => 'solid',
                         'spacing' => 'normal',
                     ],
                 ],
-            ] ),
-            'html' => array_merge( self::TYPE_METADATA['html'], [
-                'label'    => __( 'Custom HTML' ),
+            ]),
+            'html' => array_merge(self::TYPE_METADATA['html'], [
+                'label' => __('Custom HTML'),
                 'defaults' => [
-                    'label'        => __( 'Custom Content' ),
+                    'label' => __('Custom Content'),
                     'field_config' => [
                         'content' => '',
                     ],
                 ],
-            ] ),
+            ]),
         ];
     }
 
@@ -437,19 +433,19 @@ class FieldTypes
     {
         return [
             'full' => [
-                'label' => __( 'Full Width' ),
+                'label' => __('Full Width'),
                 'class' => self::WIDTH_CLASSES['full'],
             ],
             'half' => [
-                'label' => __( 'Half Width' ),
+                'label' => __('Half Width'),
                 'class' => self::WIDTH_CLASSES['half'],
             ],
             'third' => [
-                'label' => __( 'One Third' ),
+                'label' => __('One Third'),
                 'class' => self::WIDTH_CLASSES['third'],
             ],
             'two-thirds' => [
-                'label' => __( 'Two Thirds' ),
+                'label' => __('Two Thirds'),
                 'class' => self::WIDTH_CLASSES['two-thirds'],
             ],
         ];
@@ -470,7 +466,7 @@ class FieldTypes
     /**
      * Gets all field type definitions.
      *
-     * Applies the 'forms.field_types' filter hook to allow
+     * Applies the 'ap.forms.fieldTypes' filter hook to allow
      * third-party packages to register custom field types.
      *
      * @since 1.0.0
@@ -482,8 +478,8 @@ class FieldTypes
         $types = self::types();
 
         // Apply filter hook for extensibility
-        if ( function_exists( 'applyFilters' ) ) {
-            $types = applyFilters( 'forms.field_types', $types );
+        if (function_exists('applyFilters')) {
+            $types = applyFilters('ap.forms.fieldTypes', $types);
         }
 
         return $types;
@@ -492,7 +488,7 @@ class FieldTypes
     /**
      * Gets all field categories with their field types (filtered).
      *
-     * Applies the 'forms.field_categories' filter hook to allow
+     * Applies the 'ap.forms.fieldCategories' filter hook to allow
      * third-party packages to register custom categories.
      *
      * @since 1.0.0
@@ -504,8 +500,8 @@ class FieldTypes
         $categories = self::categories();
 
         // Apply filter hook for extensibility
-        if ( function_exists( 'applyFilters' ) ) {
-            $categories = applyFilters( 'forms.field_categories', $categories );
+        if (function_exists('applyFilters')) {
+            $categories = applyFilters('ap.forms.fieldCategories', $categories);
         }
 
         return $categories;
@@ -516,15 +512,14 @@ class FieldTypes
      *
      * @since 1.0.0
      *
-     * @param string $type The field type name.
-     *
+     * @param  string  $type  The field type name.
      * @return array<string, mixed>|null The field type config or null if not found.
      */
-    public static function getTypeConfig( string $type ): ?array
+    public static function getTypeConfig(string $type): ?array
     {
         $types = self::getTypes();
 
-        return $types[ $type ] ?? null;
+        return $types[$type] ?? null;
     }
 
     /**
@@ -532,15 +527,14 @@ class FieldTypes
      *
      * @since 1.0.0
      *
-     * @param string $type The field type name.
-     *
+     * @param  string  $type  The field type name.
      * @return array<string, mixed> The default values for the field type.
      */
-    public static function getDefaults( string $type ): array
+    public static function getDefaults(string $type): array
     {
         $types = self::getTypes();
 
-        return $types[ $type ]['defaults'] ?? [];
+        return $types[$type]['defaults'] ?? [];
     }
 
     /**
@@ -548,15 +542,14 @@ class FieldTypes
      *
      * @since 1.0.0
      *
-     * @param string $type The field type name.
-     *
+     * @param  string  $type  The field type name.
      * @return bool True if the field type has configurable options.
      */
-    public static function hasOptions( string $type ): bool
+    public static function hasOptions(string $type): bool
     {
         $types = self::getTypes();
 
-        return $types[ $type ]['has_options'] ?? false;
+        return $types[$type]['has_options'] ?? false;
     }
 
     /**
@@ -564,15 +557,14 @@ class FieldTypes
      *
      * @since 1.0.0
      *
-     * @param string $type The field type name.
-     *
+     * @param  string  $type  The field type name.
      * @return array<string> Array of available validation option names.
      */
-    public static function getValidationOptions( string $type ): array
+    public static function getValidationOptions(string $type): array
     {
         $types = self::getTypes();
 
-        return $types[ $type ]['validation_options'] ?? [];
+        return $types[$type]['validation_options'] ?? [];
     }
 
     /**
@@ -592,15 +584,14 @@ class FieldTypes
      *
      * @since 1.0.0
      *
-     * @param string $type The field type name.
-     *
+     * @param  string  $type  The field type name.
      * @return bool True if the field type exists.
      */
-    public static function typeExists( string $type ): bool
+    public static function typeExists(string $type): bool
     {
         $types = self::getTypes();
 
-        return isset( $types[ $type ] );
+        return isset($types[$type]);
     }
 
     /**
@@ -608,15 +599,14 @@ class FieldTypes
      *
      * @since 1.0.0
      *
-     * @param string $type The field type name.
-     *
+     * @param  string  $type  The field type name.
      * @return bool True if the field type supports placeholders.
      */
-    public static function supportsPlaceholder( string $type ): bool
+    public static function supportsPlaceholder(string $type): bool
     {
         $types = self::getTypes();
 
-        return $types[ $type ]['supports_placeholder'] ?? false;
+        return $types[$type]['supports_placeholder'] ?? false;
     }
 
     /**
@@ -624,15 +614,14 @@ class FieldTypes
      *
      * @since 1.0.0
      *
-     * @param string $type The field type name.
-     *
+     * @param  string  $type  The field type name.
      * @return bool True if the field type supports default values.
      */
-    public static function supportsDefaultValue( string $type ): bool
+    public static function supportsDefaultValue(string $type): bool
     {
         $types = self::getTypes();
 
-        return $types[ $type ]['supports_default_value'] ?? true;
+        return $types[$type]['supports_default_value'] ?? true;
     }
 
     /**
@@ -643,15 +632,14 @@ class FieldTypes
      *
      * @since 1.0.0
      *
-     * @param string $type The field type name.
-     *
+     * @param  string  $type  The field type name.
      * @return bool True if the field type is a layout element.
      */
-    public static function isLayoutField( string $type ): bool
+    public static function isLayoutField(string $type): bool
     {
         $types = self::getTypes();
 
-        return $types[ $type ]['is_layout'] ?? false;
+        return $types[$type]['is_layout'] ?? false;
     }
 
     /**

--- a/src/Config/FieldTypes.php
+++ b/src/Config/FieldTypes.php
@@ -12,7 +12,7 @@
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Config;
 
@@ -35,10 +35,10 @@ class FieldTypes
      * @var array<string, array<string>>
      */
     public const CATEGORY_FIELDS = [
-        'basic' => ['text', 'email', 'phone', 'number', 'url', 'textarea', 'hidden'],
-        'choice' => ['select', 'radio', 'checkbox', 'checkbox_group', 'select_multiple'],
+        'basic'    => ['text', 'email', 'phone', 'number', 'url', 'textarea', 'hidden'],
+        'choice'   => ['select', 'radio', 'checkbox', 'checkbox_group', 'select_multiple'],
         'advanced' => ['file', 'date', 'time'],
-        'layout' => ['heading', 'paragraph', 'divider', 'html'],
+        'layout'   => ['heading', 'paragraph', 'divider', 'html'],
     ];
 
     /**
@@ -57,160 +57,160 @@ class FieldTypes
      */
     public const TYPE_METADATA = [
         'text' => [
-            'icon' => 'o-document-text',
-            'category' => 'basic',
-            'has_options' => false,
-            'supports_placeholder' => true,
+            'icon'                   => 'o-document-text',
+            'category'               => 'basic',
+            'has_options'            => false,
+            'supports_placeholder'   => true,
             'supports_default_value' => true,
-            'validation_options' => ['min', 'max', 'pattern'],
+            'validation_options'     => ['min', 'max', 'pattern'],
         ],
         'email' => [
-            'icon' => 'o-envelope',
-            'category' => 'basic',
-            'has_options' => false,
-            'supports_placeholder' => true,
+            'icon'                   => 'o-envelope',
+            'category'               => 'basic',
+            'has_options'            => false,
+            'supports_placeholder'   => true,
             'supports_default_value' => true,
-            'validation_options' => ['min', 'max'],
+            'validation_options'     => ['min', 'max'],
         ],
         'number' => [
-            'icon' => 'o-hashtag',
-            'category' => 'basic',
-            'has_options' => false,
-            'supports_placeholder' => true,
+            'icon'                   => 'o-hashtag',
+            'category'               => 'basic',
+            'has_options'            => false,
+            'supports_placeholder'   => true,
             'supports_default_value' => true,
-            'validation_options' => ['min', 'max', 'step'],
+            'validation_options'     => ['min', 'max', 'step'],
         ],
         'url' => [
-            'icon' => 'o-link',
-            'category' => 'basic',
-            'has_options' => false,
-            'supports_placeholder' => true,
+            'icon'                   => 'o-link',
+            'category'               => 'basic',
+            'has_options'            => false,
+            'supports_placeholder'   => true,
             'supports_default_value' => true,
-            'validation_options' => ['min', 'max'],
+            'validation_options'     => ['min', 'max'],
         ],
         'textarea' => [
-            'icon' => 'o-bars-3-bottom-left',
-            'category' => 'basic',
-            'has_options' => false,
-            'supports_placeholder' => true,
+            'icon'                   => 'o-bars-3-bottom-left',
+            'category'               => 'basic',
+            'has_options'            => false,
+            'supports_placeholder'   => true,
             'supports_default_value' => true,
-            'validation_options' => ['min', 'max'],
+            'validation_options'     => ['min', 'max'],
         ],
         'hidden' => [
-            'icon' => 'o-eye-slash',
-            'category' => 'basic',
-            'has_options' => false,
-            'supports_placeholder' => false,
+            'icon'                   => 'o-eye-slash',
+            'category'               => 'basic',
+            'has_options'            => false,
+            'supports_placeholder'   => false,
             'supports_default_value' => true,
-            'validation_options' => [],
+            'validation_options'     => [],
         ],
         'select' => [
-            'icon' => 'o-chevron-down',
-            'category' => 'choice',
-            'has_options' => true,
-            'supports_placeholder' => true,
+            'icon'                   => 'o-chevron-down',
+            'category'               => 'choice',
+            'has_options'            => true,
+            'supports_placeholder'   => true,
             'supports_default_value' => true,
-            'validation_options' => [],
+            'validation_options'     => [],
         ],
         'radio' => [
-            'icon' => 'o-stop-circle',
-            'category' => 'choice',
-            'has_options' => true,
-            'supports_placeholder' => false,
+            'icon'                   => 'o-stop-circle',
+            'category'               => 'choice',
+            'has_options'            => true,
+            'supports_placeholder'   => false,
             'supports_default_value' => true,
-            'validation_options' => [],
+            'validation_options'     => [],
         ],
         'checkbox' => [
-            'icon' => 'o-check-circle',
-            'category' => 'choice',
-            'has_options' => false,
-            'supports_placeholder' => false,
+            'icon'                   => 'o-check-circle',
+            'category'               => 'choice',
+            'has_options'            => false,
+            'supports_placeholder'   => false,
             'supports_default_value' => true,
-            'validation_options' => [],
+            'validation_options'     => [],
         ],
         'checkbox_group' => [
-            'icon' => 'o-list-bullet',
-            'category' => 'choice',
-            'has_options' => true,
-            'supports_placeholder' => false,
+            'icon'                   => 'o-list-bullet',
+            'category'               => 'choice',
+            'has_options'            => true,
+            'supports_placeholder'   => false,
             'supports_default_value' => false,
-            'validation_options' => ['min', 'max'],
+            'validation_options'     => ['min', 'max'],
         ],
         'select_multiple' => [
-            'icon' => 'o-queue-list',
-            'category' => 'choice',
-            'has_options' => true,
-            'supports_placeholder' => false,
+            'icon'                   => 'o-queue-list',
+            'category'               => 'choice',
+            'has_options'            => true,
+            'supports_placeholder'   => false,
             'supports_default_value' => false,
-            'validation_options' => ['min', 'max'],
+            'validation_options'     => ['min', 'max'],
         ],
         'file' => [
-            'icon' => 'o-paper-clip',
-            'category' => 'advanced',
-            'has_options' => false,
-            'supports_placeholder' => false,
+            'icon'                   => 'o-paper-clip',
+            'category'               => 'advanced',
+            'has_options'            => false,
+            'supports_placeholder'   => false,
             'supports_default_value' => false,
-            'validation_options' => ['max_size', 'allowed_types'],
+            'validation_options'     => ['max_size', 'allowed_types'],
         ],
         'date' => [
-            'icon' => 'o-calendar',
-            'category' => 'advanced',
-            'has_options' => false,
-            'supports_placeholder' => false,
+            'icon'                   => 'o-calendar',
+            'category'               => 'advanced',
+            'has_options'            => false,
+            'supports_placeholder'   => false,
             'supports_default_value' => true,
-            'validation_options' => ['min_date', 'max_date'],
+            'validation_options'     => ['min_date', 'max_date'],
         ],
         'phone' => [
-            'icon' => 'o-phone',
-            'category' => 'basic',
-            'has_options' => false,
-            'supports_placeholder' => true,
+            'icon'                   => 'o-phone',
+            'category'               => 'basic',
+            'has_options'            => false,
+            'supports_placeholder'   => true,
             'supports_default_value' => true,
-            'validation_options' => ['pattern'],
+            'validation_options'     => ['pattern'],
         ],
         'time' => [
-            'icon' => 'o-clock',
-            'category' => 'advanced',
-            'has_options' => false,
-            'supports_placeholder' => false,
+            'icon'                   => 'o-clock',
+            'category'               => 'advanced',
+            'has_options'            => false,
+            'supports_placeholder'   => false,
             'supports_default_value' => true,
-            'validation_options' => ['min_time', 'max_time'],
+            'validation_options'     => ['min_time', 'max_time'],
         ],
         'heading' => [
-            'icon' => 'o-h1',
-            'category' => 'layout',
-            'has_options' => false,
-            'supports_placeholder' => false,
+            'icon'                   => 'o-h1',
+            'category'               => 'layout',
+            'has_options'            => false,
+            'supports_placeholder'   => false,
             'supports_default_value' => false,
-            'is_layout' => true,
-            'validation_options' => [],
+            'is_layout'              => true,
+            'validation_options'     => [],
         ],
         'paragraph' => [
-            'icon' => 'o-document-text',
-            'category' => 'layout',
-            'has_options' => false,
-            'supports_placeholder' => false,
+            'icon'                   => 'o-document-text',
+            'category'               => 'layout',
+            'has_options'            => false,
+            'supports_placeholder'   => false,
             'supports_default_value' => false,
-            'is_layout' => true,
-            'validation_options' => [],
+            'is_layout'              => true,
+            'validation_options'     => [],
         ],
         'divider' => [
-            'icon' => 'o-minus',
-            'category' => 'layout',
-            'has_options' => false,
-            'supports_placeholder' => false,
+            'icon'                   => 'o-minus',
+            'category'               => 'layout',
+            'has_options'            => false,
+            'supports_placeholder'   => false,
             'supports_default_value' => false,
-            'is_layout' => true,
-            'validation_options' => [],
+            'is_layout'              => true,
+            'validation_options'     => [],
         ],
         'html' => [
-            'icon' => 'o-code-bracket',
-            'category' => 'layout',
-            'has_options' => false,
-            'supports_placeholder' => false,
+            'icon'                   => 'o-code-bracket',
+            'category'               => 'layout',
+            'has_options'            => false,
+            'supports_placeholder'   => false,
             'supports_default_value' => false,
-            'is_layout' => true,
-            'validation_options' => [],
+            'is_layout'              => true,
+            'validation_options'     => [],
         ],
     ];
 
@@ -222,9 +222,9 @@ class FieldTypes
      * @var array<string, string>
      */
     public const WIDTH_CLASSES = [
-        'full' => 'w-full',
-        'half' => 'w-1/2',
-        'third' => 'w-1/3',
+        'full'       => 'w-full',
+        'half'       => 'w-1/2',
+        'third'      => 'w-1/3',
         'two-thirds' => 'w-2/3',
     ];
 
@@ -239,19 +239,19 @@ class FieldTypes
     {
         return [
             'basic' => [
-                'label' => __('Basic Fields'),
+                'label'  => __( 'Basic Fields' ),
                 'fields' => self::CATEGORY_FIELDS['basic'],
             ],
             'choice' => [
-                'label' => __('Choice Fields'),
+                'label'  => __( 'Choice Fields' ),
                 'fields' => self::CATEGORY_FIELDS['choice'],
             ],
             'advanced' => [
-                'label' => __('Advanced Fields'),
+                'label'  => __( 'Advanced Fields' ),
                 'fields' => self::CATEGORY_FIELDS['advanced'],
             ],
             'layout' => [
-                'label' => __('Layout Elements'),
+                'label'  => __( 'Layout Elements' ),
                 'fields' => self::CATEGORY_FIELDS['layout'],
             ],
         ];
@@ -267,158 +267,158 @@ class FieldTypes
     public static function types(): array
     {
         return [
-            'text' => array_merge(self::TYPE_METADATA['text'], [
-                'label' => __('Text Input'),
+            'text' => array_merge( self::TYPE_METADATA['text'], [
+                'label'    => __( 'Text Input' ),
                 'defaults' => [
-                    'label' => __('Text Field'),
+                    'label'       => __( 'Text Field' ),
                     'placeholder' => '',
                 ],
-            ]),
-            'email' => array_merge(self::TYPE_METADATA['email'], [
-                'label' => __('Email'),
+            ] ),
+            'email' => array_merge( self::TYPE_METADATA['email'], [
+                'label'    => __( 'Email' ),
                 'defaults' => [
-                    'label' => __('Email Address'),
-                    'placeholder' => __('you@example.com'),
+                    'label'       => __( 'Email Address' ),
+                    'placeholder' => __( 'you@example.com' ),
                 ],
-            ]),
-            'number' => array_merge(self::TYPE_METADATA['number'], [
-                'label' => __('Number'),
+            ] ),
+            'number' => array_merge( self::TYPE_METADATA['number'], [
+                'label'    => __( 'Number' ),
                 'defaults' => [
-                    'label' => __('Number'),
+                    'label'       => __( 'Number' ),
                     'placeholder' => '',
                 ],
-            ]),
-            'url' => array_merge(self::TYPE_METADATA['url'], [
-                'label' => __('URL'),
+            ] ),
+            'url' => array_merge( self::TYPE_METADATA['url'], [
+                'label'    => __( 'URL' ),
                 'defaults' => [
-                    'label' => __('Website URL'),
+                    'label'       => __( 'Website URL' ),
                     'placeholder' => 'https://example.com',
                 ],
-            ]),
-            'textarea' => array_merge(self::TYPE_METADATA['textarea'], [
-                'label' => __('Text Area'),
+            ] ),
+            'textarea' => array_merge( self::TYPE_METADATA['textarea'], [
+                'label'    => __( 'Text Area' ),
                 'defaults' => [
-                    'label' => __('Message'),
-                    'placeholder' => '',
+                    'label'        => __( 'Message' ),
+                    'placeholder'  => '',
                     'field_config' => ['rows' => 4],
                 ],
-            ]),
-            'hidden' => array_merge(self::TYPE_METADATA['hidden'], [
-                'label' => __('Hidden Field'),
+            ] ),
+            'hidden' => array_merge( self::TYPE_METADATA['hidden'], [
+                'label'    => __( 'Hidden Field' ),
                 'defaults' => [
-                    'label' => __('Hidden Field'),
+                    'label' => __( 'Hidden Field' ),
                 ],
-            ]),
-            'select' => array_merge(self::TYPE_METADATA['select'], [
-                'label' => __('Dropdown Select'),
+            ] ),
+            'select' => array_merge( self::TYPE_METADATA['select'], [
+                'label'    => __( 'Dropdown Select' ),
                 'defaults' => [
-                    'label' => __('Select an Option'),
-                    'placeholder' => __('Choose...'),
+                    'label'        => __( 'Select an Option' ),
+                    'placeholder'  => __( 'Choose...' ),
                     'field_config' => [
                         'options' => [],
                     ],
                 ],
-            ]),
-            'radio' => array_merge(self::TYPE_METADATA['radio'], [
-                'label' => __('Radio Buttons'),
+            ] ),
+            'radio' => array_merge( self::TYPE_METADATA['radio'], [
+                'label'    => __( 'Radio Buttons' ),
                 'defaults' => [
-                    'label' => __('Choose One'),
+                    'label'        => __( 'Choose One' ),
                     'field_config' => [
                         'options' => [],
                     ],
                 ],
-            ]),
-            'checkbox' => array_merge(self::TYPE_METADATA['checkbox'], [
-                'label' => __('Single Checkbox'),
+            ] ),
+            'checkbox' => array_merge( self::TYPE_METADATA['checkbox'], [
+                'label'    => __( 'Single Checkbox' ),
                 'defaults' => [
-                    'label' => __('I agree to the terms'),
+                    'label' => __( 'I agree to the terms' ),
                 ],
-            ]),
-            'checkbox_group' => array_merge(self::TYPE_METADATA['checkbox_group'], [
-                'label' => __('Checkbox Group'),
+            ] ),
+            'checkbox_group' => array_merge( self::TYPE_METADATA['checkbox_group'], [
+                'label'    => __( 'Checkbox Group' ),
                 'defaults' => [
-                    'label' => __('Select Options'),
+                    'label'        => __( 'Select Options' ),
                     'field_config' => [
                         'options' => [],
                     ],
                 ],
-            ]),
-            'select_multiple' => array_merge(self::TYPE_METADATA['select_multiple'], [
-                'label' => __('Multi-Select'),
+            ] ),
+            'select_multiple' => array_merge( self::TYPE_METADATA['select_multiple'], [
+                'label'    => __( 'Multi-Select' ),
                 'defaults' => [
-                    'label' => __('Select Multiple Options'),
+                    'label'        => __( 'Select Multiple Options' ),
                     'field_config' => [
                         'options' => [],
                     ],
                 ],
-            ]),
-            'file' => array_merge(self::TYPE_METADATA['file'], [
-                'label' => __('File Upload'),
+            ] ),
+            'file' => array_merge( self::TYPE_METADATA['file'], [
+                'label'    => __( 'File Upload' ),
                 'defaults' => [
-                    'label' => __('Upload File'),
+                    'label'        => __( 'Upload File' ),
                     'field_config' => [
-                        'max_size' => 5120,
+                        'max_size'      => 5120,
                         'allowed_types' => ['pdf', 'doc', 'docx', 'jpg', 'png'],
                     ],
                 ],
-            ]),
-            'date' => array_merge(self::TYPE_METADATA['date'], [
-                'label' => __('Date Picker'),
+            ] ),
+            'date' => array_merge( self::TYPE_METADATA['date'], [
+                'label'    => __( 'Date Picker' ),
                 'defaults' => [
-                    'label' => __('Select Date'),
+                    'label' => __( 'Select Date' ),
                 ],
-            ]),
-            'phone' => array_merge(self::TYPE_METADATA['phone'], [
-                'label' => __('Phone Number'),
+            ] ),
+            'phone' => array_merge( self::TYPE_METADATA['phone'], [
+                'label'    => __( 'Phone Number' ),
                 'defaults' => [
-                    'label' => __('Phone Number'),
+                    'label'       => __( 'Phone Number' ),
                     'placeholder' => '(123) 456-7890',
                 ],
-            ]),
-            'time' => array_merge(self::TYPE_METADATA['time'], [
-                'label' => __('Time Picker'),
+            ] ),
+            'time' => array_merge( self::TYPE_METADATA['time'], [
+                'label'    => __( 'Time Picker' ),
                 'defaults' => [
-                    'label' => __('Select Time'),
+                    'label'        => __( 'Select Time' ),
                     'field_config' => [
                         'step' => 60,
                     ],
                 ],
-            ]),
-            'heading' => array_merge(self::TYPE_METADATA['heading'], [
-                'label' => __('Heading'),
+            ] ),
+            'heading' => array_merge( self::TYPE_METADATA['heading'], [
+                'label'    => __( 'Heading' ),
                 'defaults' => [
-                    'label' => __('Section Heading'),
+                    'label'        => __( 'Section Heading' ),
                     'field_config' => [
                         'level' => 'h3',
                     ],
                 ],
-            ]),
-            'paragraph' => array_merge(self::TYPE_METADATA['paragraph'], [
-                'label' => __('Paragraph Text'),
+            ] ),
+            'paragraph' => array_merge( self::TYPE_METADATA['paragraph'], [
+                'label'    => __( 'Paragraph Text' ),
                 'defaults' => [
-                    'label' => __('Information'),
-                    'help_text' => __('Add descriptive text here.'),
+                    'label'     => __( 'Information' ),
+                    'help_text' => __( 'Add descriptive text here.' ),
                 ],
-            ]),
-            'divider' => array_merge(self::TYPE_METADATA['divider'], [
-                'label' => __('Divider'),
+            ] ),
+            'divider' => array_merge( self::TYPE_METADATA['divider'], [
+                'label'    => __( 'Divider' ),
                 'defaults' => [
-                    'label' => __('Divider'),
+                    'label'        => __( 'Divider' ),
                     'field_config' => [
-                        'style' => 'solid',
+                        'style'   => 'solid',
                         'spacing' => 'normal',
                     ],
                 ],
-            ]),
-            'html' => array_merge(self::TYPE_METADATA['html'], [
-                'label' => __('Custom HTML'),
+            ] ),
+            'html' => array_merge( self::TYPE_METADATA['html'], [
+                'label'    => __( 'Custom HTML' ),
                 'defaults' => [
-                    'label' => __('Custom Content'),
+                    'label'        => __( 'Custom Content' ),
                     'field_config' => [
                         'content' => '',
                     ],
                 ],
-            ]),
+            ] ),
         ];
     }
 
@@ -433,19 +433,19 @@ class FieldTypes
     {
         return [
             'full' => [
-                'label' => __('Full Width'),
+                'label' => __( 'Full Width' ),
                 'class' => self::WIDTH_CLASSES['full'],
             ],
             'half' => [
-                'label' => __('Half Width'),
+                'label' => __( 'Half Width' ),
                 'class' => self::WIDTH_CLASSES['half'],
             ],
             'third' => [
-                'label' => __('One Third'),
+                'label' => __( 'One Third' ),
                 'class' => self::WIDTH_CLASSES['third'],
             ],
             'two-thirds' => [
-                'label' => __('Two Thirds'),
+                'label' => __( 'Two Thirds' ),
                 'class' => self::WIDTH_CLASSES['two-thirds'],
             ],
         ];
@@ -478,9 +478,7 @@ class FieldTypes
         $types = self::types();
 
         // Apply filter hook for extensibility
-        if (function_exists('applyFilters')) {
-            $types = applyFilters('ap.forms.fieldTypes', $types);
-        }
+        $types = applyFilters( 'ap.forms.fieldTypes', $types );
 
         return $types;
     }
@@ -500,9 +498,7 @@ class FieldTypes
         $categories = self::categories();
 
         // Apply filter hook for extensibility
-        if (function_exists('applyFilters')) {
-            $categories = applyFilters('ap.forms.fieldCategories', $categories);
-        }
+        $categories = applyFilters( 'ap.forms.fieldCategories', $categories );
 
         return $categories;
     }
@@ -513,13 +509,14 @@ class FieldTypes
      * @since 1.0.0
      *
      * @param  string  $type  The field type name.
+     *
      * @return array<string, mixed>|null The field type config or null if not found.
      */
-    public static function getTypeConfig(string $type): ?array
+    public static function getTypeConfig( string $type ): ?array
     {
         $types = self::getTypes();
 
-        return $types[$type] ?? null;
+        return $types[ $type ] ?? null;
     }
 
     /**
@@ -528,13 +525,14 @@ class FieldTypes
      * @since 1.0.0
      *
      * @param  string  $type  The field type name.
+     *
      * @return array<string, mixed> The default values for the field type.
      */
-    public static function getDefaults(string $type): array
+    public static function getDefaults( string $type ): array
     {
         $types = self::getTypes();
 
-        return $types[$type]['defaults'] ?? [];
+        return $types[ $type ]['defaults'] ?? [];
     }
 
     /**
@@ -543,13 +541,14 @@ class FieldTypes
      * @since 1.0.0
      *
      * @param  string  $type  The field type name.
+     *
      * @return bool True if the field type has configurable options.
      */
-    public static function hasOptions(string $type): bool
+    public static function hasOptions( string $type ): bool
     {
         $types = self::getTypes();
 
-        return $types[$type]['has_options'] ?? false;
+        return $types[ $type ]['has_options'] ?? false;
     }
 
     /**
@@ -558,13 +557,14 @@ class FieldTypes
      * @since 1.0.0
      *
      * @param  string  $type  The field type name.
+     *
      * @return array<string> Array of available validation option names.
      */
-    public static function getValidationOptions(string $type): array
+    public static function getValidationOptions( string $type ): array
     {
         $types = self::getTypes();
 
-        return $types[$type]['validation_options'] ?? [];
+        return $types[ $type ]['validation_options'] ?? [];
     }
 
     /**
@@ -585,13 +585,14 @@ class FieldTypes
      * @since 1.0.0
      *
      * @param  string  $type  The field type name.
+     *
      * @return bool True if the field type exists.
      */
-    public static function typeExists(string $type): bool
+    public static function typeExists( string $type ): bool
     {
         $types = self::getTypes();
 
-        return isset($types[$type]);
+        return isset( $types[ $type ] );
     }
 
     /**
@@ -600,13 +601,14 @@ class FieldTypes
      * @since 1.0.0
      *
      * @param  string  $type  The field type name.
+     *
      * @return bool True if the field type supports placeholders.
      */
-    public static function supportsPlaceholder(string $type): bool
+    public static function supportsPlaceholder( string $type ): bool
     {
         $types = self::getTypes();
 
-        return $types[$type]['supports_placeholder'] ?? false;
+        return $types[ $type ]['supports_placeholder'] ?? false;
     }
 
     /**
@@ -615,13 +617,14 @@ class FieldTypes
      * @since 1.0.0
      *
      * @param  string  $type  The field type name.
+     *
      * @return bool True if the field type supports default values.
      */
-    public static function supportsDefaultValue(string $type): bool
+    public static function supportsDefaultValue( string $type ): bool
     {
         $types = self::getTypes();
 
-        return $types[$type]['supports_default_value'] ?? true;
+        return $types[ $type ]['supports_default_value'] ?? true;
     }
 
     /**
@@ -633,13 +636,14 @@ class FieldTypes
      * @since 1.0.0
      *
      * @param  string  $type  The field type name.
+     *
      * @return bool True if the field type is a layout element.
      */
-    public static function isLayoutField(string $type): bool
+    public static function isLayoutField( string $type ): bool
     {
         $types = self::getTypes();
 
-        return $types[$type]['is_layout'] ?? false;
+        return $types[ $type ]['is_layout'] ?? false;
     }
 
     /**

--- a/src/FormsServiceProvider.php
+++ b/src/FormsServiceProvider.php
@@ -452,11 +452,11 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function publishVueComponents(): void
     {
-        if ( $this->app->runningInConsole()) {
+        if ( $this->app->runningInConsole() ) {
             $this->publishes( [
-                __DIR__ . '/../resources/js/vue'                          => resource_path( 'js/vendor/artisanpack-forms/vue'),
-                __DIR__ . '/../resources/js/shared'                       => resource_path( 'js/vendor/artisanpack-forms/shared'),
-                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts'),
+                __DIR__ . '/../resources/js/vue'                          => resource_path( 'js/vendor/artisanpack-forms/vue' ),
+                __DIR__ . '/../resources/js/shared'                       => resource_path( 'js/vendor/artisanpack-forms/shared' ),
+                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts' ),
             ], 'forms-vue');
         }
     }

--- a/src/FormsServiceProvider.php
+++ b/src/FormsServiceProvider.php
@@ -12,7 +12,7 @@
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms;
 
@@ -75,45 +75,45 @@ class FormsServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(
-            __DIR__.'/../config/forms.php',
+            __DIR__ . '/../config/forms.php',
             'artisanpack-forms-temp',
         );
 
-        $this->app->singleton('forms', function ($app) {
+        $this->app->singleton( 'forms', function ( $app ) {
             return new Forms;
-        });
+        } );
 
-        $this->app->singleton(FormService::class, function ($app) {
+        $this->app->singleton( FormService::class, function ( $app ) {
             return new FormService;
-        });
+        } );
 
-        $this->app->singleton(FieldService::class, function ($app) {
+        $this->app->singleton( FieldService::class, function ( $app ) {
             return new FieldService;
-        });
+        } );
 
-        $this->app->singleton(StepService::class, function ($app) {
+        $this->app->singleton( StepService::class, function ( $app ) {
             return new StepService;
-        });
+        } );
 
-        $this->app->singleton(ConditionalLogicService::class, function ($app) {
+        $this->app->singleton( ConditionalLogicService::class, function ( $app ) {
             return new ConditionalLogicService;
-        });
+        } );
 
-        $this->app->singleton(NotificationService::class, function ($app) {
-            return new NotificationService($app->make(ConditionalLogicService::class));
-        });
+        $this->app->singleton( NotificationService::class, function ( $app ) {
+            return new NotificationService( $app->make( ConditionalLogicService::class ) );
+        } );
 
-        $this->app->singleton(SubmissionService::class, function ($app) {
-            return new SubmissionService($app->make(NotificationService::class));
-        });
+        $this->app->singleton( SubmissionService::class, function ( $app ) {
+            return new SubmissionService( $app->make( NotificationService::class ) );
+        } );
 
-        $this->app->singleton(ExportService::class, function ($app) {
+        $this->app->singleton( ExportService::class, function ( $app ) {
             return new ExportService;
-        });
+        } );
 
-        $this->app->singleton(IntegrationService::class, function ($app) {
+        $this->app->singleton( IntegrationService::class, function ( $app ) {
             return new IntegrationService;
-        });
+        } );
     }
 
     /**
@@ -135,9 +135,9 @@ class FormsServiceProvider extends ServiceProvider
         $this->registerEventListeners();
         $this->registerPolicies();
         $this->publishConfiguration();
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'forms');
-        $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
+        $this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
+        $this->loadViewsFrom( __DIR__ . '/../resources/views', 'forms' );
+        $this->loadRoutesFrom( __DIR__ . '/../routes/web.php' );
         $this->loadApiRoutes();
         $this->registerLivewireComponents();
         $this->publishViews();
@@ -164,34 +164,34 @@ class FormsServiceProvider extends ServiceProvider
         // admin listings) never receive class-strings for agents whose ArtisanPackAgent
         // base cannot be autoloaded. Uses static:: so subclasses can override the
         // availability probe in tests.
-        if (! static::aiPackageAvailable()) {
+        if ( ! static::aiPackageAvailable() ) {
             return [];
         }
 
         return [
             'forms.spam_detection' => [
-                'agent' => SpamDetectionAgent::class,
-                'package' => 'artisanpack-ui/forms',
-                'label' => __('Spam detection'),
-                'description' => __('Semantic spam score, verdict, and reasons on top of existing honeypot and rate-limit checks.'),
+                'agent'       => SpamDetectionAgent::class,
+                'package'     => 'artisanpack-ui/forms',
+                'label'       => __( 'Spam detection' ),
+                'description' => __( 'Semantic spam score, verdict, and reasons on top of existing honeypot and rate-limit checks.' ),
             ],
             'forms.submission_summary' => [
-                'agent' => SubmissionSummaryAgent::class,
-                'package' => 'artisanpack-ui/forms',
-                'label' => __('Submission summary'),
-                'description' => __('Periodic digest of submission themes, notable entries, and suggested follow-ups.'),
+                'agent'       => SubmissionSummaryAgent::class,
+                'package'     => 'artisanpack-ui/forms',
+                'label'       => __( 'Submission summary' ),
+                'description' => __( 'Periodic digest of submission themes, notable entries, and suggested follow-ups.' ),
             ],
             'forms.response_classification' => [
-                'agent' => ResponseClassificationAgent::class,
-                'package' => 'artisanpack-ui/forms',
-                'label' => __('Response classification'),
-                'description' => __('Auto-categorize incoming submissions against a caller-supplied set of labels.'),
+                'agent'       => ResponseClassificationAgent::class,
+                'package'     => 'artisanpack-ui/forms',
+                'label'       => __( 'Response classification' ),
+                'description' => __( 'Auto-categorize incoming submissions against a caller-supplied set of labels.' ),
             ],
             'forms.smart_validation' => [
-                'agent' => SmartFieldValidationAgent::class,
-                'package' => 'artisanpack-ui/forms',
-                'label' => __('Smart field validation'),
-                'description' => __('Opt-in semantic per-field plausibility check that complements format validation.'),
+                'agent'       => SmartFieldValidationAgent::class,
+                'package'     => 'artisanpack-ui/forms',
+                'label'       => __( 'Smart field validation' ),
+                'description' => __( 'Opt-in semantic per-field plausibility check that complements format validation.' ),
             ],
         ];
     }
@@ -208,7 +208,7 @@ class FormsServiceProvider extends ServiceProvider
      */
     public static function aiPackageAvailable(): bool
     {
-        return class_exists(ArtisanPackAgent::class);
+        return class_exists( ArtisanPackAgent::class );
     }
 
     /**
@@ -221,10 +221,10 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function mergeConfiguration(): void
     {
-        $packageDefaults = config('artisanpack-forms-temp', []);
-        $userConfig = config('artisanpack.forms', []);
-        $mergedConfig = array_replace_recursive($packageDefaults, $userConfig);
-        config(['artisanpack.forms' => $mergedConfig]);
+        $packageDefaults = config( 'artisanpack-forms-temp', [] );
+        $userConfig      = config( 'artisanpack.forms', [] );
+        $mergedConfig    = array_replace_recursive( $packageDefaults, $userConfig );
+        config( ['artisanpack.forms' => $mergedConfig] );
     }
 
     /**
@@ -241,23 +241,23 @@ class FormsServiceProvider extends ServiceProvider
     protected function validateUserModelConfiguration(): void
     {
         // Only validate if ownership restriction is enabled
-        if (! config('artisanpack.forms.authorization.restrict_by_owner', false)) {
+        if ( ! config( 'artisanpack.forms.authorization.restrict_by_owner', false ) ) {
             return;
         }
 
-        $userModel = config('artisanpack.forms.authorization.user_model', 'App\\Models\\User');
+        $userModel = config( 'artisanpack.forms.authorization.user_model', 'App\\Models\\User' );
 
-        if (! class_exists($userModel)) {
+        if ( ! class_exists( $userModel ) ) {
             throw new RuntimeException(
-                "The configured user model class '{$userModel}' does not exist. ".
-                'Please set a valid class in FORMS_USER_MODEL environment variable or '.
+                "The configured user model class '{$userModel}' does not exist. " .
+                'Please set a valid class in FORMS_USER_MODEL environment variable or ' .
                 'artisanpack.forms.authorization.user_model configuration.',
             );
         }
 
-        if (! is_subclass_of($userModel, Model::class)) {
+        if ( ! is_subclass_of( $userModel, Model::class ) ) {
             throw new RuntimeException(
-                "The configured user model class '{$userModel}' must extend ".
+                "The configured user model class '{$userModel}' must extend " .
                 'Illuminate\\Database\\Eloquent\\Model.',
             );
         }
@@ -273,12 +273,12 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function registerFilesystemDisk(): void
     {
-        $diskConfig = config('artisanpack.forms.disk_config', []);
+        $diskConfig = config( 'artisanpack.forms.disk_config', [] );
 
-        foreach ($diskConfig as $diskName => $diskSettings) {
+        foreach ( $diskConfig as $diskName => $diskSettings ) {
             // Only add the disk if it doesn't already exist
-            if (config("filesystems.disks.{$diskName}") === null) {
-                config(["filesystems.disks.{$diskName}" => $diskSettings]);
+            if ( null === config( "filesystems.disks.{$diskName}" ) ) {
+                config( ["filesystems.disks.{$diskName}" => $diskSettings] );
             }
         }
     }
@@ -292,11 +292,11 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function registerCommands(): void
     {
-        if ($this->app->runningInConsole()) {
-            $this->commands([
+        if ( $this->app->runningInConsole() ) {
+            $this->commands( [
                 InstallFrontend::class,
                 PruneFormSubmissions::class,
-            ]);
+            ] );
         }
     }
 
@@ -309,7 +309,7 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function registerEventListeners(): void
     {
-        Event::listen(FormSubmitted::class, SendWebhookOnSubmission::class);
+        Event::listen( FormSubmitted::class, SendWebhookOnSubmission::class );
     }
 
     /**
@@ -322,8 +322,8 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function registerPolicies(): void
     {
-        Gate::policy(Models\Form::class, Policies\FormPolicy::class);
-        Gate::policy(Models\FormSubmission::class, Policies\SubmissionPolicy::class);
+        Gate::policy( Models\Form::class, Policies\FormPolicy::class );
+        Gate::policy( Models\FormSubmission::class, Policies\SubmissionPolicy::class );
     }
 
     /**
@@ -336,10 +336,10 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function publishConfiguration(): void
     {
-        if ($this->app->runningInConsole()) {
-            $this->publishes([
-                __DIR__.'/../config/forms.php' => config_path('artisanpack/forms.php'),
-            ], 'artisanpack-package-config');
+        if ( $this->app->runningInConsole() ) {
+            $this->publishes( [
+                __DIR__ . '/../config/forms.php' => config_path( 'artisanpack/forms.php' ),
+            ], 'artisanpack-package-config' );
         }
     }
 
@@ -352,28 +352,28 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function registerLivewireComponents(): void
     {
-        if (! class_exists(Livewire::class)) {
+        if ( ! class_exists( Livewire::class ) ) {
             return;
         }
 
-        Livewire::component('forms-list', FormsList::class);
-        Livewire::component('form-builder', FormBuilder::class);
-        Livewire::component('form-renderer', FormRenderer::class);
-        Livewire::component('notification-editor', NotificationEditor::class);
-        Livewire::component('submissions-list', SubmissionsList::class);
-        Livewire::component('submission-detail', SubmissionDetail::class);
+        Livewire::component( 'forms-list', FormsList::class );
+        Livewire::component( 'form-builder', FormBuilder::class );
+        Livewire::component( 'form-renderer', FormRenderer::class );
+        Livewire::component( 'notification-editor', NotificationEditor::class );
+        Livewire::component( 'submissions-list', SubmissionsList::class );
+        Livewire::component( 'submission-detail', SubmissionDetail::class );
 
         // AI trigger components are only registered when artisanpack-ui/ai is
         // installed, since each component's mount path constructs an agent
         // that extends the ai package's ArtisanPackAgent base class.
-        if (! self::aiPackageAvailable()) {
+        if ( ! self::aiPackageAvailable() ) {
             return;
         }
 
-        Livewire::component('forms::ai-spam-check', SpamCheck::class);
-        Livewire::component('forms::ai-submission-summary', SubmissionSummary::class);
-        Livewire::component('forms::ai-response-classifier', ResponseClassifier::class);
-        Livewire::component('forms::ai-smart-field-validator', SmartFieldValidator::class);
+        Livewire::component( 'forms::ai-spam-check', SpamCheck::class );
+        Livewire::component( 'forms::ai-submission-summary', SubmissionSummary::class );
+        Livewire::component( 'forms::ai-response-classifier', ResponseClassifier::class );
+        Livewire::component( 'forms::ai-smart-field-validator', SmartFieldValidator::class );
     }
 
     /**
@@ -385,8 +385,8 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function loadApiRoutes(): void
     {
-        if (config('artisanpack.forms.api.enabled', true)) {
-            $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
+        if ( config( 'artisanpack.forms.api.enabled', true ) ) {
+            $this->loadRoutesFrom( __DIR__ . '/../routes/api.php' );
         }
     }
 
@@ -399,10 +399,10 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function publishViews(): void
     {
-        if ($this->app->runningInConsole()) {
-            $this->publishes([
-                __DIR__.'/../resources/views' => resource_path('views/vendor/forms'),
-            ], 'artisanpack-forms-views');
+        if ( $this->app->runningInConsole() ) {
+            $this->publishes( [
+                __DIR__ . '/../resources/views' => resource_path( 'views/vendor/forms' ),
+            ], 'artisanpack-forms-views' );
         }
     }
 
@@ -416,10 +416,10 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function publishTypeDefinitions(): void
     {
-        if ($this->app->runningInConsole()) {
-            $this->publishes([
-                __DIR__.'/../resources/js/types/artisanpack-forms.d.ts' => resource_path('types/artisanpack-forms.d.ts'),
-            ], 'forms-types');
+        if ( $this->app->runningInConsole() ) {
+            $this->publishes( [
+                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'types/artisanpack-forms.d.ts' ),
+            ], 'forms-types' );
         }
     }
 
@@ -433,12 +433,12 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function publishReactComponents(): void
     {
-        if ($this->app->runningInConsole()) {
-            $this->publishes([
-                __DIR__.'/../resources/js/react' => resource_path('js/vendor/artisanpack-forms/react'),
-                __DIR__.'/../resources/js/shared' => resource_path('js/vendor/artisanpack-forms/shared'),
-                __DIR__.'/../resources/js/types/artisanpack-forms.d.ts' => resource_path('js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts'),
-            ], 'forms-react');
+        if ( $this->app->runningInConsole() ) {
+            $this->publishes( [
+                __DIR__ . '/../resources/js/react'                        => resource_path( 'js/vendor/artisanpack-forms/react' ),
+                __DIR__ . '/../resources/js/shared'                       => resource_path( 'js/vendor/artisanpack-forms/shared' ),
+                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts' ),
+            ], 'forms-react' );
         }
     }
 
@@ -452,11 +452,11 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function publishVueComponents(): void
     {
-        if ($this->app->runningInConsole()) {
-            $this->publishes([
-                __DIR__.'/../resources/js/vue' => resource_path('js/vendor/artisanpack-forms/vue'),
-                __DIR__.'/../resources/js/shared' => resource_path('js/vendor/artisanpack-forms/shared'),
-                __DIR__.'/../resources/js/types/artisanpack-forms.d.ts' => resource_path('js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts'),
+        if ( $this->app->runningInConsole()) {
+            $this->publishes( [
+                __DIR__ . '/../resources/js/vue'                          => resource_path( 'js/vendor/artisanpack-forms/vue'),
+                __DIR__ . '/../resources/js/shared'                       => resource_path( 'js/vendor/artisanpack-forms/shared'),
+                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts'),
             ], 'forms-vue');
         }
     }

--- a/src/FormsServiceProvider.php
+++ b/src/FormsServiceProvider.php
@@ -12,7 +12,7 @@
  * @since      1.0.0
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Forms;
 
@@ -75,45 +75,45 @@ class FormsServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(
-            __DIR__ . '/../config/forms.php',
+            __DIR__.'/../config/forms.php',
             'artisanpack-forms-temp',
         );
 
-        $this->app->singleton( 'forms', function ( $app ) {
+        $this->app->singleton('forms', function ($app) {
             return new Forms;
-        } );
+        });
 
-        $this->app->singleton( FormService::class, function ( $app ) {
+        $this->app->singleton(FormService::class, function ($app) {
             return new FormService;
-        } );
+        });
 
-        $this->app->singleton( FieldService::class, function ( $app ) {
+        $this->app->singleton(FieldService::class, function ($app) {
             return new FieldService;
-        } );
+        });
 
-        $this->app->singleton( StepService::class, function ( $app ) {
+        $this->app->singleton(StepService::class, function ($app) {
             return new StepService;
-        } );
+        });
 
-        $this->app->singleton( ConditionalLogicService::class, function ( $app ) {
+        $this->app->singleton(ConditionalLogicService::class, function ($app) {
             return new ConditionalLogicService;
-        } );
+        });
 
-        $this->app->singleton( NotificationService::class, function ( $app ) {
-            return new NotificationService( $app->make( ConditionalLogicService::class ) );
-        } );
+        $this->app->singleton(NotificationService::class, function ($app) {
+            return new NotificationService($app->make(ConditionalLogicService::class));
+        });
 
-        $this->app->singleton( SubmissionService::class, function ( $app ) {
-            return new SubmissionService( $app->make( NotificationService::class ) );
-        } );
+        $this->app->singleton(SubmissionService::class, function ($app) {
+            return new SubmissionService($app->make(NotificationService::class));
+        });
 
-        $this->app->singleton( ExportService::class, function ( $app ) {
+        $this->app->singleton(ExportService::class, function ($app) {
             return new ExportService;
-        } );
+        });
 
-        $this->app->singleton( IntegrationService::class, function ( $app ) {
+        $this->app->singleton(IntegrationService::class, function ($app) {
             return new IntegrationService;
-        } );
+        });
     }
 
     /**
@@ -126,6 +126,8 @@ class FormsServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        Support\HookAliases::register();
+
         $this->mergeConfiguration();
         $this->validateUserModelConfiguration();
         $this->registerFilesystemDisk();
@@ -133,9 +135,9 @@ class FormsServiceProvider extends ServiceProvider
         $this->registerEventListeners();
         $this->registerPolicies();
         $this->publishConfiguration();
-        $this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
-        $this->loadViewsFrom( __DIR__ . '/../resources/views', 'forms' );
-        $this->loadRoutesFrom( __DIR__ . '/../routes/web.php' );
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'forms');
+        $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
         $this->loadApiRoutes();
         $this->registerLivewireComponents();
         $this->publishViews();
@@ -162,34 +164,34 @@ class FormsServiceProvider extends ServiceProvider
         // admin listings) never receive class-strings for agents whose ArtisanPackAgent
         // base cannot be autoloaded. Uses static:: so subclasses can override the
         // availability probe in tests.
-        if ( ! static::aiPackageAvailable() ) {
+        if (! static::aiPackageAvailable()) {
             return [];
         }
 
         return [
             'forms.spam_detection' => [
-                'agent'       => SpamDetectionAgent::class,
-                'package'     => 'artisanpack-ui/forms',
-                'label'       => __( 'Spam detection' ),
-                'description' => __( 'Semantic spam score, verdict, and reasons on top of existing honeypot and rate-limit checks.' ),
+                'agent' => SpamDetectionAgent::class,
+                'package' => 'artisanpack-ui/forms',
+                'label' => __('Spam detection'),
+                'description' => __('Semantic spam score, verdict, and reasons on top of existing honeypot and rate-limit checks.'),
             ],
             'forms.submission_summary' => [
-                'agent'       => SubmissionSummaryAgent::class,
-                'package'     => 'artisanpack-ui/forms',
-                'label'       => __( 'Submission summary' ),
-                'description' => __( 'Periodic digest of submission themes, notable entries, and suggested follow-ups.' ),
+                'agent' => SubmissionSummaryAgent::class,
+                'package' => 'artisanpack-ui/forms',
+                'label' => __('Submission summary'),
+                'description' => __('Periodic digest of submission themes, notable entries, and suggested follow-ups.'),
             ],
             'forms.response_classification' => [
-                'agent'       => ResponseClassificationAgent::class,
-                'package'     => 'artisanpack-ui/forms',
-                'label'       => __( 'Response classification' ),
-                'description' => __( 'Auto-categorize incoming submissions against a caller-supplied set of labels.' ),
+                'agent' => ResponseClassificationAgent::class,
+                'package' => 'artisanpack-ui/forms',
+                'label' => __('Response classification'),
+                'description' => __('Auto-categorize incoming submissions against a caller-supplied set of labels.'),
             ],
             'forms.smart_validation' => [
-                'agent'       => SmartFieldValidationAgent::class,
-                'package'     => 'artisanpack-ui/forms',
-                'label'       => __( 'Smart field validation' ),
-                'description' => __( 'Opt-in semantic per-field plausibility check that complements format validation.' ),
+                'agent' => SmartFieldValidationAgent::class,
+                'package' => 'artisanpack-ui/forms',
+                'label' => __('Smart field validation'),
+                'description' => __('Opt-in semantic per-field plausibility check that complements format validation.'),
             ],
         ];
     }
@@ -206,7 +208,7 @@ class FormsServiceProvider extends ServiceProvider
      */
     public static function aiPackageAvailable(): bool
     {
-        return class_exists( ArtisanPackAgent::class );
+        return class_exists(ArtisanPackAgent::class);
     }
 
     /**
@@ -219,10 +221,10 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function mergeConfiguration(): void
     {
-        $packageDefaults = config( 'artisanpack-forms-temp', [] );
-        $userConfig      = config( 'artisanpack.forms', [] );
-        $mergedConfig    = array_replace_recursive( $packageDefaults, $userConfig );
-        config( ['artisanpack.forms' => $mergedConfig] );
+        $packageDefaults = config('artisanpack-forms-temp', []);
+        $userConfig = config('artisanpack.forms', []);
+        $mergedConfig = array_replace_recursive($packageDefaults, $userConfig);
+        config(['artisanpack.forms' => $mergedConfig]);
     }
 
     /**
@@ -239,23 +241,23 @@ class FormsServiceProvider extends ServiceProvider
     protected function validateUserModelConfiguration(): void
     {
         // Only validate if ownership restriction is enabled
-        if ( ! config( 'artisanpack.forms.authorization.restrict_by_owner', false ) ) {
+        if (! config('artisanpack.forms.authorization.restrict_by_owner', false)) {
             return;
         }
 
-        $userModel = config( 'artisanpack.forms.authorization.user_model', 'App\\Models\\User' );
+        $userModel = config('artisanpack.forms.authorization.user_model', 'App\\Models\\User');
 
-        if ( ! class_exists( $userModel ) ) {
+        if (! class_exists($userModel)) {
             throw new RuntimeException(
-                "The configured user model class '{$userModel}' does not exist. " .
-                'Please set a valid class in FORMS_USER_MODEL environment variable or ' .
+                "The configured user model class '{$userModel}' does not exist. ".
+                'Please set a valid class in FORMS_USER_MODEL environment variable or '.
                 'artisanpack.forms.authorization.user_model configuration.',
             );
         }
 
-        if ( ! is_subclass_of( $userModel, Model::class ) ) {
+        if (! is_subclass_of($userModel, Model::class)) {
             throw new RuntimeException(
-                "The configured user model class '{$userModel}' must extend " .
+                "The configured user model class '{$userModel}' must extend ".
                 'Illuminate\\Database\\Eloquent\\Model.',
             );
         }
@@ -271,12 +273,12 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function registerFilesystemDisk(): void
     {
-        $diskConfig = config( 'artisanpack.forms.disk_config', [] );
+        $diskConfig = config('artisanpack.forms.disk_config', []);
 
-        foreach ( $diskConfig as $diskName => $diskSettings ) {
+        foreach ($diskConfig as $diskName => $diskSettings) {
             // Only add the disk if it doesn't already exist
-            if ( null === config( "filesystems.disks.{$diskName}" ) ) {
-                config( ["filesystems.disks.{$diskName}" => $diskSettings] );
+            if (config("filesystems.disks.{$diskName}") === null) {
+                config(["filesystems.disks.{$diskName}" => $diskSettings]);
             }
         }
     }
@@ -290,11 +292,11 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function registerCommands(): void
     {
-        if ( $this->app->runningInConsole() ) {
-            $this->commands( [
+        if ($this->app->runningInConsole()) {
+            $this->commands([
                 InstallFrontend::class,
                 PruneFormSubmissions::class,
-            ] );
+            ]);
         }
     }
 
@@ -307,7 +309,7 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function registerEventListeners(): void
     {
-        Event::listen( FormSubmitted::class, SendWebhookOnSubmission::class );
+        Event::listen(FormSubmitted::class, SendWebhookOnSubmission::class);
     }
 
     /**
@@ -320,8 +322,8 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function registerPolicies(): void
     {
-        Gate::policy( Models\Form::class, Policies\FormPolicy::class );
-        Gate::policy( Models\FormSubmission::class, Policies\SubmissionPolicy::class );
+        Gate::policy(Models\Form::class, Policies\FormPolicy::class);
+        Gate::policy(Models\FormSubmission::class, Policies\SubmissionPolicy::class);
     }
 
     /**
@@ -334,10 +336,10 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function publishConfiguration(): void
     {
-        if ( $this->app->runningInConsole() ) {
-            $this->publishes( [
-                __DIR__ . '/../config/forms.php' => config_path( 'artisanpack/forms.php' ),
-            ], 'artisanpack-package-config' );
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/forms.php' => config_path('artisanpack/forms.php'),
+            ], 'artisanpack-package-config');
         }
     }
 
@@ -350,28 +352,28 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function registerLivewireComponents(): void
     {
-        if ( ! class_exists( Livewire::class ) ) {
+        if (! class_exists(Livewire::class)) {
             return;
         }
 
-        Livewire::component( 'forms-list', FormsList::class );
-        Livewire::component( 'form-builder', FormBuilder::class );
-        Livewire::component( 'form-renderer', FormRenderer::class );
-        Livewire::component( 'notification-editor', NotificationEditor::class );
-        Livewire::component( 'submissions-list', SubmissionsList::class );
-        Livewire::component( 'submission-detail', SubmissionDetail::class );
+        Livewire::component('forms-list', FormsList::class);
+        Livewire::component('form-builder', FormBuilder::class);
+        Livewire::component('form-renderer', FormRenderer::class);
+        Livewire::component('notification-editor', NotificationEditor::class);
+        Livewire::component('submissions-list', SubmissionsList::class);
+        Livewire::component('submission-detail', SubmissionDetail::class);
 
         // AI trigger components are only registered when artisanpack-ui/ai is
         // installed, since each component's mount path constructs an agent
         // that extends the ai package's ArtisanPackAgent base class.
-        if ( ! self::aiPackageAvailable() ) {
+        if (! self::aiPackageAvailable()) {
             return;
         }
 
-        Livewire::component( 'forms::ai-spam-check', SpamCheck::class );
-        Livewire::component( 'forms::ai-submission-summary', SubmissionSummary::class );
-        Livewire::component( 'forms::ai-response-classifier', ResponseClassifier::class );
-        Livewire::component( 'forms::ai-smart-field-validator', SmartFieldValidator::class );
+        Livewire::component('forms::ai-spam-check', SpamCheck::class);
+        Livewire::component('forms::ai-submission-summary', SubmissionSummary::class);
+        Livewire::component('forms::ai-response-classifier', ResponseClassifier::class);
+        Livewire::component('forms::ai-smart-field-validator', SmartFieldValidator::class);
     }
 
     /**
@@ -383,8 +385,8 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function loadApiRoutes(): void
     {
-        if ( config( 'artisanpack.forms.api.enabled', true ) ) {
-            $this->loadRoutesFrom( __DIR__ . '/../routes/api.php' );
+        if (config('artisanpack.forms.api.enabled', true)) {
+            $this->loadRoutesFrom(__DIR__.'/../routes/api.php');
         }
     }
 
@@ -397,10 +399,10 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function publishViews(): void
     {
-        if ( $this->app->runningInConsole() ) {
-            $this->publishes( [
-                __DIR__ . '/../resources/views' => resource_path( 'views/vendor/forms' ),
-            ], 'artisanpack-forms-views' );
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../resources/views' => resource_path('views/vendor/forms'),
+            ], 'artisanpack-forms-views');
         }
     }
 
@@ -414,10 +416,10 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function publishTypeDefinitions(): void
     {
-        if ( $this->app->runningInConsole() ) {
-            $this->publishes( [
-                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'types/artisanpack-forms.d.ts' ),
-            ], 'forms-types' );
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../resources/js/types/artisanpack-forms.d.ts' => resource_path('types/artisanpack-forms.d.ts'),
+            ], 'forms-types');
         }
     }
 
@@ -431,12 +433,12 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function publishReactComponents(): void
     {
-        if ( $this->app->runningInConsole() ) {
-            $this->publishes( [
-                __DIR__ . '/../resources/js/react'                        => resource_path( 'js/vendor/artisanpack-forms/react' ),
-                __DIR__ . '/../resources/js/shared'                       => resource_path( 'js/vendor/artisanpack-forms/shared' ),
-                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts' ),
-            ], 'forms-react' );
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../resources/js/react' => resource_path('js/vendor/artisanpack-forms/react'),
+                __DIR__.'/../resources/js/shared' => resource_path('js/vendor/artisanpack-forms/shared'),
+                __DIR__.'/../resources/js/types/artisanpack-forms.d.ts' => resource_path('js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts'),
+            ], 'forms-react');
         }
     }
 
@@ -450,11 +452,11 @@ class FormsServiceProvider extends ServiceProvider
      */
     protected function publishVueComponents(): void
     {
-        if ( $this->app->runningInConsole() ) {
-            $this->publishes( [
-                __DIR__ . '/../resources/js/vue'                          => resource_path( 'js/vendor/artisanpack-forms/vue' ),
-                __DIR__ . '/../resources/js/shared'                       => resource_path( 'js/vendor/artisanpack-forms/shared' ),
-                __DIR__ . '/../resources/js/types/artisanpack-forms.d.ts' => resource_path( 'js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts' ),
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../resources/js/vue' => resource_path('js/vendor/artisanpack-forms/vue'),
+                __DIR__.'/../resources/js/shared' => resource_path('js/vendor/artisanpack-forms/shared'),
+                __DIR__.'/../resources/js/types/artisanpack-forms.d.ts' => resource_path('js/vendor/artisanpack-forms/types/artisanpack-forms.d.ts'),
             ], 'forms-vue');
         }
     }

--- a/src/Http/Requests/Api/BulkSubmissionApiRequest.php
+++ b/src/Http/Requests/Api/BulkSubmissionApiRequest.php
@@ -18,6 +18,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\Forms\Http\Requests\Api;
 
 use ArtisanPackUI\Forms\Models\FormSubmission;
+use ArtisanPackUI\Forms\Support\FiresValidationHooks;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -30,6 +31,8 @@ use Illuminate\Foundation\Http\FormRequest;
  */
 class BulkSubmissionApiRequest extends FormRequest
 {
+    use FiresValidationHooks;
+
     /**
      * Determines if the user is authorized to make this request.
      *

--- a/src/Http/Requests/Api/ReorderFieldsApiRequest.php
+++ b/src/Http/Requests/Api/ReorderFieldsApiRequest.php
@@ -17,6 +17,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Http\Requests\Api;
 
+use ArtisanPackUI\Forms\Support\FiresValidationHooks;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -30,6 +31,8 @@ use Illuminate\Validation\Rule;
  */
 class ReorderFieldsApiRequest extends FormRequest
 {
+    use FiresValidationHooks;
+
     /**
      * Determines if the user is authorized to make this request.
      *

--- a/src/Http/Requests/Api/ReorderStepsApiRequest.php
+++ b/src/Http/Requests/Api/ReorderStepsApiRequest.php
@@ -17,6 +17,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Http\Requests\Api;
 
+use ArtisanPackUI\Forms\Support\FiresValidationHooks;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -30,6 +31,8 @@ use Illuminate\Validation\Rule;
  */
 class ReorderStepsApiRequest extends FormRequest
 {
+    use FiresValidationHooks;
+
     /**
      * Determines if the user is authorized to make this request.
      *

--- a/src/Http/Requests/Api/StoreFieldApiRequest.php
+++ b/src/Http/Requests/Api/StoreFieldApiRequest.php
@@ -17,6 +17,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Http\Requests\Api;
 
+use ArtisanPackUI\Forms\Support\FiresValidationHooks;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -30,6 +31,8 @@ use Illuminate\Validation\Rule;
  */
 class StoreFieldApiRequest extends FormRequest
 {
+    use FiresValidationHooks;
+
     /**
      * Determines if the user is authorized to make this request.
      *

--- a/src/Http/Requests/Api/StoreFormApiRequest.php
+++ b/src/Http/Requests/Api/StoreFormApiRequest.php
@@ -18,6 +18,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\Forms\Http\Requests\Api;
 
 use ArtisanPackUI\Forms\Models\Form;
+use ArtisanPackUI\Forms\Support\FiresValidationHooks;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -30,6 +31,8 @@ use Illuminate\Foundation\Http\FormRequest;
  */
 class StoreFormApiRequest extends FormRequest
 {
+    use FiresValidationHooks;
+
     /**
      * Determines if the user is authorized to make this request.
      *
@@ -74,6 +77,8 @@ class StoreFormApiRequest extends FormRequest
      */
     protected function prepareForValidation(): void
     {
+        $this->fireBeforeValidate();
+
         if ( $this->has( 'slug' ) && '' === $this->slug ) {
             $this->merge( ['slug' => null] );
         }

--- a/src/Http/Requests/Api/StoreNotificationApiRequest.php
+++ b/src/Http/Requests/Api/StoreNotificationApiRequest.php
@@ -18,6 +18,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\Forms\Http\Requests\Api;
 
 use ArtisanPackUI\Forms\Models\FormNotification;
+use ArtisanPackUI\Forms\Support\FiresValidationHooks;
 use Closure;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -31,6 +32,8 @@ use Illuminate\Foundation\Http\FormRequest;
  */
 class StoreNotificationApiRequest extends FormRequest
 {
+    use FiresValidationHooks;
+
     /**
      * Determines if the user is authorized to make this request.
      *

--- a/src/Http/Requests/Api/StoreStepApiRequest.php
+++ b/src/Http/Requests/Api/StoreStepApiRequest.php
@@ -17,6 +17,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Http\Requests\Api;
 
+use ArtisanPackUI\Forms\Support\FiresValidationHooks;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -29,6 +30,8 @@ use Illuminate\Foundation\Http\FormRequest;
  */
 class StoreStepApiRequest extends FormRequest
 {
+    use FiresValidationHooks;
+
     /**
      * Determines if the user is authorized to make this request.
      *

--- a/src/Http/Requests/Api/SubmitFormApiRequest.php
+++ b/src/Http/Requests/Api/SubmitFormApiRequest.php
@@ -20,6 +20,7 @@ namespace ArtisanPackUI\Forms\Http\Requests\Api;
 
 use ArtisanPackUI\Forms\Models\Form;
 use ArtisanPackUI\Forms\Services\ConditionalLogicService;
+use ArtisanPackUI\Forms\Support\FiresValidationHooks;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -32,6 +33,8 @@ use Illuminate\Foundation\Http\FormRequest;
  */
 class SubmitFormApiRequest extends FormRequest
 {
+    use FiresValidationHooks;
+
     /**
      * Determines if the user is authorized to make this request.
      *

--- a/src/Http/Requests/Api/UpdateFieldApiRequest.php
+++ b/src/Http/Requests/Api/UpdateFieldApiRequest.php
@@ -17,6 +17,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Http\Requests\Api;
 
+use ArtisanPackUI\Forms\Support\FiresValidationHooks;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -30,6 +31,8 @@ use Illuminate\Validation\Rule;
  */
 class UpdateFieldApiRequest extends FormRequest
 {
+    use FiresValidationHooks;
+
     /**
      * Determines if the user is authorized to make this request.
      *

--- a/src/Http/Requests/Api/UpdateFormApiRequest.php
+++ b/src/Http/Requests/Api/UpdateFormApiRequest.php
@@ -18,6 +18,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\Forms\Http\Requests\Api;
 
 use ArtisanPackUI\Forms\Models\Form;
+use ArtisanPackUI\Forms\Support\FiresValidationHooks;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -31,6 +32,8 @@ use Illuminate\Validation\Rule;
  */
 class UpdateFormApiRequest extends FormRequest
 {
+    use FiresValidationHooks;
+
     /**
      * Determines if the user is authorized to make this request.
      *
@@ -93,6 +96,8 @@ class UpdateFormApiRequest extends FormRequest
      */
     protected function prepareForValidation(): void
     {
+        $this->fireBeforeValidate();
+
         if ( $this->has( 'slug' ) && '' === $this->slug ) {
             $this->merge( ['slug' => null] );
         }

--- a/src/Http/Requests/Api/UpdateNotificationApiRequest.php
+++ b/src/Http/Requests/Api/UpdateNotificationApiRequest.php
@@ -18,6 +18,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\Forms\Http\Requests\Api;
 
 use ArtisanPackUI\Forms\Models\FormNotification;
+use ArtisanPackUI\Forms\Support\FiresValidationHooks;
 use Closure;
 use Illuminate\Foundation\Http\FormRequest;
 
@@ -31,6 +32,8 @@ use Illuminate\Foundation\Http\FormRequest;
  */
 class UpdateNotificationApiRequest extends FormRequest
 {
+    use FiresValidationHooks;
+
     /**
      * Determines if the user is authorized to make this request.
      *

--- a/src/Http/Requests/Api/UpdateStepApiRequest.php
+++ b/src/Http/Requests/Api/UpdateStepApiRequest.php
@@ -17,6 +17,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Http\Requests\Api;
 
+use ArtisanPackUI\Forms\Support\FiresValidationHooks;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -29,6 +30,8 @@ use Illuminate\Foundation\Http\FormRequest;
  */
 class UpdateStepApiRequest extends FormRequest
 {
+    use FiresValidationHooks;
+
     /**
      * Determines if the user is authorized to make this request.
      *

--- a/src/Http/Requests/Api/UpdateSubmissionApiRequest.php
+++ b/src/Http/Requests/Api/UpdateSubmissionApiRequest.php
@@ -17,6 +17,7 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Http\Requests\Api;
 
+use ArtisanPackUI\Forms\Support\FiresValidationHooks;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -29,6 +30,8 @@ use Illuminate\Foundation\Http\FormRequest;
  */
 class UpdateSubmissionApiRequest extends FormRequest
 {
+    use FiresValidationHooks;
+
     /**
      * Determines if the user is authorized to make this request.
      *

--- a/src/Http/Requests/StoreFormRequest.php
+++ b/src/Http/Requests/StoreFormRequest.php
@@ -18,6 +18,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\Forms\Http\Requests;
 
 use ArtisanPackUI\Forms\Models\Form;
+use ArtisanPackUI\Forms\Support\FiresValidationHooks;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 
@@ -33,6 +34,8 @@ use Illuminate\Support\Facades\Gate;
  */
 class StoreFormRequest extends FormRequest
 {
+    use FiresValidationHooks;
+
     /**
      * Determines if the user is authorized to make this request.
      *
@@ -108,6 +111,8 @@ class StoreFormRequest extends FormRequest
      */
     protected function prepareForValidation(): void
     {
+        $this->fireBeforeValidate();
+
         // Convert empty slug to null so it gets auto-generated
         if ( $this->has( 'slug' ) && '' === $this->slug ) {
             $this->merge( ['slug' => null] );

--- a/src/Http/Requests/UpdateFormRequest.php
+++ b/src/Http/Requests/UpdateFormRequest.php
@@ -18,6 +18,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\Forms\Http\Requests;
 
 use ArtisanPackUI\Forms\Models\Form;
+use ArtisanPackUI\Forms\Support\FiresValidationHooks;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Validation\Rule;
@@ -34,6 +35,8 @@ use Illuminate\Validation\Rule;
  */
 class UpdateFormRequest extends FormRequest
 {
+    use FiresValidationHooks;
+
     /**
      * Determines if the user is authorized to make this request.
      *
@@ -124,6 +127,8 @@ class UpdateFormRequest extends FormRequest
      */
     protected function prepareForValidation(): void
     {
+        $this->fireBeforeValidate();
+
         // Convert empty slug to null so it gets auto-generated
         if ( $this->has( 'slug' ) && '' === $this->slug ) {
             $this->merge( ['slug' => null] );

--- a/src/Jobs/SendFormNotification.php
+++ b/src/Jobs/SendFormNotification.php
@@ -12,7 +12,7 @@
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Jobs;
 
@@ -81,10 +81,10 @@ class SendFormNotification implements ShouldQueue
      * @param  FormNotification  $notification  The notification to send.
      * @param  FormSubmission  $submission  The form submission data.
      */
-    public function __construct(FormNotification $notification, FormSubmission $submission)
+    public function __construct( FormNotification $notification, FormSubmission $submission )
     {
         $this->notification = $notification;
-        $this->submission = $submission;
+        $this->submission   = $submission;
     }
 
     /**
@@ -97,69 +97,63 @@ class SendFormNotification implements ShouldQueue
     public function handle(): void
     {
         // Ensure relationships are loaded
-        $this->submission->loadMissing(['form', 'values.field']);
-        $this->notification->loadMissing('form');
+        $this->submission->loadMissing( ['form', 'values.field'] );
+        $this->notification->loadMissing( 'form' );
 
         // Get recipient emails
-        $recipients = $this->notification->getRecipientEmails($this->submission);
+        $recipients = $this->notification->getRecipientEmails( $this->submission );
 
         // Apply filter hook to allow modifying recipients
-        if (function_exists('applyFilters')) {
-            $recipients = applyFilters(
-                'ap.forms.notificationRecipients',
-                $recipients,
-                $this->notification,
-            );
-        }
+        $recipients = applyFilters(
+            'ap.forms.notificationRecipients',
+            $recipients,
+            $this->notification,
+        );
 
-        if (empty($recipients)) {
-            Log::warning('Form notification has no valid recipients', [
-                'notification_id' => $this->notification->id,
+        if ( empty( $recipients ) ) {
+            Log::warning( 'Form notification has no valid recipients', [
+                'notification_id'   => $this->notification->id,
                 'notification_name' => $this->notification->name,
-                'submission_id' => $this->submission->id,
-                'form_id' => $this->submission->form_id,
-            ]);
+                'submission_id'     => $this->submission->id,
+                'form_id'           => $this->submission->form_id,
+            ] );
 
             return;
         }
 
         try {
             // Fire before_send action hook
-            if (function_exists('doAction')) {
-                doAction(
-                    'ap.forms.notification.beforeSend',
-                    $this->notification,
-                    $this->submission,
-                );
-            }
+            doAction(
+                'ap.forms.notification.beforeSend',
+                $this->notification,
+                $this->submission,
+            );
 
             // Create and send the mailable
-            $mailable = new FormSubmissionNotification($this->notification, $this->submission);
+            $mailable = new FormSubmissionNotification( $this->notification, $this->submission );
 
-            Mail::to($recipients)->send($mailable);
+            Mail::to( $recipients )->send( $mailable );
 
             // Fire sent action hook
-            if (function_exists('doAction')) {
-                doAction(
-                    'ap.forms.notification.sent',
-                    $this->notification,
-                    $this->submission,
-                );
-            }
+            doAction(
+                'ap.forms.notification.sent',
+                $this->notification,
+                $this->submission,
+            );
 
-            Log::info('Form notification sent successfully', [
-                'notification_id' => $this->notification->id,
+            Log::info( 'Form notification sent successfully', [
+                'notification_id'   => $this->notification->id,
                 'notification_name' => $this->notification->name,
-                'submission_id' => $this->submission->id,
-                'recipients' => $recipients,
-            ]);
-        } catch (Exception $e) {
-            Log::error('Failed to send form notification', [
-                'notification_id' => $this->notification->id,
+                'submission_id'     => $this->submission->id,
+                'recipients'        => $recipients,
+            ] );
+        } catch ( Exception $e ) {
+            Log::error( 'Failed to send form notification', [
+                'notification_id'   => $this->notification->id,
                 'notification_name' => $this->notification->name,
-                'submission_id' => $this->submission->id,
-                'error' => $e->getMessage(),
-            ]);
+                'submission_id'     => $this->submission->id,
+                'error'             => $e->getMessage(),
+            ] );
 
             throw $e; // Re-throw to trigger retry
         }
@@ -174,14 +168,14 @@ class SendFormNotification implements ShouldQueue
      *
      * @param  Throwable  $exception  The exception that caused the failure.
      */
-    public function failed(Throwable $exception): void
+    public function failed( Throwable $exception ): void
     {
-        Log::error('Form notification job failed permanently', [
-            'notification_id' => $this->notification->id,
+        Log::error( 'Form notification job failed permanently', [
+            'notification_id'   => $this->notification->id,
             'notification_name' => $this->notification->name,
-            'submission_id' => $this->submission->id,
-            'error' => $exception->getMessage(),
-        ]);
+            'submission_id'     => $this->submission->id,
+            'error'             => $exception->getMessage(),
+        ] );
     }
 
     /**
@@ -197,9 +191,9 @@ class SendFormNotification implements ShouldQueue
     {
         return [
             'form-notification',
-            'notification:'.$this->notification->id,
-            'submission:'.$this->submission->id,
-            'form:'.$this->submission->form_id,
+            'notification:' . $this->notification->id,
+            'submission:' . $this->submission->id,
+            'form:' . $this->submission->form_id,
         ];
     }
 }

--- a/src/Jobs/SendFormNotification.php
+++ b/src/Jobs/SendFormNotification.php
@@ -6,15 +6,13 @@
  * Queued job that sends a single form notification email.
  * Handles recipient resolution, email building, and error logging.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @author     Jacob Martella <support@artisanpackui.dev>
  *
  * @since      1.0.0
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Forms\Jobs;
 
@@ -37,8 +35,6 @@ use Throwable;
  * Queued job that sends a single form notification email.
  * Handles recipient resolution, email building, and error logging.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @since      1.0.0
  */
@@ -53,8 +49,6 @@ class SendFormNotification implements ShouldQueue
      * The number of times the job may be attempted.
      *
      * @since 1.0.0
-     *
-     * @var int
      */
     public int $tries = 3;
 
@@ -62,8 +56,6 @@ class SendFormNotification implements ShouldQueue
      * The number of seconds to wait before retrying the job.
      *
      * @since 1.0.0
-     *
-     * @var int
      */
     public int $backoff = 60;
 
@@ -71,8 +63,6 @@ class SendFormNotification implements ShouldQueue
      * The form notification to send.
      *
      * @since 1.0.0
-     *
-     * @var FormNotification
      */
     public FormNotification $notification;
 
@@ -80,8 +70,6 @@ class SendFormNotification implements ShouldQueue
      * The form submission data.
      *
      * @since 1.0.0
-     *
-     * @var FormSubmission
      */
     public FormSubmission $submission;
 
@@ -90,13 +78,13 @@ class SendFormNotification implements ShouldQueue
      *
      * @since 1.0.0
      *
-     * @param FormNotification $notification The notification to send.
-     * @param FormSubmission   $submission   The form submission data.
+     * @param  FormNotification  $notification  The notification to send.
+     * @param  FormSubmission  $submission  The form submission data.
      */
-    public function __construct( FormNotification $notification, FormSubmission $submission )
+    public function __construct(FormNotification $notification, FormSubmission $submission)
     {
         $this->notification = $notification;
-        $this->submission   = $submission;
+        $this->submission = $submission;
     }
 
     /**
@@ -105,75 +93,73 @@ class SendFormNotification implements ShouldQueue
      * Loads required relationships, resolves recipients, and sends the notification email.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     public function handle(): void
     {
         // Ensure relationships are loaded
-        $this->submission->loadMissing( ['form', 'values.field'] );
-        $this->notification->loadMissing( 'form' );
+        $this->submission->loadMissing(['form', 'values.field']);
+        $this->notification->loadMissing('form');
 
         // Get recipient emails
-        $recipients = $this->notification->getRecipientEmails( $this->submission );
+        $recipients = $this->notification->getRecipientEmails($this->submission);
 
         // Apply filter hook to allow modifying recipients
-        if ( function_exists( 'applyFilters' ) ) {
+        if (function_exists('applyFilters')) {
             $recipients = applyFilters(
-                'forms.notification_recipients',
+                'ap.forms.notificationRecipients',
                 $recipients,
                 $this->notification,
             );
         }
 
-        if ( empty( $recipients ) ) {
-            Log::warning( 'Form notification has no valid recipients', [
-                'notification_id'   => $this->notification->id,
+        if (empty($recipients)) {
+            Log::warning('Form notification has no valid recipients', [
+                'notification_id' => $this->notification->id,
                 'notification_name' => $this->notification->name,
-                'submission_id'     => $this->submission->id,
-                'form_id'           => $this->submission->form_id,
-            ] );
+                'submission_id' => $this->submission->id,
+                'form_id' => $this->submission->form_id,
+            ]);
 
             return;
         }
 
         try {
             // Fire before_send action hook
-            if ( function_exists( 'doAction' ) ) {
+            if (function_exists('doAction')) {
                 doAction(
-                    'forms.notification.before_send',
+                    'ap.forms.notification.beforeSend',
                     $this->notification,
                     $this->submission,
                 );
             }
 
             // Create and send the mailable
-            $mailable = new FormSubmissionNotification( $this->notification, $this->submission );
+            $mailable = new FormSubmissionNotification($this->notification, $this->submission);
 
-            Mail::to( $recipients )->send( $mailable );
+            Mail::to($recipients)->send($mailable);
 
             // Fire sent action hook
-            if ( function_exists( 'doAction' ) ) {
+            if (function_exists('doAction')) {
                 doAction(
-                    'forms.notification.sent',
+                    'ap.forms.notification.sent',
                     $this->notification,
                     $this->submission,
                 );
             }
 
-            Log::info( 'Form notification sent successfully', [
-                'notification_id'   => $this->notification->id,
+            Log::info('Form notification sent successfully', [
+                'notification_id' => $this->notification->id,
                 'notification_name' => $this->notification->name,
-                'submission_id'     => $this->submission->id,
-                'recipients'        => $recipients,
-            ] );
-        } catch ( Exception $e ) {
-            Log::error( 'Failed to send form notification', [
-                'notification_id'   => $this->notification->id,
+                'submission_id' => $this->submission->id,
+                'recipients' => $recipients,
+            ]);
+        } catch (Exception $e) {
+            Log::error('Failed to send form notification', [
+                'notification_id' => $this->notification->id,
                 'notification_name' => $this->notification->name,
-                'submission_id'     => $this->submission->id,
-                'error'             => $e->getMessage(),
-            ] );
+                'submission_id' => $this->submission->id,
+                'error' => $e->getMessage(),
+            ]);
 
             throw $e; // Re-throw to trigger retry
         }
@@ -186,18 +172,16 @@ class SendFormNotification implements ShouldQueue
      *
      * @since 1.0.0
      *
-     * @param Throwable $exception The exception that caused the failure.
-     *
-     * @return void
+     * @param  Throwable  $exception  The exception that caused the failure.
      */
-    public function failed( Throwable $exception ): void
+    public function failed(Throwable $exception): void
     {
-        Log::error( 'Form notification job failed permanently', [
-            'notification_id'   => $this->notification->id,
+        Log::error('Form notification job failed permanently', [
+            'notification_id' => $this->notification->id,
             'notification_name' => $this->notification->name,
-            'submission_id'     => $this->submission->id,
-            'error'             => $exception->getMessage(),
-        ] );
+            'submission_id' => $this->submission->id,
+            'error' => $exception->getMessage(),
+        ]);
     }
 
     /**
@@ -213,9 +197,9 @@ class SendFormNotification implements ShouldQueue
     {
         return [
             'form-notification',
-            'notification:' . $this->notification->id,
-            'submission:' . $this->submission->id,
-            'form:' . $this->submission->form_id,
+            'notification:'.$this->notification->id,
+            'submission:'.$this->submission->id,
+            'form:'.$this->submission->form_id,
         ];
     }
 }

--- a/src/Jobs/SendWebhook.php
+++ b/src/Jobs/SendWebhook.php
@@ -6,15 +6,13 @@
  * Queued job that sends a webhook notification when a form submission is created.
  * Supports webhook secret verification for secure integrations.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @author     Jacob Martella <support@artisanpackui.dev>
  *
  * @since      1.0.0
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Forms\Jobs;
 
@@ -36,8 +34,6 @@ use Throwable;
  * Queued job that sends a webhook notification when a form submission is created.
  * Supports webhook secret verification for secure integrations.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @since      1.0.0
  */
@@ -52,8 +48,6 @@ class SendWebhook implements ShouldQueue
      * The number of times the job may be attempted.
      *
      * @since 1.0.0
-     *
-     * @var int
      */
     public int $tries = 3;
 
@@ -72,8 +66,6 @@ class SendWebhook implements ShouldQueue
      * The form submission to send.
      *
      * @since 1.0.0
-     *
-     * @var FormSubmission
      */
     public FormSubmission $submission;
 
@@ -81,8 +73,6 @@ class SendWebhook implements ShouldQueue
      * The webhook URL to send to.
      *
      * @since 1.0.0
-     *
-     * @var string
      */
     public string $url;
 
@@ -90,8 +80,6 @@ class SendWebhook implements ShouldQueue
      * The optional webhook secret for signature verification.
      *
      * @since 1.0.0
-     *
-     * @var string|null
      */
     public ?string $secret;
 
@@ -100,15 +88,15 @@ class SendWebhook implements ShouldQueue
      *
      * @since 1.0.0
      *
-     * @param FormSubmission $submission The form submission to send.
-     * @param string         $url        The webhook URL.
-     * @param string|null    $secret     Optional secret for signature verification.
+     * @param  FormSubmission  $submission  The form submission to send.
+     * @param  string  $url  The webhook URL.
+     * @param  string|null  $secret  Optional secret for signature verification.
      */
-    public function __construct( FormSubmission $submission, string $url, ?string $secret = null )
+    public function __construct(FormSubmission $submission, string $url, ?string $secret = null)
     {
         $this->submission = $submission;
-        $this->url        = $url;
-        $this->secret     = $secret;
+        $this->url = $url;
+        $this->secret = $secret;
     }
 
     /**
@@ -117,53 +105,51 @@ class SendWebhook implements ShouldQueue
      * Builds the payload, sends the webhook request, and handles the response.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     public function handle(): void
     {
         // Ensure relationships are loaded
-        $this->submission->loadMissing( ['form', 'values.field'] );
+        $this->submission->loadMissing(['form', 'values.field']);
 
         // Build the webhook payload
         $payload = $this->buildPayload();
 
         // Build headers
-        $headers = $this->buildHeaders( $payload );
+        $headers = $this->buildHeaders($payload);
 
         try {
-            $response = Http::timeout( 30 )
-                ->withHeaders( $headers )
-                ->post( $this->url, $payload );
+            $response = Http::timeout(30)
+                ->withHeaders($headers)
+                ->post($this->url, $payload);
 
-            if ( $response->successful() ) {
-                Log::info( 'Webhook sent successfully', [
+            if ($response->successful()) {
+                Log::info('Webhook sent successfully', [
                     'submission_id' => $this->submission->id,
-                    'form_id'       => $this->submission->form_id,
-                    'url'           => $this->url,
-                    'status'        => $response->status(),
-                ] );
+                    'form_id' => $this->submission->form_id,
+                    'url' => $this->url,
+                    'status' => $response->status(),
+                ]);
             } else {
-                Log::warning( 'Webhook received non-success response', [
+                Log::warning('Webhook received non-success response', [
                     'submission_id' => $this->submission->id,
-                    'form_id'       => $this->submission->form_id,
-                    'url'           => $this->url,
-                    'status'        => $response->status(),
-                    'body'          => $response->body(),
-                ] );
+                    'form_id' => $this->submission->form_id,
+                    'url' => $this->url,
+                    'status' => $response->status(),
+                    'body' => $response->body(),
+                ]);
 
                 // Throw exception to trigger retry for server errors
-                if ( $response->serverError() ) {
-                    throw new RuntimeException( "Webhook failed with status {$response->status()}" );
+                if ($response->serverError()) {
+                    throw new RuntimeException("Webhook failed with status {$response->status()}");
                 }
             }
-        } catch ( Exception $e ) {
-            Log::error( 'Failed to send webhook', [
+        } catch (Exception $e) {
+            Log::error('Failed to send webhook', [
                 'submission_id' => $this->submission->id,
-                'form_id'       => $this->submission->form_id,
-                'url'           => $this->url,
-                'error'         => $e->getMessage(),
-            ] );
+                'form_id' => $this->submission->form_id,
+                'url' => $this->url,
+                'error' => $e->getMessage(),
+            ]);
 
             throw $e; // Re-throw to trigger retry
         }
@@ -176,18 +162,16 @@ class SendWebhook implements ShouldQueue
      *
      * @since 1.0.0
      *
-     * @param Throwable $exception The exception that caused the failure.
-     *
-     * @return void
+     * @param  Throwable  $exception  The exception that caused the failure.
      */
-    public function failed( Throwable $exception ): void
+    public function failed(Throwable $exception): void
     {
-        Log::error( 'Webhook job failed permanently', [
+        Log::error('Webhook job failed permanently', [
             'submission_id' => $this->submission->id,
-            'form_id'       => $this->submission->form_id,
-            'url'           => $this->url,
-            'error'         => $exception->getMessage(),
-        ] );
+            'form_id' => $this->submission->form_id,
+            'url' => $this->url,
+            'error' => $exception->getMessage(),
+        ]);
     }
 
     /**
@@ -203,8 +187,8 @@ class SendWebhook implements ShouldQueue
     {
         return [
             'webhook',
-            'submission:' . $this->submission->id,
-            'form:' . $this->submission->form_id,
+            'submission:'.$this->submission->id,
+            'form:'.$this->submission->form_id,
         ];
     }
 
@@ -222,40 +206,40 @@ class SendWebhook implements ShouldQueue
     {
         // Build metadata, respecting privacy settings
         $metadata = [
-            'page_url'     => $this->submission->page_url,
+            'page_url' => $this->submission->page_url,
             'referrer_url' => $this->submission->referrer_url,
         ];
 
         // Only include IP address if explicitly enabled in config
-        if ( config( 'artisanpack.forms.privacy.include_ip_address', false ) ) {
+        if (config('artisanpack.forms.privacy.include_ip_address', false)) {
             $metadata['ip_address'] = $this->submission->ip_address;
         }
 
         // Only include user agent if explicitly enabled in config
-        if ( config( 'artisanpack.forms.privacy.include_user_agent', false ) ) {
+        if (config('artisanpack.forms.privacy.include_user_agent', false)) {
             $metadata['user_agent'] = $this->submission->user_agent;
         }
 
         $payload = [
-            'event'     => 'submission.created',
+            'event' => 'submission.created',
             'timestamp' => now()->toIso8601String(),
-            'form'      => [
-                'id'   => $this->submission->form->id,
+            'form' => [
+                'id' => $this->submission->form->id,
                 'name' => $this->submission->form->name,
                 'slug' => $this->submission->form->slug,
             ],
             'submission' => [
-                'id'                => $this->submission->id,
+                'id' => $this->submission->id,
                 'submission_number' => $this->submission->submission_number,
-                'created_at'        => $this->submission->created_at->toIso8601String(),
-                'data'              => $this->submission->data_array,
-                'metadata'          => $metadata,
+                'created_at' => $this->submission->created_at->toIso8601String(),
+                'data' => $this->submission->data_array,
+                'metadata' => $metadata,
             ],
         ];
 
         // Apply filter hook to allow modifying the webhook payload
-        if ( function_exists( 'applyFilters' ) ) {
-            $payload = applyFilters( 'forms.webhook_payload', $payload, $this->submission );
+        if (function_exists('applyFilters')) {
+            $payload = applyFilters('ap.forms.webhookPayload', $payload, $this->submission);
         }
 
         return $payload;
@@ -268,24 +252,23 @@ class SendWebhook implements ShouldQueue
      *
      * @since 1.0.0
      *
-     * @param array<string, mixed> $payload The webhook payload for signature generation.
-     *
+     * @param  array<string, mixed>  $payload  The webhook payload for signature generation.
      * @return array<string, string> The request headers.
      */
-    protected function buildHeaders( array $payload ): array
+    protected function buildHeaders(array $payload): array
     {
         $headers = [
-            'Content-Type'     => 'application/json',
-            'User-Agent'       => 'ArtisanPackUI-Forms/1.0',
-            'X-Forms-Event'    => 'submission.created',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'ArtisanPackUI-Forms/1.0',
+            'X-Forms-Event' => 'submission.created',
             'X-Forms-Delivery' => (string) $this->submission->id,
         ];
 
         // Add signature if secret is configured
-        if ( null !== $this->secret ) {
-            $signature                        = $this->generateSignature( $payload );
-            $headers['X-Forms-Signature']     = $signature;
-            $headers['X-Forms-Signature-256'] = 'sha256=' . $signature;
+        if ($this->secret !== null) {
+            $signature = $this->generateSignature($payload);
+            $headers['X-Forms-Signature'] = $signature;
+            $headers['X-Forms-Signature-256'] = 'sha256='.$signature;
         }
 
         return $headers;
@@ -298,14 +281,13 @@ class SendWebhook implements ShouldQueue
      *
      * @since 1.0.0
      *
-     * @param array<string, mixed> $payload The webhook payload to sign.
-     *
+     * @param  array<string, mixed>  $payload  The webhook payload to sign.
      * @return string The HMAC signature.
      */
-    protected function generateSignature( array $payload ): string
+    protected function generateSignature(array $payload): string
     {
-        $jsonPayload = json_encode( $payload, JSON_THROW_ON_ERROR );
+        $jsonPayload = json_encode($payload, JSON_THROW_ON_ERROR);
 
-        return hash_hmac( 'sha256', $jsonPayload, $this->secret );
+        return hash_hmac('sha256', $jsonPayload, $this->secret);
     }
 }

--- a/src/Jobs/SendWebhook.php
+++ b/src/Jobs/SendWebhook.php
@@ -12,7 +12,7 @@
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Jobs;
 
@@ -92,11 +92,11 @@ class SendWebhook implements ShouldQueue
      * @param  string  $url  The webhook URL.
      * @param  string|null  $secret  Optional secret for signature verification.
      */
-    public function __construct(FormSubmission $submission, string $url, ?string $secret = null)
+    public function __construct( FormSubmission $submission, string $url, ?string $secret = null )
     {
         $this->submission = $submission;
-        $this->url = $url;
-        $this->secret = $secret;
+        $this->url        = $url;
+        $this->secret     = $secret;
     }
 
     /**
@@ -109,47 +109,47 @@ class SendWebhook implements ShouldQueue
     public function handle(): void
     {
         // Ensure relationships are loaded
-        $this->submission->loadMissing(['form', 'values.field']);
+        $this->submission->loadMissing( ['form', 'values.field'] );
 
         // Build the webhook payload
         $payload = $this->buildPayload();
 
         // Build headers
-        $headers = $this->buildHeaders($payload);
+        $headers = $this->buildHeaders( $payload );
 
         try {
-            $response = Http::timeout(30)
-                ->withHeaders($headers)
-                ->post($this->url, $payload);
+            $response = Http::timeout( 30 )
+                ->withHeaders( $headers )
+                ->post( $this->url, $payload );
 
-            if ($response->successful()) {
-                Log::info('Webhook sent successfully', [
+            if ( $response->successful() ) {
+                Log::info( 'Webhook sent successfully', [
                     'submission_id' => $this->submission->id,
-                    'form_id' => $this->submission->form_id,
-                    'url' => $this->url,
-                    'status' => $response->status(),
-                ]);
+                    'form_id'       => $this->submission->form_id,
+                    'url'           => $this->url,
+                    'status'        => $response->status(),
+                ] );
             } else {
-                Log::warning('Webhook received non-success response', [
+                Log::warning( 'Webhook received non-success response', [
                     'submission_id' => $this->submission->id,
-                    'form_id' => $this->submission->form_id,
-                    'url' => $this->url,
-                    'status' => $response->status(),
-                    'body' => $response->body(),
-                ]);
+                    'form_id'       => $this->submission->form_id,
+                    'url'           => $this->url,
+                    'status'        => $response->status(),
+                    'body'          => $response->body(),
+                ] );
 
                 // Throw exception to trigger retry for server errors
-                if ($response->serverError()) {
-                    throw new RuntimeException("Webhook failed with status {$response->status()}");
+                if ( $response->serverError() ) {
+                    throw new RuntimeException( "Webhook failed with status {$response->status()}" );
                 }
             }
-        } catch (Exception $e) {
-            Log::error('Failed to send webhook', [
+        } catch ( Exception $e ) {
+            Log::error( 'Failed to send webhook', [
                 'submission_id' => $this->submission->id,
-                'form_id' => $this->submission->form_id,
-                'url' => $this->url,
-                'error' => $e->getMessage(),
-            ]);
+                'form_id'       => $this->submission->form_id,
+                'url'           => $this->url,
+                'error'         => $e->getMessage(),
+            ] );
 
             throw $e; // Re-throw to trigger retry
         }
@@ -164,14 +164,14 @@ class SendWebhook implements ShouldQueue
      *
      * @param  Throwable  $exception  The exception that caused the failure.
      */
-    public function failed(Throwable $exception): void
+    public function failed( Throwable $exception ): void
     {
-        Log::error('Webhook job failed permanently', [
+        Log::error( 'Webhook job failed permanently', [
             'submission_id' => $this->submission->id,
-            'form_id' => $this->submission->form_id,
-            'url' => $this->url,
-            'error' => $exception->getMessage(),
-        ]);
+            'form_id'       => $this->submission->form_id,
+            'url'           => $this->url,
+            'error'         => $exception->getMessage(),
+        ] );
     }
 
     /**
@@ -187,8 +187,8 @@ class SendWebhook implements ShouldQueue
     {
         return [
             'webhook',
-            'submission:'.$this->submission->id,
-            'form:'.$this->submission->form_id,
+            'submission:' . $this->submission->id,
+            'form:' . $this->submission->form_id,
         ];
     }
 
@@ -206,41 +206,39 @@ class SendWebhook implements ShouldQueue
     {
         // Build metadata, respecting privacy settings
         $metadata = [
-            'page_url' => $this->submission->page_url,
+            'page_url'     => $this->submission->page_url,
             'referrer_url' => $this->submission->referrer_url,
         ];
 
         // Only include IP address if explicitly enabled in config
-        if (config('artisanpack.forms.privacy.include_ip_address', false)) {
+        if ( config( 'artisanpack.forms.privacy.include_ip_address', false ) ) {
             $metadata['ip_address'] = $this->submission->ip_address;
         }
 
         // Only include user agent if explicitly enabled in config
-        if (config('artisanpack.forms.privacy.include_user_agent', false)) {
+        if ( config( 'artisanpack.forms.privacy.include_user_agent', false ) ) {
             $metadata['user_agent'] = $this->submission->user_agent;
         }
 
         $payload = [
-            'event' => 'submission.created',
+            'event'     => 'submission.created',
             'timestamp' => now()->toIso8601String(),
-            'form' => [
-                'id' => $this->submission->form->id,
+            'form'      => [
+                'id'   => $this->submission->form->id,
                 'name' => $this->submission->form->name,
                 'slug' => $this->submission->form->slug,
             ],
             'submission' => [
-                'id' => $this->submission->id,
+                'id'                => $this->submission->id,
                 'submission_number' => $this->submission->submission_number,
-                'created_at' => $this->submission->created_at->toIso8601String(),
-                'data' => $this->submission->data_array,
-                'metadata' => $metadata,
+                'created_at'        => $this->submission->created_at->toIso8601String(),
+                'data'              => $this->submission->data_array,
+                'metadata'          => $metadata,
             ],
         ];
 
         // Apply filter hook to allow modifying the webhook payload
-        if (function_exists('applyFilters')) {
-            $payload = applyFilters('ap.forms.webhookPayload', $payload, $this->submission);
-        }
+        $payload = applyFilters( 'ap.forms.webhookPayload', $payload, $this->submission );
 
         return $payload;
     }
@@ -253,22 +251,23 @@ class SendWebhook implements ShouldQueue
      * @since 1.0.0
      *
      * @param  array<string, mixed>  $payload  The webhook payload for signature generation.
+     *
      * @return array<string, string> The request headers.
      */
-    protected function buildHeaders(array $payload): array
+    protected function buildHeaders( array $payload ): array
     {
         $headers = [
-            'Content-Type' => 'application/json',
-            'User-Agent' => 'ArtisanPackUI-Forms/1.0',
-            'X-Forms-Event' => 'submission.created',
+            'Content-Type'     => 'application/json',
+            'User-Agent'       => 'ArtisanPackUI-Forms/1.0',
+            'X-Forms-Event'    => 'submission.created',
             'X-Forms-Delivery' => (string) $this->submission->id,
         ];
 
         // Add signature if secret is configured
-        if ($this->secret !== null) {
-            $signature = $this->generateSignature($payload);
-            $headers['X-Forms-Signature'] = $signature;
-            $headers['X-Forms-Signature-256'] = 'sha256='.$signature;
+        if ( null !== $this->secret ) {
+            $signature                        = $this->generateSignature( $payload );
+            $headers['X-Forms-Signature']     = $signature;
+            $headers['X-Forms-Signature-256'] = 'sha256=' . $signature;
         }
 
         return $headers;
@@ -282,12 +281,13 @@ class SendWebhook implements ShouldQueue
      * @since 1.0.0
      *
      * @param  array<string, mixed>  $payload  The webhook payload to sign.
+     *
      * @return string The HMAC signature.
      */
-    protected function generateSignature(array $payload): string
+    protected function generateSignature( array $payload ): string
     {
-        $jsonPayload = json_encode($payload, JSON_THROW_ON_ERROR);
+        $jsonPayload = json_encode( $payload, JSON_THROW_ON_ERROR );
 
-        return hash_hmac('sha256', $jsonPayload, $this->secret);
+        return hash_hmac( 'sha256', $jsonPayload, $this->secret );
     }
 }

--- a/src/Mail/FormSubmissionNotification.php
+++ b/src/Mail/FormSubmissionNotification.php
@@ -13,7 +13,7 @@
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Mail;
 
@@ -111,37 +111,49 @@ class FormSubmissionNotification extends Mailable
      * @param  FormNotification  $notification  The notification configuration.
      * @param  FormSubmission  $submission  The form submission data.
      */
-    public function __construct(FormNotification $notification, FormSubmission $submission)
+    public function __construct( FormNotification $notification, FormSubmission $submission )
     {
         $this->notification = $notification;
-        $this->submission = $submission;
+        $this->submission   = $submission;
 
         // Pre-parse templates
-        $notificationService = app(NotificationService::class);
-        $this->parsedSubject = $notificationService->parseTemplate($notification->subject, $submission);
-        $this->parsedMessage = $notificationService->parseTemplate($notification->message, $submission);
+        $notificationService = app( NotificationService::class );
+        $this->parsedSubject = $notificationService->parseTemplate( $notification->subject, $submission );
+        $this->parsedMessage = $notificationService->parseTemplate( $notification->message, $submission );
 
-        // Apply filter hook to allow modifying the message
-        if (function_exists('applyFilters')) {
-            $this->parsedMessage = applyFilters(
-                'ap.forms.notificationMessage',
-                $this->parsedMessage,
-                $notification,
-                $submission,
-            );
-        }
+        // Apply filter hooks to allow modifying the message
+        $this->parsedMessage = applyFilters(
+            'ap.forms.notificationMessage',
+            $this->parsedMessage,
+            $notification,
+            $submission,
+        );
 
-        $this->submissionDataTable = $notificationService->formatAllFieldsAsTable($submission);
+        $this->parsedSubject = applyFilters(
+            'ap.forms.notificationSubject',
+            $this->parsedSubject,
+            $notification,
+            $submission,
+        );
+
+        $this->parsedMessage = applyFilters(
+            'ap.forms.notificationBody',
+            $this->parsedMessage,
+            $notification,
+            $submission,
+        );
+
+        $this->submissionDataTable = $notificationService->formatAllFieldsAsTable( $submission );
 
         // Get CC/BCC recipients upfront
-        $this->ccEmails = $notificationService->getCcEmails($notification);
-        $this->bccEmails = $notificationService->getBccEmails($notification);
+        $this->ccEmails  = $notificationService->getCcEmails( $notification );
+        $this->bccEmails = $notificationService->getBccEmails( $notification );
 
         // Determine whether to show IP address:
         // - Check config setting
         // - Hide for autoresponder emails (privacy: don't show submitter their own IP)
-        $this->showIpAddress = config('artisanpack.forms.notifications.show_ip_in_emails', true)
-            && $notification->type !== FormNotification::TYPE_AUTORESPONDER;
+        $this->showIpAddress = config( 'artisanpack.forms.notifications.show_ip_in_emails', true )
+            && FormNotification::TYPE_AUTORESPONDER !== $notification->type;
     }
 
     /**
@@ -155,18 +167,18 @@ class FormSubmissionNotification extends Mailable
     {
         // Build from address
         $from = null;
-        if ($this->notification->from_email) {
+        if ( $this->notification->from_email ) {
             $from = new Address(
                 $this->notification->from_email,
-                $this->notification->from_name ?? config('app.name'),
+                $this->notification->from_name ?? config( 'app.name' ),
             );
         }
 
         // Build reply-to
-        $replyTo = [];
-        $replyToEmail = $this->notification->getReplyToEmail($this->submission);
-        if ($replyToEmail && filter_var($replyToEmail, FILTER_VALIDATE_EMAIL)) {
-            $replyTo = [new Address($replyToEmail)];
+        $replyTo      = [];
+        $replyToEmail = $this->notification->getReplyToEmail( $this->submission );
+        if ( $replyToEmail && filter_var( $replyToEmail, FILTER_VALIDATE_EMAIL ) ) {
+            $replyTo = [new Address( $replyToEmail )];
         }
 
         return new Envelope(

--- a/src/Mail/FormSubmissionNotification.php
+++ b/src/Mail/FormSubmissionNotification.php
@@ -7,15 +7,13 @@
  * Supports dynamic recipients, placeholder parsing, and
  * conditional submission data inclusion.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @author     Jacob Martella <support@artisanpackui.dev>
  *
  * @since      1.0.0
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Forms\Mail;
 
@@ -25,6 +23,7 @@ use ArtisanPackUI\Forms\Services\NotificationService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Address;
+use Illuminate\Mail\Mailables\Attachment;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
@@ -36,8 +35,6 @@ use Illuminate\Queue\SerializesModels;
  * Supports dynamic recipients, placeholder parsing, and
  * conditional submission data inclusion.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @since      1.0.0
  */
@@ -111,40 +108,40 @@ class FormSubmissionNotification extends Mailable
      *
      * @since 1.0.0
      *
-     * @param FormNotification $notification The notification configuration.
-     * @param FormSubmission   $submission   The form submission data.
+     * @param  FormNotification  $notification  The notification configuration.
+     * @param  FormSubmission  $submission  The form submission data.
      */
-    public function __construct( FormNotification $notification, FormSubmission $submission )
+    public function __construct(FormNotification $notification, FormSubmission $submission)
     {
         $this->notification = $notification;
-        $this->submission   = $submission;
+        $this->submission = $submission;
 
         // Pre-parse templates
-        $notificationService = app( NotificationService::class );
-        $this->parsedSubject = $notificationService->parseTemplate( $notification->subject, $submission );
-        $this->parsedMessage = $notificationService->parseTemplate( $notification->message, $submission );
+        $notificationService = app(NotificationService::class);
+        $this->parsedSubject = $notificationService->parseTemplate($notification->subject, $submission);
+        $this->parsedMessage = $notificationService->parseTemplate($notification->message, $submission);
 
         // Apply filter hook to allow modifying the message
-        if ( function_exists( 'applyFilters' ) ) {
+        if (function_exists('applyFilters')) {
             $this->parsedMessage = applyFilters(
-                'forms.notification_message',
+                'ap.forms.notificationMessage',
                 $this->parsedMessage,
                 $notification,
                 $submission,
             );
         }
 
-        $this->submissionDataTable = $notificationService->formatAllFieldsAsTable( $submission );
+        $this->submissionDataTable = $notificationService->formatAllFieldsAsTable($submission);
 
         // Get CC/BCC recipients upfront
-        $this->ccEmails  = $notificationService->getCcEmails( $notification );
-        $this->bccEmails = $notificationService->getBccEmails( $notification );
+        $this->ccEmails = $notificationService->getCcEmails($notification);
+        $this->bccEmails = $notificationService->getBccEmails($notification);
 
         // Determine whether to show IP address:
         // - Check config setting
         // - Hide for autoresponder emails (privacy: don't show submitter their own IP)
-        $this->showIpAddress = config( 'artisanpack.forms.notifications.show_ip_in_emails', true )
-            && FormNotification::TYPE_AUTORESPONDER !== $notification->type;
+        $this->showIpAddress = config('artisanpack.forms.notifications.show_ip_in_emails', true)
+            && $notification->type !== FormNotification::TYPE_AUTORESPONDER;
     }
 
     /**
@@ -158,18 +155,18 @@ class FormSubmissionNotification extends Mailable
     {
         // Build from address
         $from = null;
-        if ( $this->notification->from_email ) {
+        if ($this->notification->from_email) {
             $from = new Address(
                 $this->notification->from_email,
-                $this->notification->from_name ?? config( 'app.name' ),
+                $this->notification->from_name ?? config('app.name'),
             );
         }
 
         // Build reply-to
-        $replyTo      = [];
-        $replyToEmail = $this->notification->getReplyToEmail( $this->submission );
-        if ( $replyToEmail && filter_var( $replyToEmail, FILTER_VALIDATE_EMAIL ) ) {
-            $replyTo = [new Address( $replyToEmail )];
+        $replyTo = [];
+        $replyToEmail = $this->notification->getReplyToEmail($this->submission);
+        if ($replyToEmail && filter_var($replyToEmail, FILTER_VALIDATE_EMAIL)) {
+            $replyTo = [new Address($replyToEmail)];
         }
 
         return new Envelope(
@@ -201,7 +198,7 @@ class FormSubmissionNotification extends Mailable
      *
      * @since 1.0.0
      *
-     * @return array<int, \Illuminate\Mail\Mailables\Attachment> The message attachments.
+     * @return array<int, Attachment> The message attachments.
      */
     public function attachments(): array
     {

--- a/src/Models/Form.php
+++ b/src/Models/Form.php
@@ -12,7 +12,7 @@
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Models;
 
@@ -100,9 +100,9 @@ class Form extends Model
      */
     public function owner(): BelongsTo
     {
-        $userModel = config('artisanpack.forms.authorization.user_model', 'App\\Models\\User');
+        $userModel = config( 'artisanpack.forms.authorization.user_model', 'App\\Models\\User' );
 
-        return $this->belongsTo($userModel, 'user_id');
+        return $this->belongsTo( $userModel, 'user_id' );
     }
 
     /**
@@ -114,7 +114,7 @@ class Form extends Model
      */
     public function fields(): HasMany
     {
-        return $this->hasMany(FormField::class)->orderBy('sort_order');
+        return $this->hasMany( FormField::class )->orderBy( 'sort_order' );
     }
 
     /**
@@ -126,7 +126,7 @@ class Form extends Model
      */
     public function steps(): HasMany
     {
-        return $this->hasMany(FormStep::class)->orderBy('sort_order');
+        return $this->hasMany( FormStep::class )->orderBy( 'sort_order' );
     }
 
     /**
@@ -138,7 +138,7 @@ class Form extends Model
      */
     public function submissions(): HasMany
     {
-        return $this->hasMany(FormSubmission::class);
+        return $this->hasMany( FormSubmission::class );
     }
 
     /**
@@ -150,7 +150,7 @@ class Form extends Model
      */
     public function notifications(): HasMany
     {
-        return $this->hasMany(FormNotification::class)->orderBy('sort_order');
+        return $this->hasMany( FormNotification::class )->orderBy( 'sort_order' );
     }
 
     // =========================================
@@ -163,11 +163,12 @@ class Form extends Model
      * @since 1.0.0
      *
      * @param  Builder<Form>  $query  The query builder instance.
+     *
      * @return Builder<Form> The modified query builder.
      */
-    public function scopeActive(Builder $query): Builder
+    public function scopeActive( Builder $query ): Builder
     {
-        return $query->where('is_active', true);
+        return $query->where( 'is_active', true );
     }
 
     /**
@@ -176,11 +177,12 @@ class Form extends Model
      * @since 1.0.0
      *
      * @param  Builder<Form>  $query  The query builder instance.
+     *
      * @return Builder<Form> The modified query builder.
      */
-    public function scopeMultiStep(Builder $query): Builder
+    public function scopeMultiStep( Builder $query ): Builder
     {
-        return $query->where('is_multi_step', true);
+        return $query->where( 'is_multi_step', true );
     }
 
     /**
@@ -189,11 +191,12 @@ class Form extends Model
      * @since 1.0.0
      *
      * @param  Builder<Form>  $query  The query builder instance.
+     *
      * @return Builder<Form> The modified query builder.
      */
-    public function scopeSingleStep(Builder $query): Builder
+    public function scopeSingleStep( Builder $query ): Builder
     {
-        return $query->where('is_multi_step', false);
+        return $query->where( 'is_multi_step', false );
     }
 
     // =========================================
@@ -245,14 +248,14 @@ class Form extends Model
      */
     public function getFieldsOrderedAttribute(): Collection
     {
-        if ($this->is_multi_step) {
+        if ( $this->is_multi_step ) {
             return $this->steps()
-                ->with(['fields' => fn ($q) => $q->orderBy('sort_order')])
+                ->with( ['fields' => fn ( $q ) => $q->orderBy( 'sort_order' )] )
                 ->get()
                 ->flatMap->fields;
         }
 
-        return $this->fields()->orderBy('sort_order')->get();
+        return $this->fields()->orderBy( 'sort_order' )->get();
     }
 
     // =========================================
@@ -266,11 +269,12 @@ class Form extends Model
      *
      * @param  string  $key  The setting key using dot notation.
      * @param  mixed  $default  The default value if key not found.
+     *
      * @return mixed The setting value or default.
      */
-    public function getSetting(string $key, mixed $default = null): mixed
+    public function getSetting( string $key, mixed $default = null ): mixed
     {
-        return data_get($this->settings, $key, $default);
+        return data_get( $this->settings, $key, $default );
     }
 
     /**
@@ -282,39 +286,39 @@ class Form extends Model
      */
     public function duplicate(): self
     {
-        $clone = $this->replicate();
-        $clone->name = $this->name.' (Copy)';
-        $clone->slug = static::generateUniqueSlug($clone->name);
+        $clone            = $this->replicate();
+        $clone->name      = $this->name . ' (Copy)';
+        $clone->slug      = static::generateUniqueSlug( $clone->name );
         $clone->is_active = false;
         $clone->save();
 
         // Clone steps and their fields
-        foreach ($this->steps as $step) {
-            $newStep = $step->replicate();
+        foreach ( $this->steps as $step ) {
+            $newStep          = $step->replicate();
             $newStep->form_id = $clone->id;
             $newStep->save();
 
             // Clone fields in step
-            foreach ($step->fields as $field) {
-                $newField = $field->replicate();
+            foreach ( $step->fields as $field ) {
+                $newField          = $field->replicate();
                 $newField->form_id = $clone->id;
                 $newField->step_id = $newStep->id;
-                $newField->uuid = Str::uuid()->toString();
+                $newField->uuid    = Str::uuid()->toString();
                 $newField->save();
             }
         }
 
         // Clone fields without steps
-        foreach ($this->fields()->whereNull('step_id')->get() as $field) {
-            $newField = $field->replicate();
+        foreach ( $this->fields()->whereNull( 'step_id' )->get() as $field ) {
+            $newField          = $field->replicate();
             $newField->form_id = $clone->id;
-            $newField->uuid = Str::uuid()->toString();
+            $newField->uuid    = Str::uuid()->toString();
             $newField->save();
         }
 
         // Clone notifications
-        foreach ($this->notifications as $notification) {
-            $newNotification = $notification->replicate();
+        foreach ( $this->notifications as $notification ) {
+            $newNotification          = $notification->replicate();
             $newNotification->form_id = $clone->id;
             $newNotification->save();
         }
@@ -356,11 +360,11 @@ class Form extends Model
     protected function casts(): array
     {
         return [
-            'settings' => 'array',
-            'is_multi_step' => 'boolean',
-            'show_progress_bar' => 'boolean',
+            'settings'              => 'array',
+            'is_multi_step'         => 'boolean',
+            'show_progress_bar'     => 'boolean',
             'allow_step_navigation' => 'boolean',
-            'is_active' => 'boolean',
+            'is_active'             => 'boolean',
         ];
     }
 
@@ -379,41 +383,35 @@ class Form extends Model
     {
         parent::boot();
 
-        static::creating(function (Form $form): void {
-            if (empty($form->slug)) {
-                $form->slug = static::generateUniqueSlug($form->name);
+        static::creating( function ( Form $form ): void {
+            if ( empty( $form->slug ) ) {
+                $form->slug = static::generateUniqueSlug( $form->name );
             }
-        });
+        } );
 
-        static::created(function (Form $form): void {
+        static::created( function ( Form $form ): void {
             // Fire action hook for extensibility
-            if (function_exists('doAction')) {
-                doAction('ap.forms.form.created', $form);
-            }
+            doAction( 'ap.forms.form.created', $form );
 
             // Dispatch Laravel event
-            FormCreated::dispatch($form);
-        });
+            FormCreated::dispatch( $form );
+        } );
 
-        static::updated(function (Form $form): void {
+        static::updated( function ( Form $form ): void {
             // Fire action hook for extensibility
-            if (function_exists('doAction')) {
-                doAction('ap.forms.form.updated', $form);
-            }
+            doAction( 'ap.forms.form.updated', $form );
 
             // Dispatch Laravel event
-            FormUpdated::dispatch($form);
-        });
+            FormUpdated::dispatch( $form );
+        } );
 
-        static::deleted(function (Form $form): void {
+        static::deleted( function ( Form $form ): void {
             // Fire action hook for extensibility
-            if (function_exists('doAction')) {
-                doAction('ap.forms.form.deleted', $form);
-            }
+            doAction( 'ap.forms.form.deleted', $form );
 
             // Dispatch Laravel event
-            FormDeleted::dispatch($form);
-        });
+            FormDeleted::dispatch( $form );
+        } );
     }
 
     /**
@@ -422,16 +420,17 @@ class Form extends Model
      * @since 1.0.0
      *
      * @param  string  $name  The name to generate a slug from.
+     *
      * @return string The unique slug.
      */
-    protected static function generateUniqueSlug(string $name): string
+    protected static function generateUniqueSlug( string $name ): string
     {
-        $slug = Str::slug($name);
+        $slug         = Str::slug( $name );
         $originalSlug = $slug;
-        $count = 1;
+        $count        = 1;
 
-        while (static::where('slug', $slug)->exists()) {
-            $slug = $originalSlug.'-'.$count;
+        while ( static::where( 'slug', $slug )->exists() ) {
+            $slug = $originalSlug . '-' . $count;
             $count++;
         }
 

--- a/src/Models/Form.php
+++ b/src/Models/Form.php
@@ -6,15 +6,13 @@
  * Represents the main form definition including basic info,
  * display settings, multi-step configuration, and status.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @author     Jacob Martella <support@artisanpackui.dev>
  *
  * @since      1.0.0
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Forms\Models;
 
@@ -27,6 +25,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
@@ -36,26 +35,24 @@ use Illuminate\Support\Str;
  * Represents the main form definition including basic info,
  * display settings, multi-step configuration, and status.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @since      1.0.0
  *
- * @property int                              $id
- * @property int|null                         $user_id
- * @property string                           $name
- * @property string                           $slug
- * @property string|null                      $description
- * @property string                           $submit_button_text
- * @property string|null                      $success_message
- * @property string|null                      $redirect_url
- * @property array|null                       $settings
- * @property bool                             $is_multi_step
- * @property bool                             $show_progress_bar
- * @property bool                             $allow_step_navigation
- * @property bool                             $is_active
- * @property \Illuminate\Support\Carbon|null  $created_at
- * @property \Illuminate\Support\Carbon|null  $updated_at
+ * @property int $id
+ * @property int|null $user_id
+ * @property string $name
+ * @property string $slug
+ * @property string|null $description
+ * @property string $submit_button_text
+ * @property string|null $success_message
+ * @property string|null $redirect_url
+ * @property array|null $settings
+ * @property bool $is_multi_step
+ * @property bool $show_progress_bar
+ * @property bool $allow_step_navigation
+ * @property bool $is_active
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  * @property-read int                         $unread_submissions_count
  * @property-read int                         $total_submissions_count
  * @property-read Collection                  $active_notifications
@@ -103,9 +100,9 @@ class Form extends Model
      */
     public function owner(): BelongsTo
     {
-        $userModel = config( 'artisanpack.forms.authorization.user_model', 'App\\Models\\User' );
+        $userModel = config('artisanpack.forms.authorization.user_model', 'App\\Models\\User');
 
-        return $this->belongsTo( $userModel, 'user_id' );
+        return $this->belongsTo($userModel, 'user_id');
     }
 
     /**
@@ -117,7 +114,7 @@ class Form extends Model
      */
     public function fields(): HasMany
     {
-        return $this->hasMany( FormField::class )->orderBy( 'sort_order' );
+        return $this->hasMany(FormField::class)->orderBy('sort_order');
     }
 
     /**
@@ -129,7 +126,7 @@ class Form extends Model
      */
     public function steps(): HasMany
     {
-        return $this->hasMany( FormStep::class )->orderBy( 'sort_order' );
+        return $this->hasMany(FormStep::class)->orderBy('sort_order');
     }
 
     /**
@@ -141,7 +138,7 @@ class Form extends Model
      */
     public function submissions(): HasMany
     {
-        return $this->hasMany( FormSubmission::class );
+        return $this->hasMany(FormSubmission::class);
     }
 
     /**
@@ -153,7 +150,7 @@ class Form extends Model
      */
     public function notifications(): HasMany
     {
-        return $this->hasMany( FormNotification::class )->orderBy( 'sort_order' );
+        return $this->hasMany(FormNotification::class)->orderBy('sort_order');
     }
 
     // =========================================
@@ -165,13 +162,12 @@ class Form extends Model
      *
      * @since 1.0.0
      *
-     * @param Builder<Form> $query The query builder instance.
-     *
+     * @param  Builder<Form>  $query  The query builder instance.
      * @return Builder<Form> The modified query builder.
      */
-    public function scopeActive( Builder $query ): Builder
+    public function scopeActive(Builder $query): Builder
     {
-        return $query->where( 'is_active', true );
+        return $query->where('is_active', true);
     }
 
     /**
@@ -179,13 +175,12 @@ class Form extends Model
      *
      * @since 1.0.0
      *
-     * @param Builder<Form> $query The query builder instance.
-     *
+     * @param  Builder<Form>  $query  The query builder instance.
      * @return Builder<Form> The modified query builder.
      */
-    public function scopeMultiStep( Builder $query ): Builder
+    public function scopeMultiStep(Builder $query): Builder
     {
-        return $query->where( 'is_multi_step', true );
+        return $query->where('is_multi_step', true);
     }
 
     /**
@@ -193,13 +188,12 @@ class Form extends Model
      *
      * @since 1.0.0
      *
-     * @param Builder<Form> $query The query builder instance.
-     *
+     * @param  Builder<Form>  $query  The query builder instance.
      * @return Builder<Form> The modified query builder.
      */
-    public function scopeSingleStep( Builder $query ): Builder
+    public function scopeSingleStep(Builder $query): Builder
     {
-        return $query->where( 'is_multi_step', false );
+        return $query->where('is_multi_step', false);
     }
 
     // =========================================
@@ -251,14 +245,14 @@ class Form extends Model
      */
     public function getFieldsOrderedAttribute(): Collection
     {
-        if ( $this->is_multi_step ) {
+        if ($this->is_multi_step) {
             return $this->steps()
-                ->with( ['fields' => fn ( $q ) => $q->orderBy( 'sort_order' )] )
+                ->with(['fields' => fn ($q) => $q->orderBy('sort_order')])
                 ->get()
                 ->flatMap->fields;
         }
 
-        return $this->fields()->orderBy( 'sort_order' )->get();
+        return $this->fields()->orderBy('sort_order')->get();
     }
 
     // =========================================
@@ -270,14 +264,13 @@ class Form extends Model
      *
      * @since 1.0.0
      *
-     * @param string $key     The setting key using dot notation.
-     * @param mixed  $default The default value if key not found.
-     *
+     * @param  string  $key  The setting key using dot notation.
+     * @param  mixed  $default  The default value if key not found.
      * @return mixed The setting value or default.
      */
-    public function getSetting( string $key, mixed $default = null ): mixed
+    public function getSetting(string $key, mixed $default = null): mixed
     {
-        return data_get( $this->settings, $key, $default );
+        return data_get($this->settings, $key, $default);
     }
 
     /**
@@ -289,39 +282,39 @@ class Form extends Model
      */
     public function duplicate(): self
     {
-        $clone            = $this->replicate();
-        $clone->name      = $this->name . ' (Copy)';
-        $clone->slug      = static::generateUniqueSlug( $clone->name );
+        $clone = $this->replicate();
+        $clone->name = $this->name.' (Copy)';
+        $clone->slug = static::generateUniqueSlug($clone->name);
         $clone->is_active = false;
         $clone->save();
 
         // Clone steps and their fields
-        foreach ( $this->steps as $step ) {
-            $newStep          = $step->replicate();
+        foreach ($this->steps as $step) {
+            $newStep = $step->replicate();
             $newStep->form_id = $clone->id;
             $newStep->save();
 
             // Clone fields in step
-            foreach ( $step->fields as $field ) {
-                $newField          = $field->replicate();
+            foreach ($step->fields as $field) {
+                $newField = $field->replicate();
                 $newField->form_id = $clone->id;
                 $newField->step_id = $newStep->id;
-                $newField->uuid    = Str::uuid()->toString();
+                $newField->uuid = Str::uuid()->toString();
                 $newField->save();
             }
         }
 
         // Clone fields without steps
-        foreach ( $this->fields()->whereNull( 'step_id' )->get() as $field ) {
-            $newField          = $field->replicate();
+        foreach ($this->fields()->whereNull('step_id')->get() as $field) {
+            $newField = $field->replicate();
             $newField->form_id = $clone->id;
-            $newField->uuid    = Str::uuid()->toString();
+            $newField->uuid = Str::uuid()->toString();
             $newField->save();
         }
 
         // Clone notifications
-        foreach ( $this->notifications as $notification ) {
-            $newNotification          = $notification->replicate();
+        foreach ($this->notifications as $notification) {
+            $newNotification = $notification->replicate();
             $newNotification->form_id = $clone->id;
             $newNotification->save();
         }
@@ -363,11 +356,11 @@ class Form extends Model
     protected function casts(): array
     {
         return [
-            'settings'              => 'array',
-            'is_multi_step'         => 'boolean',
-            'show_progress_bar'     => 'boolean',
+            'settings' => 'array',
+            'is_multi_step' => 'boolean',
+            'show_progress_bar' => 'boolean',
             'allow_step_navigation' => 'boolean',
-            'is_active'             => 'boolean',
+            'is_active' => 'boolean',
         ];
     }
 
@@ -381,48 +374,46 @@ class Form extends Model
      * Sets up model event listeners for creating, created, updated, and deleted events.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     protected static function boot(): void
     {
         parent::boot();
 
-        static::creating( function ( Form $form ): void {
-            if ( empty( $form->slug ) ) {
-                $form->slug = static::generateUniqueSlug( $form->name );
+        static::creating(function (Form $form): void {
+            if (empty($form->slug)) {
+                $form->slug = static::generateUniqueSlug($form->name);
             }
-        } );
+        });
 
-        static::created( function ( Form $form ): void {
+        static::created(function (Form $form): void {
             // Fire action hook for extensibility
-            if ( function_exists( 'doAction' ) ) {
-                doAction( 'forms.form.created', $form );
+            if (function_exists('doAction')) {
+                doAction('ap.forms.form.created', $form);
             }
 
             // Dispatch Laravel event
-            FormCreated::dispatch( $form );
-        } );
+            FormCreated::dispatch($form);
+        });
 
-        static::updated( function ( Form $form ): void {
+        static::updated(function (Form $form): void {
             // Fire action hook for extensibility
-            if ( function_exists( 'doAction' ) ) {
-                doAction( 'forms.form.updated', $form );
+            if (function_exists('doAction')) {
+                doAction('ap.forms.form.updated', $form);
             }
 
             // Dispatch Laravel event
-            FormUpdated::dispatch( $form );
-        } );
+            FormUpdated::dispatch($form);
+        });
 
-        static::deleted( function ( Form $form ): void {
+        static::deleted(function (Form $form): void {
             // Fire action hook for extensibility
-            if ( function_exists( 'doAction' ) ) {
-                doAction( 'forms.form.deleted', $form );
+            if (function_exists('doAction')) {
+                doAction('ap.forms.form.deleted', $form);
             }
 
             // Dispatch Laravel event
-            FormDeleted::dispatch( $form );
-        } );
+            FormDeleted::dispatch($form);
+        });
     }
 
     /**
@@ -430,18 +421,17 @@ class Form extends Model
      *
      * @since 1.0.0
      *
-     * @param string $name The name to generate a slug from.
-     *
+     * @param  string  $name  The name to generate a slug from.
      * @return string The unique slug.
      */
-    protected static function generateUniqueSlug( string $name ): string
+    protected static function generateUniqueSlug(string $name): string
     {
-        $slug         = Str::slug( $name );
+        $slug = Str::slug($name);
         $originalSlug = $slug;
-        $count        = 1;
+        $count = 1;
 
-        while ( static::where( 'slug', $slug )->exists() ) {
-            $slug = $originalSlug . '-' . $count;
+        while (static::where('slug', $slug)->exists()) {
+            $slug = $originalSlug.'-'.$count;
             $count++;
         }
 

--- a/src/Models/FormField.php
+++ b/src/Models/FormField.php
@@ -6,24 +6,24 @@
  * Represents an individual field configuration including type,
  * validation rules, conditional logic, and display settings.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @author     Jacob Martella <support@artisanpackui.dev>
  *
  * @since      1.0.0
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Forms\Models;
 
+use ArtisanPackUI\Forms\Config\FieldTypes;
 use ArtisanPackUI\Forms\Database\Factories\FormFieldFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 
 /**
@@ -32,8 +32,6 @@ use Illuminate\Support\Str;
  * Represents an individual field configuration including type,
  * validation rules, conditional logic, and display settings.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @property int $id
  * @property int $form_id
@@ -52,8 +50,8 @@ use Illuminate\Support\Str;
  * @property string $width
  * @property string|null $css_classes
  * @property int $sort_order
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  * @property-read Form $form
  * @property-read FormStep|null $step
  * @property-read bool $has_conditional_logic
@@ -106,7 +104,7 @@ class FormField extends Model
      */
     public function form(): BelongsTo
     {
-        return $this->belongsTo( Form::class );
+        return $this->belongsTo(Form::class);
     }
 
     /**
@@ -118,7 +116,7 @@ class FormField extends Model
      */
     public function step(): BelongsTo
     {
-        return $this->belongsTo( FormStep::class );
+        return $this->belongsTo(FormStep::class);
     }
 
     /**
@@ -130,7 +128,7 @@ class FormField extends Model
      */
     public function submissionValues(): HasMany
     {
-        return $this->hasMany( FormSubmissionValue::class, 'field_id' );
+        return $this->hasMany(FormSubmissionValue::class, 'field_id');
     }
 
     // =========================================
@@ -142,13 +140,12 @@ class FormField extends Model
      *
      * @since 1.0.0
      *
-     * @param Builder<FormField> $query The query builder instance.
-     *
+     * @param  Builder<FormField>  $query  The query builder instance.
      * @return Builder<FormField> The modified query builder.
      */
-    public function scopeRequired( Builder $query ): Builder
+    public function scopeRequired(Builder $query): Builder
     {
-        return $query->where( 'is_required', true );
+        return $query->where('is_required', true);
     }
 
     /**
@@ -156,14 +153,13 @@ class FormField extends Model
      *
      * @since 1.0.0
      *
-     * @param Builder<FormField> $query The query builder instance.
-     * @param string             $type  The field type to filter by.
-     *
+     * @param  Builder<FormField>  $query  The query builder instance.
+     * @param  string  $type  The field type to filter by.
      * @return Builder<FormField> The modified query builder.
      */
-    public function scopeOfType( Builder $query, string $type ): Builder
+    public function scopeOfType(Builder $query, string $type): Builder
     {
-        return $query->where( 'type', $type );
+        return $query->where('type', $type);
     }
 
     /**
@@ -171,13 +167,12 @@ class FormField extends Model
      *
      * @since 1.0.0
      *
-     * @param Builder<FormField> $query The query builder instance.
-     *
+     * @param  Builder<FormField>  $query  The query builder instance.
      * @return Builder<FormField> The modified query builder.
      */
-    public function scopeWithoutStep( Builder $query ): Builder
+    public function scopeWithoutStep(Builder $query): Builder
     {
-        return $query->whereNull( 'step_id' );
+        return $query->whereNull('step_id');
     }
 
     /**
@@ -185,14 +180,13 @@ class FormField extends Model
      *
      * @since 1.0.0
      *
-     * @param Builder<FormField> $query  The query builder instance.
-     * @param int                $stepId The step ID to filter by.
-     *
+     * @param  Builder<FormField>  $query  The query builder instance.
+     * @param  int  $stepId  The step ID to filter by.
      * @return Builder<FormField> The modified query builder.
      */
-    public function scopeInStep( Builder $query, int $stepId ): Builder
+    public function scopeInStep(Builder $query, int $stepId): Builder
     {
-        return $query->where( 'step_id', $stepId );
+        return $query->where('step_id', $stepId);
     }
 
     // =========================================
@@ -208,8 +202,8 @@ class FormField extends Model
      */
     public function getHasConditionalLogicAttribute(): bool
     {
-        return ! empty( $this->conditional_logic ) &&
-               ! empty( $this->conditional_logic['rules'] );
+        return ! empty($this->conditional_logic) &&
+               ! empty($this->conditional_logic['rules']);
     }
 
     /**
@@ -221,7 +215,7 @@ class FormField extends Model
      */
     public function getIsFileFieldAttribute(): bool
     {
-        return 'file' === $this->type;
+        return $this->type === 'file';
     }
 
     /**
@@ -245,11 +239,11 @@ class FormField extends Model
      */
     public function getWidthClassAttribute(): string
     {
-        return match ( $this->width ) {
-            'half'       => 'w-full md:w-1/2',
-            'third'      => 'w-full md:w-1/3',
+        return match ($this->width) {
+            'half' => 'w-full md:w-1/2',
+            'third' => 'w-full md:w-1/3',
             'two-thirds' => 'w-full md:w-2/3',
-            default      => 'w-full',
+            default => 'w-full',
         };
     }
 
@@ -262,14 +256,13 @@ class FormField extends Model
      *
      * @since 1.0.0
      *
-     * @param string $key     The config key using dot notation.
-     * @param mixed  $default The default value if key not found.
-     *
+     * @param  string  $key  The config key using dot notation.
+     * @param  mixed  $default  The default value if key not found.
      * @return mixed The config value or default.
      */
-    public function getConfig( string $key, mixed $default = null ): mixed
+    public function getConfig(string $key, mixed $default = null): mixed
     {
-        return data_get( $this->field_config, $key, $default );
+        return data_get($this->field_config, $key, $default);
     }
 
     /**
@@ -277,20 +270,19 @@ class FormField extends Model
      *
      * @since 1.0.0
      *
-     * @param string $key     The validation rule key.
-     * @param mixed  $default The default value if key not found.
-     *
+     * @param  string  $key  The validation rule key.
+     * @param  mixed  $default  The default value if key not found.
      * @return mixed The validation rule or default.
      */
-    public function getValidationRule( string $key, mixed $default = null ): mixed
+    public function getValidationRule(string $key, mixed $default = null): mixed
     {
-        return data_get( $this->validation_rules, $key, $default );
+        return data_get($this->validation_rules, $key, $default);
     }
 
     /**
      * Builds the Laravel validation rules array for this field.
      *
-     * Applies the 'forms.validation_rules' filter hook to allow
+     * Applies the 'ap.forms.validationRules' filter hook to allow
      * third-party packages to modify validation rules for a field.
      *
      * @since 1.0.0
@@ -300,55 +292,55 @@ class FormField extends Model
     public function buildValidationRules(): array
     {
         // Layout fields don't need validation
-        if ( $this->isLayoutField() ) {
+        if ($this->isLayoutField()) {
             return [];
         }
 
         $rules = [];
 
-        if ( $this->is_required ) {
+        if ($this->is_required) {
             $rules[] = 'required';
         } else {
             $rules[] = 'nullable';
         }
 
         // Type-specific rules
-        $rules = array_merge( $rules, $this->getTypeValidationRules() );
+        $rules = array_merge($rules, $this->getTypeValidationRules());
 
         // Custom validation rules
-        if ( $min = $this->getValidationRule( 'min' ) ) {
+        if ($min = $this->getValidationRule('min')) {
             $rules[] = "min:{$min}";
         }
 
-        if ( $max = $this->getValidationRule( 'max' ) ) {
+        if ($max = $this->getValidationRule('max')) {
             $rules[] = "max:{$max}";
         }
 
-        if ( $pattern = $this->getValidationRule( 'pattern' ) ) {
+        if ($pattern = $this->getValidationRule('pattern')) {
             $rules[] = "regex:{$pattern}";
         }
 
         // Date range validation
-        if ( $minDate = $this->getValidationRule( 'min_date' ) ) {
+        if ($minDate = $this->getValidationRule('min_date')) {
             $rules[] = "after_or_equal:{$minDate}";
         }
 
-        if ( $maxDate = $this->getValidationRule( 'max_date' ) ) {
+        if ($maxDate = $this->getValidationRule('max_date')) {
             $rules[] = "before_or_equal:{$maxDate}";
         }
 
         // Time range validation
-        if ( $minTime = $this->getValidationRule( 'min_time' ) ) {
+        if ($minTime = $this->getValidationRule('min_time')) {
             $rules[] = "after_or_equal:{$minTime}";
         }
 
-        if ( $maxTime = $this->getValidationRule( 'max_time' ) ) {
+        if ($maxTime = $this->getValidationRule('max_time')) {
             $rules[] = "before_or_equal:{$maxTime}";
         }
 
         // Apply filter hook for extensibility
-        if ( function_exists( 'applyFilters' ) ) {
-            $rules = applyFilters( 'forms.validation_rules', $rules, $this );
+        if (function_exists('applyFilters')) {
+            $rules = applyFilters('ap.forms.validationRules', $rules, $this);
         }
 
         return $rules;
@@ -365,7 +357,7 @@ class FormField extends Model
      */
     public function isLayoutField(): bool
     {
-        return \ArtisanPackUI\Forms\Config\FieldTypes::isLayoutField( $this->type );
+        return FieldTypes::isLayoutField($this->type);
     }
 
     /**
@@ -390,9 +382,9 @@ class FormField extends Model
     protected function casts(): array
     {
         return [
-            'is_required'       => 'boolean',
-            'validation_rules'  => 'array',
-            'field_config'      => 'array',
+            'is_required' => 'boolean',
+            'validation_rules' => 'array',
+            'field_config' => 'array',
             'conditional_logic' => 'array',
         ];
     }
@@ -407,24 +399,22 @@ class FormField extends Model
      * Sets up model event listeners to auto-generate UUIDs on creation.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     protected static function boot(): void
     {
         parent::boot();
 
-        static::creating( function ( FormField $field ): void {
-            if ( empty( $field->uuid ) ) {
+        static::creating(function (FormField $field): void {
+            if (empty($field->uuid)) {
                 $field->uuid = Str::uuid()->toString();
             }
-        } );
+        });
     }
 
     /**
      * Gets validation rules specific to the field type.
      *
-     * Supports custom field types registered via the 'artisanpack.forms.field_types'
+     * Supports custom field types registered via the 'ap.forms.fieldTypes'
      * filter hook by checking for a 'type_validation' key in the field type config.
      *
      * @since 1.0.0
@@ -434,31 +424,31 @@ class FormField extends Model
     protected function getTypeValidationRules(): array
     {
         // Check for built-in types first
-        $builtInRules = match ( $this->type ) {
-            'email'                             => ['email'],
-            'url'                               => ['url'],
-            'number'                            => ['numeric'],
-            'phone'                             => ['string'],
-            'date'                              => ['date'],
-            'time'                              => ['date_format:H:i'],
-            'file'                              => $this->getFileValidationRules(),
+        $builtInRules = match ($this->type) {
+            'email' => ['email'],
+            'url' => ['url'],
+            'number' => ['numeric'],
+            'phone' => ['string'],
+            'date' => ['date'],
+            'time' => ['date_format:H:i'],
+            'file' => $this->getFileValidationRules(),
             'checkbox_group', 'select_multiple' => ['array'],
-            'checkbox'                          => ['boolean'],
-            default                             => null,
+            'checkbox' => ['boolean'],
+            default => null,
         };
 
-        if ( null !== $builtInRules ) {
+        if ($builtInRules !== null) {
             return $builtInRules;
         }
 
         // Check for custom type validation rules from the filter hook
-        $typeConfig = \ArtisanPackUI\Forms\Config\FieldTypes::getTypeConfig( $this->type );
+        $typeConfig = FieldTypes::getTypeConfig($this->type);
 
-        if ( null !== $typeConfig && isset( $typeConfig['type_validation'] ) ) {
+        if ($typeConfig !== null && isset($typeConfig['type_validation'])) {
             $customRules = $typeConfig['type_validation'];
 
             // Support both array of rules and single rule string
-            return is_array( $customRules ) ? $customRules : [$customRules];
+            return is_array($customRules) ? $customRules : [$customRules];
         }
 
         // Default to string validation for unknown types
@@ -476,11 +466,11 @@ class FormField extends Model
     {
         $rules = ['file'];
 
-        if ( $types = $this->getConfig( 'allowed_types' ) ) {
-            $rules[] = 'mimes:' . implode( ',', $types );
+        if ($types = $this->getConfig('allowed_types')) {
+            $rules[] = 'mimes:'.implode(',', $types);
         }
 
-        if ( $maxSize = $this->getConfig( 'max_size' ) ) {
+        if ($maxSize = $this->getConfig('max_size')) {
             $rules[] = "max:{$maxSize}";
         }
 

--- a/src/Models/FormField.php
+++ b/src/Models/FormField.php
@@ -12,7 +12,7 @@
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Models;
 
@@ -104,7 +104,7 @@ class FormField extends Model
      */
     public function form(): BelongsTo
     {
-        return $this->belongsTo(Form::class);
+        return $this->belongsTo( Form::class );
     }
 
     /**
@@ -116,7 +116,7 @@ class FormField extends Model
      */
     public function step(): BelongsTo
     {
-        return $this->belongsTo(FormStep::class);
+        return $this->belongsTo( FormStep::class );
     }
 
     /**
@@ -128,7 +128,7 @@ class FormField extends Model
      */
     public function submissionValues(): HasMany
     {
-        return $this->hasMany(FormSubmissionValue::class, 'field_id');
+        return $this->hasMany( FormSubmissionValue::class, 'field_id' );
     }
 
     // =========================================
@@ -141,11 +141,12 @@ class FormField extends Model
      * @since 1.0.0
      *
      * @param  Builder<FormField>  $query  The query builder instance.
+     *
      * @return Builder<FormField> The modified query builder.
      */
-    public function scopeRequired(Builder $query): Builder
+    public function scopeRequired( Builder $query ): Builder
     {
-        return $query->where('is_required', true);
+        return $query->where( 'is_required', true );
     }
 
     /**
@@ -155,11 +156,12 @@ class FormField extends Model
      *
      * @param  Builder<FormField>  $query  The query builder instance.
      * @param  string  $type  The field type to filter by.
+     *
      * @return Builder<FormField> The modified query builder.
      */
-    public function scopeOfType(Builder $query, string $type): Builder
+    public function scopeOfType( Builder $query, string $type ): Builder
     {
-        return $query->where('type', $type);
+        return $query->where( 'type', $type );
     }
 
     /**
@@ -168,11 +170,12 @@ class FormField extends Model
      * @since 1.0.0
      *
      * @param  Builder<FormField>  $query  The query builder instance.
+     *
      * @return Builder<FormField> The modified query builder.
      */
-    public function scopeWithoutStep(Builder $query): Builder
+    public function scopeWithoutStep( Builder $query ): Builder
     {
-        return $query->whereNull('step_id');
+        return $query->whereNull( 'step_id' );
     }
 
     /**
@@ -182,11 +185,12 @@ class FormField extends Model
      *
      * @param  Builder<FormField>  $query  The query builder instance.
      * @param  int  $stepId  The step ID to filter by.
+     *
      * @return Builder<FormField> The modified query builder.
      */
-    public function scopeInStep(Builder $query, int $stepId): Builder
+    public function scopeInStep( Builder $query, int $stepId ): Builder
     {
-        return $query->where('step_id', $stepId);
+        return $query->where( 'step_id', $stepId );
     }
 
     // =========================================
@@ -202,8 +206,8 @@ class FormField extends Model
      */
     public function getHasConditionalLogicAttribute(): bool
     {
-        return ! empty($this->conditional_logic) &&
-               ! empty($this->conditional_logic['rules']);
+        return ! empty( $this->conditional_logic ) &&
+               ! empty( $this->conditional_logic['rules'] );
     }
 
     /**
@@ -215,7 +219,7 @@ class FormField extends Model
      */
     public function getIsFileFieldAttribute(): bool
     {
-        return $this->type === 'file';
+        return 'file' === $this->type;
     }
 
     /**
@@ -239,11 +243,11 @@ class FormField extends Model
      */
     public function getWidthClassAttribute(): string
     {
-        return match ($this->width) {
-            'half' => 'w-full md:w-1/2',
-            'third' => 'w-full md:w-1/3',
+        return match ( $this->width ) {
+            'half'       => 'w-full md:w-1/2',
+            'third'      => 'w-full md:w-1/3',
             'two-thirds' => 'w-full md:w-2/3',
-            default => 'w-full',
+            default      => 'w-full',
         };
     }
 
@@ -258,11 +262,12 @@ class FormField extends Model
      *
      * @param  string  $key  The config key using dot notation.
      * @param  mixed  $default  The default value if key not found.
+     *
      * @return mixed The config value or default.
      */
-    public function getConfig(string $key, mixed $default = null): mixed
+    public function getConfig( string $key, mixed $default = null ): mixed
     {
-        return data_get($this->field_config, $key, $default);
+        return data_get( $this->field_config, $key, $default );
     }
 
     /**
@@ -272,11 +277,12 @@ class FormField extends Model
      *
      * @param  string  $key  The validation rule key.
      * @param  mixed  $default  The default value if key not found.
+     *
      * @return mixed The validation rule or default.
      */
-    public function getValidationRule(string $key, mixed $default = null): mixed
+    public function getValidationRule( string $key, mixed $default = null ): mixed
     {
-        return data_get($this->validation_rules, $key, $default);
+        return data_get( $this->validation_rules, $key, $default );
     }
 
     /**
@@ -292,56 +298,54 @@ class FormField extends Model
     public function buildValidationRules(): array
     {
         // Layout fields don't need validation
-        if ($this->isLayoutField()) {
+        if ( $this->isLayoutField() ) {
             return [];
         }
 
         $rules = [];
 
-        if ($this->is_required) {
+        if ( $this->is_required ) {
             $rules[] = 'required';
         } else {
             $rules[] = 'nullable';
         }
 
         // Type-specific rules
-        $rules = array_merge($rules, $this->getTypeValidationRules());
+        $rules = array_merge( $rules, $this->getTypeValidationRules() );
 
         // Custom validation rules
-        if ($min = $this->getValidationRule('min')) {
+        if ( $min = $this->getValidationRule( 'min' ) ) {
             $rules[] = "min:{$min}";
         }
 
-        if ($max = $this->getValidationRule('max')) {
+        if ( $max = $this->getValidationRule( 'max' ) ) {
             $rules[] = "max:{$max}";
         }
 
-        if ($pattern = $this->getValidationRule('pattern')) {
+        if ( $pattern = $this->getValidationRule( 'pattern' ) ) {
             $rules[] = "regex:{$pattern}";
         }
 
         // Date range validation
-        if ($minDate = $this->getValidationRule('min_date')) {
+        if ( $minDate = $this->getValidationRule( 'min_date' ) ) {
             $rules[] = "after_or_equal:{$minDate}";
         }
 
-        if ($maxDate = $this->getValidationRule('max_date')) {
+        if ( $maxDate = $this->getValidationRule( 'max_date' ) ) {
             $rules[] = "before_or_equal:{$maxDate}";
         }
 
         // Time range validation
-        if ($minTime = $this->getValidationRule('min_time')) {
+        if ( $minTime = $this->getValidationRule( 'min_time' ) ) {
             $rules[] = "after_or_equal:{$minTime}";
         }
 
-        if ($maxTime = $this->getValidationRule('max_time')) {
+        if ( $maxTime = $this->getValidationRule( 'max_time' ) ) {
             $rules[] = "before_or_equal:{$maxTime}";
         }
 
         // Apply filter hook for extensibility
-        if (function_exists('applyFilters')) {
-            $rules = applyFilters('ap.forms.validationRules', $rules, $this);
-        }
+        $rules = applyFilters( 'ap.forms.validationRules', $rules, $this );
 
         return $rules;
     }
@@ -357,7 +361,7 @@ class FormField extends Model
      */
     public function isLayoutField(): bool
     {
-        return FieldTypes::isLayoutField($this->type);
+        return FieldTypes::isLayoutField( $this->type );
     }
 
     /**
@@ -382,9 +386,9 @@ class FormField extends Model
     protected function casts(): array
     {
         return [
-            'is_required' => 'boolean',
-            'validation_rules' => 'array',
-            'field_config' => 'array',
+            'is_required'       => 'boolean',
+            'validation_rules'  => 'array',
+            'field_config'      => 'array',
             'conditional_logic' => 'array',
         ];
     }
@@ -404,11 +408,11 @@ class FormField extends Model
     {
         parent::boot();
 
-        static::creating(function (FormField $field): void {
-            if (empty($field->uuid)) {
+        static::creating( function ( FormField $field ): void {
+            if ( empty( $field->uuid ) ) {
                 $field->uuid = Str::uuid()->toString();
             }
-        });
+        } );
     }
 
     /**
@@ -424,31 +428,31 @@ class FormField extends Model
     protected function getTypeValidationRules(): array
     {
         // Check for built-in types first
-        $builtInRules = match ($this->type) {
-            'email' => ['email'],
-            'url' => ['url'],
-            'number' => ['numeric'],
-            'phone' => ['string'],
-            'date' => ['date'],
-            'time' => ['date_format:H:i'],
-            'file' => $this->getFileValidationRules(),
+        $builtInRules = match ( $this->type ) {
+            'email'                             => ['email'],
+            'url'                               => ['url'],
+            'number'                            => ['numeric'],
+            'phone'                             => ['string'],
+            'date'                              => ['date'],
+            'time'                              => ['date_format:H:i'],
+            'file'                              => $this->getFileValidationRules(),
             'checkbox_group', 'select_multiple' => ['array'],
-            'checkbox' => ['boolean'],
-            default => null,
+            'checkbox'                          => ['boolean'],
+            default                             => null,
         };
 
-        if ($builtInRules !== null) {
+        if ( null !== $builtInRules ) {
             return $builtInRules;
         }
 
         // Check for custom type validation rules from the filter hook
-        $typeConfig = FieldTypes::getTypeConfig($this->type);
+        $typeConfig = FieldTypes::getTypeConfig( $this->type );
 
-        if ($typeConfig !== null && isset($typeConfig['type_validation'])) {
+        if ( null !== $typeConfig && isset( $typeConfig['type_validation'] ) ) {
             $customRules = $typeConfig['type_validation'];
 
             // Support both array of rules and single rule string
-            return is_array($customRules) ? $customRules : [$customRules];
+            return is_array( $customRules ) ? $customRules : [$customRules];
         }
 
         // Default to string validation for unknown types
@@ -466,11 +470,11 @@ class FormField extends Model
     {
         $rules = ['file'];
 
-        if ($types = $this->getConfig('allowed_types')) {
-            $rules[] = 'mimes:'.implode(',', $types);
+        if ( $types = $this->getConfig( 'allowed_types' ) ) {
+            $rules[] = 'mimes:' . implode( ',', $types );
         }
 
-        if ($maxSize = $this->getConfig('max_size')) {
+        if ( $maxSize = $this->getConfig( 'max_size' ) ) {
             $rules[] = "max:{$maxSize}";
         }
 

--- a/src/Models/FormSubmission.php
+++ b/src/Models/FormSubmission.php
@@ -12,7 +12,7 @@
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Models;
 
@@ -91,7 +91,7 @@ class FormSubmission extends Model
      */
     public function form(): BelongsTo
     {
-        return $this->belongsTo(Form::class);
+        return $this->belongsTo( Form::class );
     }
 
     /**
@@ -103,7 +103,7 @@ class FormSubmission extends Model
      */
     public function values(): HasMany
     {
-        return $this->hasMany(FormSubmissionValue::class, 'submission_id');
+        return $this->hasMany( FormSubmissionValue::class, 'submission_id' );
     }
 
     /**
@@ -115,7 +115,7 @@ class FormSubmission extends Model
      */
     public function uploads(): HasMany
     {
-        return $this->hasMany(FormUpload::class, 'submission_id');
+        return $this->hasMany( FormUpload::class, 'submission_id' );
     }
 
     // =========================================
@@ -128,11 +128,12 @@ class FormSubmission extends Model
      * @since 1.0.0
      *
      * @param  Builder<FormSubmission>  $query  The query builder instance.
+     *
      * @return Builder<FormSubmission> The modified query builder.
      */
-    public function scopeUnread(Builder $query): Builder
+    public function scopeUnread( Builder $query ): Builder
     {
-        return $query->where('is_read', false);
+        return $query->where( 'is_read', false );
     }
 
     /**
@@ -141,11 +142,12 @@ class FormSubmission extends Model
      * @since 1.0.0
      *
      * @param  Builder<FormSubmission>  $query  The query builder instance.
+     *
      * @return Builder<FormSubmission> The modified query builder.
      */
-    public function scopeRead(Builder $query): Builder
+    public function scopeRead( Builder $query ): Builder
     {
-        return $query->where('is_read', true);
+        return $query->where( 'is_read', true );
     }
 
     /**
@@ -154,11 +156,12 @@ class FormSubmission extends Model
      * @since 1.0.0
      *
      * @param  Builder<FormSubmission>  $query  The query builder instance.
+     *
      * @return Builder<FormSubmission> The modified query builder.
      */
-    public function scopeNotSpam(Builder $query): Builder
+    public function scopeNotSpam( Builder $query ): Builder
     {
-        return $query->where('is_spam', false);
+        return $query->where( 'is_spam', false );
     }
 
     /**
@@ -167,11 +170,12 @@ class FormSubmission extends Model
      * @since 1.0.0
      *
      * @param  Builder<FormSubmission>  $query  The query builder instance.
+     *
      * @return Builder<FormSubmission> The modified query builder.
      */
-    public function scopeSpam(Builder $query): Builder
+    public function scopeSpam( Builder $query ): Builder
     {
-        return $query->where('is_spam', true);
+        return $query->where( 'is_spam', true );
     }
 
     /**
@@ -180,11 +184,12 @@ class FormSubmission extends Model
      * @since 1.0.0
      *
      * @param  Builder<FormSubmission>  $query  The query builder instance.
+     *
      * @return Builder<FormSubmission> The modified query builder.
      */
-    public function scopeStarred(Builder $query): Builder
+    public function scopeStarred( Builder $query ): Builder
     {
-        return $query->where('is_starred', true);
+        return $query->where( 'is_starred', true );
     }
 
     /**
@@ -194,11 +199,12 @@ class FormSubmission extends Model
      *
      * @param  Builder<FormSubmission>  $query  The query builder instance.
      * @param  int  $days  Number of days to look back.
+     *
      * @return Builder<FormSubmission> The modified query builder.
      */
-    public function scopeRecent(Builder $query, int $days = 30): Builder
+    public function scopeRecent( Builder $query, int $days = 30 ): Builder
     {
-        return $query->where('created_at', '>=', now()->subDays($days));
+        return $query->where( 'created_at', '>=', now()->subDays( $days ) );
     }
 
     // =========================================
@@ -214,9 +220,9 @@ class FormSubmission extends Model
      */
     public function getDataAttribute(): Collection
     {
-        return $this->values->mapWithKeys(function (FormSubmissionValue $value) {
+        return $this->values->mapWithKeys( function ( FormSubmissionValue $value ) {
             return [$value->field_name => $value->display_value];
-        });
+        } );
     }
 
     /**
@@ -242,7 +248,7 @@ class FormSubmission extends Model
      */
     public function markAsRead(): void
     {
-        $this->update(['is_read' => true]);
+        $this->update( ['is_read' => true] );
     }
 
     /**
@@ -252,7 +258,7 @@ class FormSubmission extends Model
      */
     public function markAsUnread(): void
     {
-        $this->update(['is_read' => false]);
+        $this->update( ['is_read' => false] );
     }
 
     /**
@@ -262,7 +268,7 @@ class FormSubmission extends Model
      */
     public function toggleSpam(): void
     {
-        $this->update(['is_spam' => ! $this->is_spam]);
+        $this->update( ['is_spam' => ! $this->is_spam] );
     }
 
     /**
@@ -272,7 +278,7 @@ class FormSubmission extends Model
      */
     public function toggleStar(): void
     {
-        $this->update(['is_starred' => ! $this->is_starred]);
+        $this->update( ['is_starred' => ! $this->is_starred] );
     }
 
     /**
@@ -281,12 +287,13 @@ class FormSubmission extends Model
      * @since 1.0.0
      *
      * @param  string  $fieldName  The field name to retrieve.
+     *
      * @return string|null The field value or null if not found.
      */
-    public function getValue(string $fieldName): ?string
+    public function getValue( string $fieldName ): ?string
     {
         return $this->values
-            ->firstWhere('field_name', $fieldName)
+            ->firstWhere( 'field_name', $fieldName )
             ?->display_value;
     }
 
@@ -299,9 +306,9 @@ class FormSubmission extends Model
      */
     public function getEmailValue(): ?string
     {
-        $emailValue = $this->values->first(function ($value) {
-            return $value->field_type === 'email';
-        });
+        $emailValue = $this->values->first( function ( $value ) {
+            return 'email' === $value->field_type;
+        } );
 
         return $emailValue?->value;
     }
@@ -328,8 +335,8 @@ class FormSubmission extends Model
     protected function casts(): array
     {
         return [
-            'is_read' => 'boolean',
-            'is_spam' => 'boolean',
+            'is_read'    => 'boolean',
+            'is_spam'    => 'boolean',
             'is_starred' => 'boolean',
         ];
     }
@@ -349,41 +356,35 @@ class FormSubmission extends Model
     {
         parent::boot();
 
-        static::creating(function (FormSubmission $submission): void {
-            if (empty($submission->submission_number)) {
-                $submission->submission_number = static::generateSubmissionNumber($submission->form_id);
+        static::creating( function ( FormSubmission $submission ): void {
+            if ( empty( $submission->submission_number ) ) {
+                $submission->submission_number = static::generateSubmissionNumber( $submission->form_id );
             }
-        });
+        } );
 
-        static::created(function (FormSubmission $submission): void {
+        static::created( function ( FormSubmission $submission ): void {
             // Fire action hook for extensibility
-            if (function_exists('doAction')) {
-                doAction('ap.forms.submission.created', $submission);
-            }
+            doAction( 'ap.forms.submission.created', $submission );
 
             // Dispatch Laravel event
-            FormSubmitted::dispatch($submission);
-        });
+            FormSubmitted::dispatch( $submission );
+        } );
 
-        static::updated(function (FormSubmission $submission): void {
+        static::updated( function ( FormSubmission $submission ): void {
             // Fire action hook for extensibility
-            if (function_exists('doAction')) {
-                doAction('ap.forms.submission.updated', $submission);
-            }
+            doAction( 'ap.forms.submission.updated', $submission );
 
             // Dispatch Laravel event
-            SubmissionUpdated::dispatch($submission);
-        });
+            SubmissionUpdated::dispatch( $submission );
+        } );
 
-        static::deleted(function (FormSubmission $submission): void {
+        static::deleted( function ( FormSubmission $submission ): void {
             // Fire action hook for extensibility
-            if (function_exists('doAction')) {
-                doAction('ap.forms.submission.deleted', $submission);
-            }
+            doAction( 'ap.forms.submission.deleted', $submission );
 
             // Dispatch Laravel event
-            SubmissionDeleted::dispatch($submission);
-        });
+            SubmissionDeleted::dispatch( $submission );
+        } );
     }
 
     /**
@@ -392,22 +393,23 @@ class FormSubmission extends Model
      * @since 1.0.0
      *
      * @param  int  $formId  The form ID to generate a submission number for.
+     *
      * @return string The unique submission number.
      */
-    protected static function generateSubmissionNumber(int $formId): string
+    protected static function generateSubmissionNumber( int $formId ): string
     {
-        $format = config('artisanpack.forms.submissions.submission_number_format', 'FORM-{year}-{sequence}');
+        $format = config( 'artisanpack.forms.submissions.submission_number_format', 'FORM-{year}-{sequence}' );
 
-        $count = static::where('form_id', $formId)
-            ->whereYear('created_at', now()->year)
+        $count = static::where( 'form_id', $formId )
+            ->whereYear( 'created_at', now()->year )
             ->count() + 1;
 
         $replacements = [
-            '{year}' => now()->format('Y'),
-            '{sequence}' => sprintf('%05d', $count),
-            '{form_id}' => $formId,
+            '{year}'     => now()->format( 'Y' ),
+            '{sequence}' => sprintf( '%05d', $count ),
+            '{form_id}'  => $formId,
         ];
 
-        return str_replace(array_keys($replacements), array_values($replacements), $format);
+        return str_replace( array_keys( $replacements ), array_values( $replacements), $format);
     }
 }

--- a/src/Models/FormSubmission.php
+++ b/src/Models/FormSubmission.php
@@ -6,15 +6,13 @@
  * Represents a form submission including metadata, status flags,
  * and admin notes. Links to submitted values and file uploads.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @author     Jacob Martella <support@artisanpackui.dev>
  *
  * @since      1.0.0
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Forms\Models;
 
@@ -27,6 +25,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
 /**
@@ -35,8 +34,6 @@ use Illuminate\Support\Collection;
  * Represents a form submission including metadata, status flags,
  * and admin notes. Links to submitted values and file uploads.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @property int $id
  * @property int $form_id
@@ -49,8 +46,8 @@ use Illuminate\Support\Collection;
  * @property bool $is_spam
  * @property bool $is_starred
  * @property string|null $admin_notes
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  * @property-read Form $form
  * @property-read Collection $data
  * @property-read array $data_array
@@ -94,7 +91,7 @@ class FormSubmission extends Model
      */
     public function form(): BelongsTo
     {
-        return $this->belongsTo( Form::class );
+        return $this->belongsTo(Form::class);
     }
 
     /**
@@ -106,7 +103,7 @@ class FormSubmission extends Model
      */
     public function values(): HasMany
     {
-        return $this->hasMany( FormSubmissionValue::class, 'submission_id' );
+        return $this->hasMany(FormSubmissionValue::class, 'submission_id');
     }
 
     /**
@@ -118,7 +115,7 @@ class FormSubmission extends Model
      */
     public function uploads(): HasMany
     {
-        return $this->hasMany( FormUpload::class, 'submission_id' );
+        return $this->hasMany(FormUpload::class, 'submission_id');
     }
 
     // =========================================
@@ -130,13 +127,12 @@ class FormSubmission extends Model
      *
      * @since 1.0.0
      *
-     * @param Builder<FormSubmission> $query The query builder instance.
-     *
+     * @param  Builder<FormSubmission>  $query  The query builder instance.
      * @return Builder<FormSubmission> The modified query builder.
      */
-    public function scopeUnread( Builder $query ): Builder
+    public function scopeUnread(Builder $query): Builder
     {
-        return $query->where( 'is_read', false );
+        return $query->where('is_read', false);
     }
 
     /**
@@ -144,13 +140,12 @@ class FormSubmission extends Model
      *
      * @since 1.0.0
      *
-     * @param Builder<FormSubmission> $query The query builder instance.
-     *
+     * @param  Builder<FormSubmission>  $query  The query builder instance.
      * @return Builder<FormSubmission> The modified query builder.
      */
-    public function scopeRead( Builder $query ): Builder
+    public function scopeRead(Builder $query): Builder
     {
-        return $query->where( 'is_read', true );
+        return $query->where('is_read', true);
     }
 
     /**
@@ -158,13 +153,12 @@ class FormSubmission extends Model
      *
      * @since 1.0.0
      *
-     * @param Builder<FormSubmission> $query The query builder instance.
-     *
+     * @param  Builder<FormSubmission>  $query  The query builder instance.
      * @return Builder<FormSubmission> The modified query builder.
      */
-    public function scopeNotSpam( Builder $query ): Builder
+    public function scopeNotSpam(Builder $query): Builder
     {
-        return $query->where( 'is_spam', false );
+        return $query->where('is_spam', false);
     }
 
     /**
@@ -172,13 +166,12 @@ class FormSubmission extends Model
      *
      * @since 1.0.0
      *
-     * @param Builder<FormSubmission> $query The query builder instance.
-     *
+     * @param  Builder<FormSubmission>  $query  The query builder instance.
      * @return Builder<FormSubmission> The modified query builder.
      */
-    public function scopeSpam( Builder $query ): Builder
+    public function scopeSpam(Builder $query): Builder
     {
-        return $query->where( 'is_spam', true );
+        return $query->where('is_spam', true);
     }
 
     /**
@@ -186,13 +179,12 @@ class FormSubmission extends Model
      *
      * @since 1.0.0
      *
-     * @param Builder<FormSubmission> $query The query builder instance.
-     *
+     * @param  Builder<FormSubmission>  $query  The query builder instance.
      * @return Builder<FormSubmission> The modified query builder.
      */
-    public function scopeStarred( Builder $query ): Builder
+    public function scopeStarred(Builder $query): Builder
     {
-        return $query->where( 'is_starred', true );
+        return $query->where('is_starred', true);
     }
 
     /**
@@ -200,14 +192,13 @@ class FormSubmission extends Model
      *
      * @since 1.0.0
      *
-     * @param Builder<FormSubmission> $query The query builder instance.
-     * @param int                     $days  Number of days to look back.
-     *
+     * @param  Builder<FormSubmission>  $query  The query builder instance.
+     * @param  int  $days  Number of days to look back.
      * @return Builder<FormSubmission> The modified query builder.
      */
-    public function scopeRecent( Builder $query, int $days = 30 ): Builder
+    public function scopeRecent(Builder $query, int $days = 30): Builder
     {
-        return $query->where( 'created_at', '>=', now()->subDays( $days ) );
+        return $query->where('created_at', '>=', now()->subDays($days));
     }
 
     // =========================================
@@ -223,9 +214,9 @@ class FormSubmission extends Model
      */
     public function getDataAttribute(): Collection
     {
-        return $this->values->mapWithKeys( function ( FormSubmissionValue $value ) {
+        return $this->values->mapWithKeys(function (FormSubmissionValue $value) {
             return [$value->field_name => $value->display_value];
-        } );
+        });
     }
 
     /**
@@ -248,48 +239,40 @@ class FormSubmission extends Model
      * Marks the submission as read.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     public function markAsRead(): void
     {
-        $this->update( ['is_read' => true] );
+        $this->update(['is_read' => true]);
     }
 
     /**
      * Marks the submission as unread.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     public function markAsUnread(): void
     {
-        $this->update( ['is_read' => false] );
+        $this->update(['is_read' => false]);
     }
 
     /**
      * Toggles the spam status.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     public function toggleSpam(): void
     {
-        $this->update( ['is_spam' => ! $this->is_spam] );
+        $this->update(['is_spam' => ! $this->is_spam]);
     }
 
     /**
      * Toggles the starred status.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     public function toggleStar(): void
     {
-        $this->update( ['is_starred' => ! $this->is_starred] );
+        $this->update(['is_starred' => ! $this->is_starred]);
     }
 
     /**
@@ -297,14 +280,13 @@ class FormSubmission extends Model
      *
      * @since 1.0.0
      *
-     * @param string $fieldName The field name to retrieve.
-     *
+     * @param  string  $fieldName  The field name to retrieve.
      * @return string|null The field value or null if not found.
      */
-    public function getValue( string $fieldName ): ?string
+    public function getValue(string $fieldName): ?string
     {
         return $this->values
-            ->firstWhere( 'field_name', $fieldName )
+            ->firstWhere('field_name', $fieldName)
             ?->display_value;
     }
 
@@ -317,9 +299,9 @@ class FormSubmission extends Model
      */
     public function getEmailValue(): ?string
     {
-        $emailValue = $this->values->first( function ( $value ) {
-            return 'email' === $value->field_type;
-        } );
+        $emailValue = $this->values->first(function ($value) {
+            return $value->field_type === 'email';
+        });
 
         return $emailValue?->value;
     }
@@ -346,8 +328,8 @@ class FormSubmission extends Model
     protected function casts(): array
     {
         return [
-            'is_read'    => 'boolean',
-            'is_spam'    => 'boolean',
+            'is_read' => 'boolean',
+            'is_spam' => 'boolean',
             'is_starred' => 'boolean',
         ];
     }
@@ -362,48 +344,46 @@ class FormSubmission extends Model
      * Sets up model event listeners for creating, created, updated, and deleted events.
      *
      * @since 1.0.0
-     *
-     * @return void
      */
     protected static function boot(): void
     {
         parent::boot();
 
-        static::creating( function ( FormSubmission $submission ): void {
-            if ( empty( $submission->submission_number ) ) {
-                $submission->submission_number = static::generateSubmissionNumber( $submission->form_id );
+        static::creating(function (FormSubmission $submission): void {
+            if (empty($submission->submission_number)) {
+                $submission->submission_number = static::generateSubmissionNumber($submission->form_id);
             }
-        } );
+        });
 
-        static::created( function ( FormSubmission $submission ): void {
+        static::created(function (FormSubmission $submission): void {
             // Fire action hook for extensibility
-            if ( function_exists( 'doAction' ) ) {
-                doAction( 'forms.submission.created', $submission );
+            if (function_exists('doAction')) {
+                doAction('ap.forms.submission.created', $submission);
             }
 
             // Dispatch Laravel event
-            FormSubmitted::dispatch( $submission );
-        } );
+            FormSubmitted::dispatch($submission);
+        });
 
-        static::updated( function ( FormSubmission $submission ): void {
+        static::updated(function (FormSubmission $submission): void {
             // Fire action hook for extensibility
-            if ( function_exists( 'doAction' ) ) {
-                doAction( 'forms.submission.updated', $submission );
+            if (function_exists('doAction')) {
+                doAction('ap.forms.submission.updated', $submission);
             }
 
             // Dispatch Laravel event
-            SubmissionUpdated::dispatch( $submission );
-        } );
+            SubmissionUpdated::dispatch($submission);
+        });
 
-        static::deleted( function ( FormSubmission $submission ): void {
+        static::deleted(function (FormSubmission $submission): void {
             // Fire action hook for extensibility
-            if ( function_exists( 'doAction' ) ) {
-                doAction( 'forms.submission.deleted', $submission );
+            if (function_exists('doAction')) {
+                doAction('ap.forms.submission.deleted', $submission);
             }
 
             // Dispatch Laravel event
-            SubmissionDeleted::dispatch( $submission );
-        } );
+            SubmissionDeleted::dispatch($submission);
+        });
     }
 
     /**
@@ -411,24 +391,23 @@ class FormSubmission extends Model
      *
      * @since 1.0.0
      *
-     * @param int $formId The form ID to generate a submission number for.
-     *
+     * @param  int  $formId  The form ID to generate a submission number for.
      * @return string The unique submission number.
      */
-    protected static function generateSubmissionNumber( int $formId ): string
+    protected static function generateSubmissionNumber(int $formId): string
     {
-        $format = config( 'artisanpack.forms.submissions.submission_number_format', 'FORM-{year}-{sequence}' );
+        $format = config('artisanpack.forms.submissions.submission_number_format', 'FORM-{year}-{sequence}');
 
-        $count = static::where( 'form_id', $formId )
-            ->whereYear( 'created_at', now()->year )
+        $count = static::where('form_id', $formId)
+            ->whereYear('created_at', now()->year)
             ->count() + 1;
 
         $replacements = [
-            '{year}'     => now()->format( 'Y' ),
-            '{sequence}' => sprintf( '%05d', $count ),
-            '{form_id}'  => $formId,
+            '{year}' => now()->format('Y'),
+            '{sequence}' => sprintf('%05d', $count),
+            '{form_id}' => $formId,
         ];
 
-        return str_replace( array_keys( $replacements ), array_values( $replacements), $format);
+        return str_replace(array_keys($replacements), array_values($replacements), $format);
     }
 }

--- a/src/Services/ExportService.php
+++ b/src/Services/ExportService.php
@@ -12,7 +12,7 @@
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Services;
 
@@ -46,35 +46,36 @@ class ExportService
      * @param  Form  $form  The form to export from.
      * @param  Collection<int, FormSubmission>  $submissions  The submissions to export.
      * @param  string|null  $filename  Optional custom filename.
+     *
      * @return StreamedResponse The CSV download response.
      */
-    public function exportToCsv(Form $form, Collection $submissions, ?string $filename = null): StreamedResponse
+    public function exportToCsv( Form $form, Collection $submissions, ?string $filename = null ): StreamedResponse
     {
-        $filename = $filename ?? $form->slug.'-submissions-'.now()->format('Y-m-d').'.csv';
+        $filename = $filename ?? $form->slug . '-submissions-' . now()->format( 'Y-m-d' ) . '.csv';
 
-        $headers = $this->buildHeaders($form);
-        $rows = $this->buildRows($form, $submissions);
+        $headers = $this->buildHeaders( $form );
+        $rows    = $this->buildRows( $form, $submissions );
 
-        return Response::streamDownload(function () use ($headers, $rows): void {
-            $handle = fopen('php://output', 'w');
+        return Response::streamDownload( function () use ( $headers, $rows ): void {
+            $handle = fopen( 'php://output', 'w' );
 
-            if ($handle === false) {
-                throw new RuntimeException(__('Failed to open output stream for CSV export.'));
+            if ( false === $handle ) {
+                throw new RuntimeException( __( 'Failed to open output stream for CSV export.' ) );
             }
 
             // Write headers
-            fputcsv($handle, $headers);
+            fputcsv( $handle, $headers );
 
             // Write rows
-            foreach ($rows as $row) {
-                fputcsv($handle, $row);
+            foreach ( $rows as $row ) {
+                fputcsv( $handle, $row );
             }
 
-            fclose($handle);
+            fclose( $handle );
         }, $filename, [
-            'Content-Type' => 'text/csv',
-            'Content-Disposition' => 'attachment; filename="'.$filename.'"',
-        ]);
+            'Content-Type'        => 'text/csv',
+            'Content-Disposition' => 'attachment; filename="' . $filename . '"',
+        ] );
     }
 
     /**
@@ -86,22 +87,23 @@ class ExportService
      * @since 1.0.0
      *
      * @param  Form  $form  The form to build headers for.
+     *
      * @return array<int, string> The CSV headers.
      */
-    public function buildHeaders(Form $form): array
+    public function buildHeaders( Form $form ): array
     {
-        $localizeHeaders = config('artisanpack.forms.export.localize_headers', false);
+        $localizeHeaders = config( 'artisanpack.forms.export.localize_headers', false );
 
         $headers = [
-            $localizeHeaders ? __('Submission ID') : 'Submission ID',
-            $localizeHeaders ? __('Submission Number') : 'Submission Number',
-            $localizeHeaders ? __('Submitted At') : 'Submitted At',
+            $localizeHeaders ? __( 'Submission ID' ) : 'Submission ID',
+            $localizeHeaders ? __( 'Submission Number' ) : 'Submission Number',
+            $localizeHeaders ? __( 'Submitted At' ) : 'Submitted At',
         ];
 
         // Add field headers
-        foreach ($form->fields()->orderBy('sort_order')->get() as $field) {
+        foreach ( $form->fields()->orderBy( 'sort_order' )->get() as $field ) {
             // Skip layout fields
-            if ($field->isLayoutField()) {
+            if ( $field->isLayoutField() ) {
                 continue;
             }
 
@@ -109,21 +111,19 @@ class ExportService
         }
 
         // Add metadata headers
-        $headers[] = $localizeHeaders ? __('Page URL') : 'Page URL';
+        $headers[] = $localizeHeaders ? __( 'Page URL' ) : 'Page URL';
 
         // Only include IP Address header if explicitly enabled in config
-        if (config('artisanpack.forms.privacy.include_ip_address', false)) {
-            $headers[] = $localizeHeaders ? __('IP Address') : 'IP Address';
+        if ( config( 'artisanpack.forms.privacy.include_ip_address', false ) ) {
+            $headers[] = $localizeHeaders ? __( 'IP Address' ) : 'IP Address';
         }
 
-        $headers[] = $localizeHeaders ? __('Is Read') : 'Is Read';
-        $headers[] = $localizeHeaders ? __('Is Spam') : 'Is Spam';
-        $headers[] = $localizeHeaders ? __('Is Starred') : 'Is Starred';
+        $headers[] = $localizeHeaders ? __( 'Is Read' ) : 'Is Read';
+        $headers[] = $localizeHeaders ? __( 'Is Spam' ) : 'Is Spam';
+        $headers[] = $localizeHeaders ? __( 'Is Starred' ) : 'Is Starred';
 
         // Apply filter hook for extensibility
-        if (function_exists('applyFilters')) {
-            $headers = applyFilters('ap.forms.exportHeaders', $headers, $form);
-        }
+        $headers = applyFilters( 'ap.forms.exportHeaders', $headers, $form );
 
         return $headers;
     }
@@ -135,15 +135,16 @@ class ExportService
      *
      * @param  Form  $form  The form.
      * @param  Collection<int, FormSubmission>  $submissions  The submissions.
+     *
      * @return array<int, array<int, string>> The CSV rows.
      */
-    public function buildRows(Form $form, Collection $submissions): array
+    public function buildRows( Form $form, Collection $submissions ): array
     {
-        $fields = $form->fields()->orderBy('sort_order')->get();
-        $rows = [];
+        $fields = $form->fields()->orderBy( 'sort_order' )->get();
+        $rows   = [];
 
-        foreach ($submissions as $submission) {
-            $row = $this->buildRow($form, $submission, $fields);
+        foreach ( $submissions as $submission ) {
+            $row    = $this->buildRow( $form, $submission, $fields );
             $rows[] = $row;
         }
 
@@ -161,24 +162,25 @@ class ExportService
      * @param  Form  $form  The form.
      * @param  FormSubmission  $submission  The submission.
      * @param  Collection<int, FormField>  $fields  The form fields.
+     *
      * @return array<int, string> The CSV row data.
      */
-    public function buildRow(Form $form, FormSubmission $submission, $fields): array
+    public function buildRow( Form $form, FormSubmission $submission, $fields ): array
     {
         $row = [
             (string) $submission->id,
             $submission->submission_number,
-            $submission->created_at->format('Y-m-d H:i:s'),
+            $submission->created_at->format( 'Y-m-d H:i:s' ),
         ];
 
         // Add field values
-        foreach ($fields as $field) {
+        foreach ( $fields as $field ) {
             // Skip layout fields
-            if ($field->isLayoutField()) {
+            if ( $field->isLayoutField() ) {
                 continue;
             }
 
-            $value = $submission->getValue($field->name);
+            $value = $submission->getValue( $field->name );
             $row[] = $value ?? '';
         }
 
@@ -186,18 +188,18 @@ class ExportService
         $row[] = $submission->page_url ?? '';
 
         // Only include IP address if explicitly enabled in config
-        if (config('artisanpack.forms.privacy.include_ip_address', false)) {
+        if ( config( 'artisanpack.forms.privacy.include_ip_address', false ) ) {
             $row[] = $submission->ip_address ?? '';
         }
 
         // Use stable boolean values (1/0) by default for machine parsing
         // Use localized Yes/No only when explicitly enabled
-        $localizeBooleans = config('artisanpack.forms.export.localize_booleans', false);
+        $localizeBooleans = config( 'artisanpack.forms.export.localize_booleans', false );
 
-        if ($localizeBooleans) {
-            $row[] = $submission->is_read ? __('Yes') : __('No');
-            $row[] = $submission->is_spam ? __('Yes') : __('No');
-            $row[] = $submission->is_starred ? __('Yes') : __('No');
+        if ( $localizeBooleans ) {
+            $row[] = $submission->is_read ? __( 'Yes' ) : __( 'No' );
+            $row[] = $submission->is_spam ? __( 'Yes' ) : __( 'No' );
+            $row[] = $submission->is_starred ? __( 'Yes' ) : __( 'No' );
         } else {
             $row[] = $submission->is_read ? '1' : '0';
             $row[] = $submission->is_spam ? '1' : '0';
@@ -205,9 +207,7 @@ class ExportService
         }
 
         // Apply filter hook for extensibility
-        if (function_exists('applyFilters')) {
-            $row = applyFilters('ap.forms.exportData', $row, $submission);
-        }
+        $row = applyFilters( 'ap.forms.exportData', $row, $submission );
 
         return $row;
     }
@@ -219,38 +219,37 @@ class ExportService
      *
      * @param  Form  $form  The form to export from.
      * @param  Collection<int, FormSubmission>  $submissions  The submissions to export.
+     *
      * @return array<int, array<string, mixed>> The JSON export data.
      */
-    public function exportToJson(Form $form, Collection $submissions): array
+    public function exportToJson( Form $form, Collection $submissions ): array
     {
         $data = [];
 
-        foreach ($submissions as $submission) {
+        foreach ( $submissions as $submission ) {
             // Build metadata, respecting privacy settings
             $metadata = [
-                'page_url' => $submission->page_url,
-                'is_read' => $submission->is_read,
-                'is_spam' => $submission->is_spam,
+                'page_url'   => $submission->page_url,
+                'is_read'    => $submission->is_read,
+                'is_spam'    => $submission->is_spam,
                 'is_starred' => $submission->is_starred,
             ];
 
             // Only include IP address if explicitly enabled in config
-            if (config('artisanpack.forms.privacy.include_ip_address', false)) {
+            if ( config( 'artisanpack.forms.privacy.include_ip_address', false ) ) {
                 $metadata['ip_address'] = $submission->ip_address;
             }
 
             $submissionData = [
-                'id' => $submission->id,
+                'id'                => $submission->id,
                 'submission_number' => $submission->submission_number,
-                'submitted_at' => $submission->created_at->toIso8601String(),
-                'data' => $submission->data_array,
-                'metadata' => $metadata,
+                'submitted_at'      => $submission->created_at->toIso8601String(),
+                'data'              => $submission->data_array,
+                'metadata'          => $metadata,
             ];
 
             // Apply filter hook for extensibility
-            if (function_exists('applyFilters')) {
-                $submissionData = applyFilters('ap.forms.exportData', $submissionData, $submission);
-            }
+            $submissionData = applyFilters( 'ap.forms.exportData', $submissionData, $submission );
 
             $data[] = $submissionData;
         }

--- a/src/Services/ExportService.php
+++ b/src/Services/ExportService.php
@@ -6,19 +6,18 @@
  * Business logic layer for exporting form submissions to various formats.
  * Supports CSV export with configurable headers and data transformations.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @author     Jacob Martella <support@artisanpackui.dev>
  *
  * @since      1.0.0
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Forms\Services;
 
 use ArtisanPackUI\Forms\Models\Form;
+use ArtisanPackUI\Forms\Models\FormField;
 use ArtisanPackUI\Forms\Models\FormSubmission;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Response;
@@ -31,8 +30,6 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  * Business logic layer for exporting form submissions to various formats.
  * Supports CSV export with configurable headers and data transformations.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @since      1.0.0
  */
@@ -41,72 +38,70 @@ class ExportService
     /**
      * Exports submissions to CSV format.
      *
-     * Applies the 'forms.export_headers' and 'forms.export_data' filter hooks
+     * Applies the 'ap.forms.exportHeaders' and 'ap.forms.exportData' filter hooks
      * to allow third-party packages to modify export data.
      *
      * @since 1.0.0
      *
-     * @param Form                              $form        The form to export from.
-     * @param Collection<int, FormSubmission>   $submissions The submissions to export.
-     * @param string|null                       $filename    Optional custom filename.
-     *
+     * @param  Form  $form  The form to export from.
+     * @param  Collection<int, FormSubmission>  $submissions  The submissions to export.
+     * @param  string|null  $filename  Optional custom filename.
      * @return StreamedResponse The CSV download response.
      */
-    public function exportToCsv( Form $form, Collection $submissions, ?string $filename = null ): StreamedResponse
+    public function exportToCsv(Form $form, Collection $submissions, ?string $filename = null): StreamedResponse
     {
-        $filename = $filename ?? $form->slug . '-submissions-' . now()->format( 'Y-m-d' ) . '.csv';
+        $filename = $filename ?? $form->slug.'-submissions-'.now()->format('Y-m-d').'.csv';
 
-        $headers = $this->buildHeaders( $form );
-        $rows    = $this->buildRows( $form, $submissions );
+        $headers = $this->buildHeaders($form);
+        $rows = $this->buildRows($form, $submissions);
 
-        return Response::streamDownload( function () use ( $headers, $rows ): void {
-            $handle = fopen( 'php://output', 'w' );
+        return Response::streamDownload(function () use ($headers, $rows): void {
+            $handle = fopen('php://output', 'w');
 
-            if ( false === $handle ) {
-                throw new RuntimeException( __( 'Failed to open output stream for CSV export.' ) );
+            if ($handle === false) {
+                throw new RuntimeException(__('Failed to open output stream for CSV export.'));
             }
 
             // Write headers
-            fputcsv( $handle, $headers );
+            fputcsv($handle, $headers);
 
             // Write rows
-            foreach ( $rows as $row ) {
-                fputcsv( $handle, $row );
+            foreach ($rows as $row) {
+                fputcsv($handle, $row);
             }
 
-            fclose( $handle );
+            fclose($handle);
         }, $filename, [
-            'Content-Type'        => 'text/csv',
-            'Content-Disposition' => 'attachment; filename="' . $filename . '"',
-        ] );
+            'Content-Type' => 'text/csv',
+            'Content-Disposition' => 'attachment; filename="'.$filename.'"',
+        ]);
     }
 
     /**
      * Builds CSV headers from form fields.
      *
-     * Applies the 'forms.export_headers' filter hook to allow
+     * Applies the 'ap.forms.exportHeaders' filter hook to allow
      * third-party packages to modify export headers.
      *
      * @since 1.0.0
      *
-     * @param Form $form The form to build headers for.
-     *
+     * @param  Form  $form  The form to build headers for.
      * @return array<int, string> The CSV headers.
      */
-    public function buildHeaders( Form $form ): array
+    public function buildHeaders(Form $form): array
     {
-        $localizeHeaders = config( 'artisanpack.forms.export.localize_headers', false );
+        $localizeHeaders = config('artisanpack.forms.export.localize_headers', false);
 
         $headers = [
-            $localizeHeaders ? __( 'Submission ID' ) : 'Submission ID',
-            $localizeHeaders ? __( 'Submission Number' ) : 'Submission Number',
-            $localizeHeaders ? __( 'Submitted At' ) : 'Submitted At',
+            $localizeHeaders ? __('Submission ID') : 'Submission ID',
+            $localizeHeaders ? __('Submission Number') : 'Submission Number',
+            $localizeHeaders ? __('Submitted At') : 'Submitted At',
         ];
 
         // Add field headers
-        foreach ( $form->fields()->orderBy( 'sort_order' )->get() as $field ) {
+        foreach ($form->fields()->orderBy('sort_order')->get() as $field) {
             // Skip layout fields
-            if ( $field->isLayoutField() ) {
+            if ($field->isLayoutField()) {
                 continue;
             }
 
@@ -114,20 +109,20 @@ class ExportService
         }
 
         // Add metadata headers
-        $headers[] = $localizeHeaders ? __( 'Page URL' ) : 'Page URL';
+        $headers[] = $localizeHeaders ? __('Page URL') : 'Page URL';
 
         // Only include IP Address header if explicitly enabled in config
-        if ( config( 'artisanpack.forms.privacy.include_ip_address', false ) ) {
-            $headers[] = $localizeHeaders ? __( 'IP Address' ) : 'IP Address';
+        if (config('artisanpack.forms.privacy.include_ip_address', false)) {
+            $headers[] = $localizeHeaders ? __('IP Address') : 'IP Address';
         }
 
-        $headers[] = $localizeHeaders ? __( 'Is Read' ) : 'Is Read';
-        $headers[] = $localizeHeaders ? __( 'Is Spam' ) : 'Is Spam';
-        $headers[] = $localizeHeaders ? __( 'Is Starred' ) : 'Is Starred';
+        $headers[] = $localizeHeaders ? __('Is Read') : 'Is Read';
+        $headers[] = $localizeHeaders ? __('Is Spam') : 'Is Spam';
+        $headers[] = $localizeHeaders ? __('Is Starred') : 'Is Starred';
 
         // Apply filter hook for extensibility
-        if ( function_exists( 'applyFilters' ) ) {
-            $headers = applyFilters( 'forms.export_headers', $headers, $form );
+        if (function_exists('applyFilters')) {
+            $headers = applyFilters('ap.forms.exportHeaders', $headers, $form);
         }
 
         return $headers;
@@ -138,18 +133,17 @@ class ExportService
      *
      * @since 1.0.0
      *
-     * @param Form                            $form        The form.
-     * @param Collection<int, FormSubmission> $submissions The submissions.
-     *
+     * @param  Form  $form  The form.
+     * @param  Collection<int, FormSubmission>  $submissions  The submissions.
      * @return array<int, array<int, string>> The CSV rows.
      */
-    public function buildRows( Form $form, Collection $submissions ): array
+    public function buildRows(Form $form, Collection $submissions): array
     {
-        $fields = $form->fields()->orderBy( 'sort_order' )->get();
-        $rows   = [];
+        $fields = $form->fields()->orderBy('sort_order')->get();
+        $rows = [];
 
-        foreach ( $submissions as $submission ) {
-            $row    = $this->buildRow( $form, $submission, $fields );
+        foreach ($submissions as $submission) {
+            $row = $this->buildRow($form, $submission, $fields);
             $rows[] = $row;
         }
 
@@ -159,33 +153,32 @@ class ExportService
     /**
      * Builds a single CSV row from a submission.
      *
-     * Applies the 'forms.export_data' filter hook to allow
+     * Applies the 'ap.forms.exportData' filter hook to allow
      * third-party packages to modify export row data.
      *
      * @since 1.0.0
      *
-     * @param Form                                                    $form       The form.
-     * @param FormSubmission                                          $submission The submission.
-     * @param Collection<int, \ArtisanPackUI\Forms\Models\FormField>  $fields     The form fields.
-     *
+     * @param  Form  $form  The form.
+     * @param  FormSubmission  $submission  The submission.
+     * @param  Collection<int, FormField>  $fields  The form fields.
      * @return array<int, string> The CSV row data.
      */
-    public function buildRow( Form $form, FormSubmission $submission, $fields ): array
+    public function buildRow(Form $form, FormSubmission $submission, $fields): array
     {
         $row = [
             (string) $submission->id,
             $submission->submission_number,
-            $submission->created_at->format( 'Y-m-d H:i:s' ),
+            $submission->created_at->format('Y-m-d H:i:s'),
         ];
 
         // Add field values
-        foreach ( $fields as $field ) {
+        foreach ($fields as $field) {
             // Skip layout fields
-            if ( $field->isLayoutField() ) {
+            if ($field->isLayoutField()) {
                 continue;
             }
 
-            $value = $submission->getValue( $field->name );
+            $value = $submission->getValue($field->name);
             $row[] = $value ?? '';
         }
 
@@ -193,18 +186,18 @@ class ExportService
         $row[] = $submission->page_url ?? '';
 
         // Only include IP address if explicitly enabled in config
-        if ( config( 'artisanpack.forms.privacy.include_ip_address', false ) ) {
+        if (config('artisanpack.forms.privacy.include_ip_address', false)) {
             $row[] = $submission->ip_address ?? '';
         }
 
         // Use stable boolean values (1/0) by default for machine parsing
         // Use localized Yes/No only when explicitly enabled
-        $localizeBooleans = config( 'artisanpack.forms.export.localize_booleans', false );
+        $localizeBooleans = config('artisanpack.forms.export.localize_booleans', false);
 
-        if ( $localizeBooleans ) {
-            $row[] = $submission->is_read ? __( 'Yes' ) : __( 'No' );
-            $row[] = $submission->is_spam ? __( 'Yes' ) : __( 'No' );
-            $row[] = $submission->is_starred ? __( 'Yes' ) : __( 'No' );
+        if ($localizeBooleans) {
+            $row[] = $submission->is_read ? __('Yes') : __('No');
+            $row[] = $submission->is_spam ? __('Yes') : __('No');
+            $row[] = $submission->is_starred ? __('Yes') : __('No');
         } else {
             $row[] = $submission->is_read ? '1' : '0';
             $row[] = $submission->is_spam ? '1' : '0';
@@ -212,8 +205,8 @@ class ExportService
         }
 
         // Apply filter hook for extensibility
-        if ( function_exists( 'applyFilters' ) ) {
-            $row = applyFilters( 'forms.export_data', $row, $submission );
+        if (function_exists('applyFilters')) {
+            $row = applyFilters('ap.forms.exportData', $row, $submission);
         }
 
         return $row;
@@ -224,40 +217,39 @@ class ExportService
      *
      * @since 1.0.0
      *
-     * @param Form                            $form        The form to export from.
-     * @param Collection<int, FormSubmission> $submissions The submissions to export.
-     *
+     * @param  Form  $form  The form to export from.
+     * @param  Collection<int, FormSubmission>  $submissions  The submissions to export.
      * @return array<int, array<string, mixed>> The JSON export data.
      */
-    public function exportToJson( Form $form, Collection $submissions ): array
+    public function exportToJson(Form $form, Collection $submissions): array
     {
         $data = [];
 
-        foreach ( $submissions as $submission ) {
+        foreach ($submissions as $submission) {
             // Build metadata, respecting privacy settings
             $metadata = [
-                'page_url'   => $submission->page_url,
-                'is_read'    => $submission->is_read,
-                'is_spam'    => $submission->is_spam,
+                'page_url' => $submission->page_url,
+                'is_read' => $submission->is_read,
+                'is_spam' => $submission->is_spam,
                 'is_starred' => $submission->is_starred,
             ];
 
             // Only include IP address if explicitly enabled in config
-            if ( config( 'artisanpack.forms.privacy.include_ip_address', false ) ) {
+            if (config('artisanpack.forms.privacy.include_ip_address', false)) {
                 $metadata['ip_address'] = $submission->ip_address;
             }
 
             $submissionData = [
-                'id'                => $submission->id,
+                'id' => $submission->id,
                 'submission_number' => $submission->submission_number,
-                'submitted_at'      => $submission->created_at->toIso8601String(),
-                'data'              => $submission->data_array,
-                'metadata'          => $metadata,
+                'submitted_at' => $submission->created_at->toIso8601String(),
+                'data' => $submission->data_array,
+                'metadata' => $metadata,
             ];
 
             // Apply filter hook for extensibility
-            if ( function_exists( 'applyFilters' ) ) {
-                $submissionData = applyFilters( 'forms.export_data', $submissionData, $submission );
+            if (function_exists('applyFilters')) {
+                $submissionData = applyFilters('ap.forms.exportData', $submissionData, $submission);
             }
 
             $data[] = $submissionData;

--- a/src/Services/IntegrationService.php
+++ b/src/Services/IntegrationService.php
@@ -13,7 +13,7 @@
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Services;
 
@@ -55,11 +55,23 @@ class IntegrationService
         $tabs = [];
 
         // Apply filter hook for extensibility
-        if (function_exists('applyFilters')) {
-            $tabs = applyFilters('ap.forms.settingsTabs', $tabs);
-        }
+        $tabs = applyFilters( 'ap.forms.settingsTabs', $tabs );
 
         return $tabs;
+    }
+
+    /**
+     * Fires the `ap.forms.integrationRegistered` action so ecosystem packages can
+     * announce themselves from their service provider `boot()`.
+     *
+     * @since 1.3.0
+     *
+     * @param  string  $slug  Unique integration slug (e.g. "mailchimp").
+     * @param  array<string, mixed>  $config  Integration metadata (label, icon, component, ...).
+     */
+    public function registerIntegration( string $slug, array $config = [] ): void
+    {
+        doAction( 'ap.forms.integrationRegistered', $slug, $config );
     }
 
     /**
@@ -74,17 +86,18 @@ class IntegrationService
      * @param  string  $provider  The integration provider name.
      * @param  string|null  $key  Specific setting key, or null for all provider settings.
      * @param  mixed  $default  Default value if setting not found.
+     *
      * @return mixed The setting value, provider settings array, or default.
      */
-    public function getIntegrationSetting(Form $form, string $provider, ?string $key = null, mixed $default = null): mixed
+    public function getIntegrationSetting( Form $form, string $provider, ?string $key = null, mixed $default = null ): mixed
     {
         $path = "integrations.{$provider}";
 
-        if ($key !== null) {
+        if ( null !== $key ) {
             $path .= ".{$key}";
         }
 
-        return $form->getSetting($path, $default);
+        return $form->getSetting( $path, $default );
     }
 
     /**
@@ -96,17 +109,17 @@ class IntegrationService
      * @param  string  $provider  The integration provider name.
      * @param  array<string, mixed>  $settings  The settings to store.
      */
-    public function setIntegrationSettings(Form $form, string $provider, array $settings): void
+    public function setIntegrationSettings( Form $form, string $provider, array $settings ): void
     {
         $currentSettings = $form->settings ?? [];
 
-        if (! isset($currentSettings['integrations'])) {
+        if ( ! isset( $currentSettings['integrations'] ) ) {
             $currentSettings['integrations'] = [];
         }
 
-        $currentSettings['integrations'][$provider] = $settings;
+        $currentSettings['integrations'][ $provider ] = $settings;
 
-        $form->update(['settings' => $currentSettings]);
+        $form->update( ['settings' => $currentSettings] );
     }
 
     /**
@@ -119,21 +132,21 @@ class IntegrationService
      * @param  string  $key  The setting key.
      * @param  mixed  $value  The setting value.
      */
-    public function updateIntegrationSetting(Form $form, string $provider, string $key, mixed $value): void
+    public function updateIntegrationSetting( Form $form, string $provider, string $key, mixed $value ): void
     {
         $currentSettings = $form->settings ?? [];
 
-        if (! isset($currentSettings['integrations'])) {
+        if ( ! isset( $currentSettings['integrations'] ) ) {
             $currentSettings['integrations'] = [];
         }
 
-        if (! isset($currentSettings['integrations'][$provider])) {
-            $currentSettings['integrations'][$provider] = [];
+        if ( ! isset( $currentSettings['integrations'][ $provider ] ) ) {
+            $currentSettings['integrations'][ $provider ] = [];
         }
 
-        $currentSettings['integrations'][$provider][$key] = $value;
+        $currentSettings['integrations'][ $provider ][ $key ] = $value;
 
-        $form->update(['settings' => $currentSettings]);
+        $form->update( ['settings' => $currentSettings] );
     }
 
     /**
@@ -144,13 +157,13 @@ class IntegrationService
      * @param  Form  $form  The form.
      * @param  string  $provider  The integration provider name.
      */
-    public function removeIntegrationSettings(Form $form, string $provider): void
+    public function removeIntegrationSettings( Form $form, string $provider ): void
     {
         $currentSettings = $form->settings ?? [];
 
-        if (isset($currentSettings['integrations'][$provider])) {
-            unset($currentSettings['integrations'][$provider]);
-            $form->update(['settings' => $currentSettings]);
+        if ( isset( $currentSettings['integrations'][ $provider ] ) ) {
+            unset( $currentSettings['integrations'][ $provider ] );
+            $form->update( ['settings' => $currentSettings] );
         }
     }
 
@@ -161,11 +174,12 @@ class IntegrationService
      *
      * @param  Form  $form  The form.
      * @param  string  $provider  The integration provider name.
+     *
      * @return bool True if the form has settings for the provider.
      */
-    public function hasIntegration(Form $form, string $provider): bool
+    public function hasIntegration( Form $form, string $provider ): bool
     {
-        return ! empty($form->getSetting("integrations.{$provider}"));
+        return ! empty( $form->getSetting( "integrations.{$provider}" ) );
     }
 
     /**
@@ -174,16 +188,17 @@ class IntegrationService
      * @since 1.0.0
      *
      * @param  Form  $form  The form.
+     *
      * @return array<int, string> The configured provider names.
      */
-    public function getConfiguredProviders(Form $form): array
+    public function getConfiguredProviders( Form $form ): array
     {
-        $integrations = $form->getSetting('integrations', []);
+        $integrations = $form->getSetting( 'integrations', [] );
 
-        if (! is_array($integrations)) {
+        if ( ! is_array( $integrations ) ) {
             return [];
         }
 
-        return array_keys(array_filter($integrations, fn ($config) => ! empty($config)));
+        return array_keys( array_filter( $integrations, fn ( $config ) => ! empty( $config )));
     }
 }

--- a/src/Services/IntegrationService.php
+++ b/src/Services/IntegrationService.php
@@ -7,15 +7,13 @@
  * Provides hooks for integration packages to register settings panels
  * and handles integration settings storage.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @author     Jacob Martella <support@artisanpackui.dev>
  *
  * @since      1.0.0
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Forms\Services;
 
@@ -28,8 +26,6 @@ use ArtisanPackUI\Forms\Models\Form;
  * Provides hooks for integration packages to register settings panels
  * and handles integration settings storage.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @since      1.0.0
  */
@@ -38,7 +34,7 @@ class IntegrationService
     /**
      * Gets all registered integration settings tabs.
      *
-     * Applies the 'forms.settings_tabs' filter hook to allow
+     * Applies the 'ap.forms.settingsTabs' filter hook to allow
      * third-party packages to register custom settings tabs.
      *
      * Each tab should have the following structure:
@@ -59,8 +55,8 @@ class IntegrationService
         $tabs = [];
 
         // Apply filter hook for extensibility
-        if ( function_exists( 'applyFilters' ) ) {
-            $tabs = applyFilters( 'forms.settings_tabs', $tabs );
+        if (function_exists('applyFilters')) {
+            $tabs = applyFilters('ap.forms.settingsTabs', $tabs);
         }
 
         return $tabs;
@@ -74,22 +70,21 @@ class IntegrationService
      *
      * @since 1.0.0
      *
-     * @param Form        $form     The form.
-     * @param string      $provider The integration provider name.
-     * @param string|null $key      Specific setting key, or null for all provider settings.
-     * @param mixed       $default  Default value if setting not found.
-     *
+     * @param  Form  $form  The form.
+     * @param  string  $provider  The integration provider name.
+     * @param  string|null  $key  Specific setting key, or null for all provider settings.
+     * @param  mixed  $default  Default value if setting not found.
      * @return mixed The setting value, provider settings array, or default.
      */
-    public function getIntegrationSetting( Form $form, string $provider, ?string $key = null, mixed $default = null ): mixed
+    public function getIntegrationSetting(Form $form, string $provider, ?string $key = null, mixed $default = null): mixed
     {
         $path = "integrations.{$provider}";
 
-        if ( null !== $key ) {
+        if ($key !== null) {
             $path .= ".{$key}";
         }
 
-        return $form->getSetting( $path, $default );
+        return $form->getSetting($path, $default);
     }
 
     /**
@@ -97,23 +92,21 @@ class IntegrationService
      *
      * @since 1.0.0
      *
-     * @param Form                 $form     The form.
-     * @param string               $provider The integration provider name.
-     * @param array<string, mixed> $settings The settings to store.
-     *
-     * @return void
+     * @param  Form  $form  The form.
+     * @param  string  $provider  The integration provider name.
+     * @param  array<string, mixed>  $settings  The settings to store.
      */
-    public function setIntegrationSettings( Form $form, string $provider, array $settings ): void
+    public function setIntegrationSettings(Form $form, string $provider, array $settings): void
     {
         $currentSettings = $form->settings ?? [];
 
-        if ( ! isset( $currentSettings['integrations'] ) ) {
+        if (! isset($currentSettings['integrations'])) {
             $currentSettings['integrations'] = [];
         }
 
-        $currentSettings['integrations'][ $provider ] = $settings;
+        $currentSettings['integrations'][$provider] = $settings;
 
-        $form->update( ['settings' => $currentSettings] );
+        $form->update(['settings' => $currentSettings]);
     }
 
     /**
@@ -121,28 +114,26 @@ class IntegrationService
      *
      * @since 1.0.0
      *
-     * @param Form   $form     The form.
-     * @param string $provider The integration provider name.
-     * @param string $key      The setting key.
-     * @param mixed  $value    The setting value.
-     *
-     * @return void
+     * @param  Form  $form  The form.
+     * @param  string  $provider  The integration provider name.
+     * @param  string  $key  The setting key.
+     * @param  mixed  $value  The setting value.
      */
-    public function updateIntegrationSetting( Form $form, string $provider, string $key, mixed $value ): void
+    public function updateIntegrationSetting(Form $form, string $provider, string $key, mixed $value): void
     {
         $currentSettings = $form->settings ?? [];
 
-        if ( ! isset( $currentSettings['integrations'] ) ) {
+        if (! isset($currentSettings['integrations'])) {
             $currentSettings['integrations'] = [];
         }
 
-        if ( ! isset( $currentSettings['integrations'][ $provider ] ) ) {
-            $currentSettings['integrations'][ $provider ] = [];
+        if (! isset($currentSettings['integrations'][$provider])) {
+            $currentSettings['integrations'][$provider] = [];
         }
 
-        $currentSettings['integrations'][ $provider ][ $key ] = $value;
+        $currentSettings['integrations'][$provider][$key] = $value;
 
-        $form->update( ['settings' => $currentSettings] );
+        $form->update(['settings' => $currentSettings]);
     }
 
     /**
@@ -150,18 +141,16 @@ class IntegrationService
      *
      * @since 1.0.0
      *
-     * @param Form   $form     The form.
-     * @param string $provider The integration provider name.
-     *
-     * @return void
+     * @param  Form  $form  The form.
+     * @param  string  $provider  The integration provider name.
      */
-    public function removeIntegrationSettings( Form $form, string $provider ): void
+    public function removeIntegrationSettings(Form $form, string $provider): void
     {
         $currentSettings = $form->settings ?? [];
 
-        if ( isset( $currentSettings['integrations'][ $provider ] ) ) {
-            unset( $currentSettings['integrations'][ $provider ] );
-            $form->update( ['settings' => $currentSettings] );
+        if (isset($currentSettings['integrations'][$provider])) {
+            unset($currentSettings['integrations'][$provider]);
+            $form->update(['settings' => $currentSettings]);
         }
     }
 
@@ -170,14 +159,13 @@ class IntegrationService
      *
      * @since 1.0.0
      *
-     * @param Form   $form     The form.
-     * @param string $provider The integration provider name.
-     *
+     * @param  Form  $form  The form.
+     * @param  string  $provider  The integration provider name.
      * @return bool True if the form has settings for the provider.
      */
-    public function hasIntegration( Form $form, string $provider ): bool
+    public function hasIntegration(Form $form, string $provider): bool
     {
-        return ! empty( $form->getSetting( "integrations.{$provider}" ) );
+        return ! empty($form->getSetting("integrations.{$provider}"));
     }
 
     /**
@@ -185,18 +173,17 @@ class IntegrationService
      *
      * @since 1.0.0
      *
-     * @param Form $form The form.
-     *
+     * @param  Form  $form  The form.
      * @return array<int, string> The configured provider names.
      */
-    public function getConfiguredProviders( Form $form ): array
+    public function getConfiguredProviders(Form $form): array
     {
-        $integrations = $form->getSetting( 'integrations', [] );
+        $integrations = $form->getSetting('integrations', []);
 
-        if ( ! is_array( $integrations ) ) {
+        if (! is_array($integrations)) {
             return [];
         }
 
-        return array_keys( array_filter( $integrations, fn ( $config ) => ! empty( $config ) ));
+        return array_keys(array_filter($integrations, fn ($config) => ! empty($config)));
     }
 }

--- a/src/Services/SubmissionService.php
+++ b/src/Services/SubmissionService.php
@@ -12,7 +12,7 @@
  * @since      1.0.0
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Services;
 
@@ -71,7 +71,7 @@ class SubmissionService
      *
      * @param  NotificationService  $notificationService  The notification service.
      */
-    public function __construct(NotificationService $notificationService)
+    public function __construct( NotificationService $notificationService )
     {
         $this->notificationService = $notificationService;
     }
@@ -88,69 +88,68 @@ class SubmissionService
      * @param  array<string, mixed>  $formData  The submitted form data.
      * @param  array<string, UploadedFile|null>  $files  Uploaded files keyed by field name.
      * @param  array<string, mixed>  $metadata  Additional metadata (ip, user_agent, etc.).
-     * @return FormSubmission The created submission.
      *
      * @throws RuntimeException If the submission cannot be created.
+     *
+     * @return FormSubmission The created submission.
      */
-    public function create(Form $form, array $formData, array $files = [], array $metadata = []): FormSubmission
+    public function create( Form $form, array $formData, array $files = [], array $metadata = [] ): FormSubmission
     {
         // Apply filter hook to allow modifying submission data before saving
-        if (function_exists('applyFilters')) {
-            $formData = applyFilters('ap.forms.submissionData', $formData, $form);
-        }
+        $formData = applyFilters( 'ap.forms.submissionData', $formData, $form );
 
-        $submission = DB::transaction(function () use ($form, $formData, $files, $metadata): FormSubmission {
+        $submission = DB::transaction( function () use ( $form, $formData, $files, $metadata ): FormSubmission {
             // Create the submission record
-            $submission = FormSubmission::create([
-                'form_id' => $form->id,
-                'page_url' => $metadata['page_url'] ?? null,
+            $submission = FormSubmission::create( [
+                'form_id'      => $form->id,
+                'page_url'     => $metadata['page_url'] ?? null,
                 'referrer_url' => $metadata['referrer_url'] ?? null,
-                'ip_address' => $metadata['ip_address'] ?? null,
-                'user_agent' => $metadata['user_agent'] ?? null,
-                'is_read' => false,
-                'is_spam' => false,
-                'is_starred' => false,
-            ]);
+                'ip_address'   => $metadata['ip_address'] ?? null,
+                'user_agent'   => $metadata['user_agent'] ?? null,
+                'is_read'      => false,
+                'is_spam'      => false,
+                'is_starred'   => false,
+            ] );
 
             // Get all form fields
-            $fields = $form->fields()->get()->keyBy('name');
+            $fields = $form->fields()->get()->keyBy( 'name' );
 
             // Save each field value (except file fields which are handled separately)
-            foreach ($formData as $fieldName => $value) {
-                $field = $fields->get($fieldName);
+            foreach ( $formData as $fieldName => $value ) {
+                $field = $fields->get( $fieldName );
 
-                if (! $field) {
+                if ( ! $field ) {
                     continue;
                 }
 
                 // Skip file fields - they're handled separately in handleFileUpload()
-                if ($field->type === 'file') {
+                if ( 'file' === $field->type ) {
                     continue;
                 }
 
-                $this->saveFieldValue($submission, $field, $value);
+                $this->saveFieldValue( $submission, $field, $value );
             }
 
             // Handle file uploads
-            foreach ($files as $fieldName => $file) {
-                if (! $file instanceof UploadedFile) {
+            foreach ( $files as $fieldName => $file ) {
+                if ( ! $file instanceof UploadedFile ) {
                     continue;
                 }
 
-                $field = $fields->get($fieldName);
+                $field = $fields->get( $fieldName );
 
-                if (! $field || $field->type !== 'file') {
+                if ( ! $field || 'file' !== $field->type ) {
                     continue;
                 }
 
-                $this->handleFileUpload($submission, $field, $file);
+                $this->handleFileUpload( $submission, $field, $file );
             }
 
             return $submission;
-        });
+        } );
 
         // Send notifications after transaction completes (outside transaction to ensure submission is persisted)
-        $this->sendNotifications($submission);
+        $this->sendNotifications( $submission );
 
         return $submission;
     }
@@ -166,31 +165,32 @@ class SubmissionService
      * @param  int|null  $formLoadedAt  Timestamp when form was loaded.
      * @param  int|null  $formId  The form ID for logging context.
      * @param  string|null  $ipAddress  The IP address for logging context.
+     *
      * @return bool True if the submission appears to be spam.
      */
-    public function isSpam(?string $honeypot, ?int $formLoadedAt, ?int $formId = null, ?string $ipAddress = null): bool
+    public function isSpam( ?string $honeypot, ?int $formLoadedAt, ?int $formId = null, ?string $ipAddress = null ): bool
     {
         // Check honeypot - if filled, it's a bot
-        if (! empty($honeypot)) {
-            $this->logSecurityEvent('honeypot_triggered', [
-                'form_id' => $formId,
-                'ip_address' => $ipAddress,
-                'honeypot_value' => Str::limit($honeypot, 50),
-            ]);
+        if ( ! empty( $honeypot ) ) {
+            $this->logSecurityEvent( 'honeypot_triggered', [
+                'form_id'        => $formId,
+                'ip_address'     => $ipAddress,
+                'honeypot_value' => Str::limit( $honeypot, 50 ),
+            ] );
 
             return true;
         }
 
         // Check submission time - if too fast, it's a bot
-        if ($formLoadedAt !== null) {
+        if ( null !== $formLoadedAt ) {
             $elapsed = time() - $formLoadedAt;
-            if ($elapsed < self::MIN_SUBMISSION_TIME) {
-                $this->logSecurityEvent('submission_too_fast', [
-                    'form_id' => $formId,
-                    'ip_address' => $ipAddress,
+            if ( $elapsed < self::MIN_SUBMISSION_TIME ) {
+                $this->logSecurityEvent( 'submission_too_fast', [
+                    'form_id'         => $formId,
+                    'ip_address'      => $ipAddress,
                     'elapsed_seconds' => $elapsed,
-                    'min_required' => self::MIN_SUBMISSION_TIME,
-                ]);
+                    'min_required'    => self::MIN_SUBMISSION_TIME,
+                ] );
 
                 return true;
             }
@@ -209,20 +209,21 @@ class SubmissionService
      * @param  string  $ipAddress  The IP address to check.
      * @param  int  $formId  The form ID.
      * @param  bool  $logEvent  Whether to log the rate limit event.
+     *
      * @return bool True if the IP is rate limited.
      */
-    public function isRateLimited(string $ipAddress, int $formId, bool $logEvent = true): bool
+    public function isRateLimited( string $ipAddress, int $formId, bool $logEvent = true ): bool
     {
-        $key = "form-submission:{$formId}:{$ipAddress}";
+        $key         = "form-submission:{$formId}:{$ipAddress}";
         $maxAttempts = $this->resolveRateLimitMaxAttempts();
-        $isLimited = RateLimiter::tooManyAttempts($key, $maxAttempts);
+        $isLimited   = RateLimiter::tooManyAttempts( $key, $maxAttempts );
 
-        if ($isLimited && $logEvent) {
-            $this->logSecurityEvent('rate_limit_exceeded', [
-                'form_id' => $formId,
-                'ip_address' => $ipAddress,
+        if ( $isLimited && $logEvent ) {
+            $this->logSecurityEvent( 'rate_limit_exceeded', [
+                'form_id'      => $formId,
+                'ip_address'   => $ipAddress,
                 'max_attempts' => $maxAttempts,
-            ]);
+            ] );
         }
 
         return $isLimited;
@@ -236,11 +237,11 @@ class SubmissionService
      * @param  string  $ipAddress  The IP address making the attempt.
      * @param  int  $formId  The form ID.
      */
-    public function recordAttempt(string $ipAddress, int $formId): void
+    public function recordAttempt( string $ipAddress, int $formId ): void
     {
         $key = "form-submission:{$formId}:{$ipAddress}";
 
-        RateLimiter::hit($key, $this->resolveRateLimitDecay());
+        RateLimiter::hit( $key, $this->resolveRateLimitDecay() );
     }
 
     /**
@@ -250,27 +251,28 @@ class SubmissionService
      *
      * @param  Collection<int, FormField>  $fields  The form fields.
      * @param  array<string, bool>  $hiddenFields  Fields hidden by conditional logic.
+     *
      * @return array<string, array<int, string>> The validation rules.
      */
-    public function buildValidationRules($fields, array $hiddenFields = []): array
+    public function buildValidationRules( $fields, array $hiddenFields = [] ): array
     {
         $rules = [];
 
-        foreach ($fields as $field) {
+        foreach ( $fields as $field ) {
             // Skip fields hidden by conditional logic
-            if (isset($hiddenFields[$field->name]) && $hiddenFields[$field->name]) {
+            if ( isset( $hiddenFields[ $field->name ] ) && $hiddenFields[ $field->name ] ) {
                 continue;
             }
 
             // Skip layout-only fields
-            if (in_array($field->type, ['heading', 'paragraph', 'divider', 'html'])) {
+            if ( in_array( $field->type, ['heading', 'paragraph', 'divider', 'html'] ) ) {
                 continue;
             }
 
             $fieldRules = $field->buildValidationRules();
 
-            if (! empty($fieldRules)) {
-                $rules["formData.{$field->name}"] = $fieldRules;
+            if ( ! empty( $fieldRules ) ) {
+                $rules[ "formData.{$field->name}" ] = $fieldRules;
             }
         }
 
@@ -283,38 +285,39 @@ class SubmissionService
      * @since 1.0.0
      *
      * @param  Collection<int, FormField>  $fields  The form fields.
+     *
      * @return array<string, string> The validation messages.
      */
-    public function buildValidationMessages($fields): array
+    public function buildValidationMessages( $fields ): array
     {
         $messages = [];
 
-        foreach ($fields as $field) {
+        foreach ( $fields as $field ) {
             // Skip layout-only fields
-            if (in_array($field->type, ['heading', 'paragraph', 'divider', 'html'])) {
+            if ( in_array( $field->type, ['heading', 'paragraph', 'divider', 'html'] ) ) {
                 continue;
             }
 
             $fieldKey = "formData.{$field->name}";
 
             // Required message
-            if ($field->is_required) {
-                $messages["{$fieldKey}.required"] = __('The :field field is required.', ['field' => $field->label]);
+            if ( $field->is_required ) {
+                $messages[ "{$fieldKey}.required" ] = __( 'The :field field is required.', ['field' => $field->label] );
             }
 
             // Type-specific messages
-            if ($field->type === 'email') {
-                $messages["{$fieldKey}.email"] = __('Please enter a valid email address for :field.', ['field' => $field->label]);
+            if ( 'email' === $field->type ) {
+                $messages[ "{$fieldKey}.email" ] = __( 'Please enter a valid email address for :field.', ['field' => $field->label] );
             }
 
-            if ($field->type === 'url') {
-                $messages["{$fieldKey}.url"] = __('Please enter a valid URL for :field.', ['field' => $field->label]);
+            if ( 'url' === $field->type ) {
+                $messages[ "{$fieldKey}.url" ] = __( 'Please enter a valid URL for :field.', ['field' => $field->label] );
             }
 
-            if ($field->type === 'file') {
-                $messages["{$fieldKey}.file"] = __('Please upload a valid file for :field.', ['field' => $field->label]);
-                $messages["{$fieldKey}.mimes"] = __('The :field must be a file of the allowed types.', ['field' => $field->label]);
-                $messages["{$fieldKey}.max"] = __('The :field must not exceed the maximum file size.', ['field' => $field->label]);
+            if ( 'file' === $field->type ) {
+                $messages[ "{$fieldKey}.file" ]  = __( 'Please upload a valid file for :field.', ['field' => $field->label] );
+                $messages[ "{$fieldKey}.mimes" ] = __( 'The :field must be a file of the allowed types.', ['field' => $field->label] );
+                $messages[ "{$fieldKey}.max" ]   = __( 'The :field must not exceed the maximum file size.', ['field' => $field->label] );
             }
         }
 
@@ -330,32 +333,33 @@ class SubmissionService
      * @since 1.0.0
      *
      * @param  Request  $request  The HTTP request.
+     *
      * @return array<string, string|null> The request metadata.
      */
-    public function getRequestMetadata(Request $request): array
+    public function getRequestMetadata( Request $request ): array
     {
         $ipAddress = null;
 
         // Check if IP logging is enabled (nested under submission settings)
-        if (config('artisanpack.forms.privacy.submission.include_ip', true)) {
+        if ( config( 'artisanpack.forms.privacy.submission.include_ip', true ) ) {
             $ipAddress = $request->ip();
 
             // Anonymize IP if configured
-            if ($ipAddress !== null && config('artisanpack.forms.privacy.submission.anonymize_ip', false)) {
-                $ipAddress = $this->anonymizeIpAddress($ipAddress);
+            if ( null !== $ipAddress && config( 'artisanpack.forms.privacy.submission.anonymize_ip', false ) ) {
+                $ipAddress = $this->anonymizeIpAddress( $ipAddress );
             }
         }
 
         $userAgent = null;
-        if (config('artisanpack.forms.privacy.submission.include_user_agent', true)) {
+        if ( config( 'artisanpack.forms.privacy.submission.include_user_agent', true ) ) {
             $userAgent = $request->userAgent();
         }
 
         return [
-            'page_url' => $request->fullUrl(),
-            'referrer_url' => $request->header('referer'),
-            'ip_address' => $ipAddress,
-            'user_agent' => $userAgent,
+            'page_url'     => $request->fullUrl(),
+            'referrer_url' => $request->header( 'referer' ),
+            'ip_address'   => $ipAddress,
+            'user_agent'   => $userAgent,
         ];
     }
 
@@ -367,9 +371,9 @@ class SubmissionService
      */
     protected function resolveRateLimitMaxAttempts(): int
     {
-        $configured = config('artisanpack.forms.spam_protection.rate_limit.attempts');
+        $configured = config( 'artisanpack.forms.spam_protection.rate_limit.attempts' );
 
-        return is_numeric($configured) && (int) $configured > 0
+        return is_numeric( $configured ) && (int) $configured > 0
             ? (int) $configured
             : self::RATE_LIMIT_MAX_ATTEMPTS;
     }
@@ -382,9 +386,9 @@ class SubmissionService
      */
     protected function resolveRateLimitDecay(): int
     {
-        $configured = config('artisanpack.forms.spam_protection.rate_limit.decay');
+        $configured = config( 'artisanpack.forms.spam_protection.rate_limit.decay' );
 
-        return is_numeric($configured) && (int) $configured > 0
+        return is_numeric( $configured ) && (int) $configured > 0
             ? (int) $configured
             : 60;
     }
@@ -397,11 +401,12 @@ class SubmissionService
      * @since 1.0.0
      *
      * @param  FormSubmission  $submission  The form submission.
+     *
      * @return int Number of notifications queued.
      */
-    protected function sendNotifications(FormSubmission $submission): int
+    protected function sendNotifications( FormSubmission $submission ): int
     {
-        return $this->notificationService->sendNotifications($submission);
+        return $this->notificationService->sendNotifications( $submission );
     }
 
     /**
@@ -412,29 +417,30 @@ class SubmissionService
      * @param  FormSubmission  $submission  The form submission.
      * @param  FormField  $field  The form field.
      * @param  mixed  $value  The field value.
+     *
      * @return FormSubmissionValue The created submission value.
      */
-    protected function saveFieldValue(FormSubmission $submission, FormField $field, mixed $value): FormSubmissionValue
+    protected function saveFieldValue( FormSubmission $submission, FormField $field, mixed $value ): FormSubmissionValue
     {
         $data = [
             'submission_id' => $submission->id,
-            'field_id' => $field->id,
-            'field_name' => $field->name,
-            'field_label' => $field->label,
-            'field_type' => $field->type,
-            'created_at' => now(),
+            'field_id'      => $field->id,
+            'field_name'    => $field->name,
+            'field_label'   => $field->label,
+            'field_type'    => $field->type,
+            'created_at'    => now(),
         ];
 
         // Handle array values (checkbox groups, multi-select)
-        if (is_array($value)) {
+        if ( is_array( $value ) ) {
             $data['value_array'] = $value;
-            $data['value'] = null;
+            $data['value']       = null;
         } else {
-            $data['value'] = (string) $value;
+            $data['value']       = (string) $value;
             $data['value_array'] = null;
         }
 
-        return FormSubmissionValue::create($data);
+        return FormSubmissionValue::create( $data );
     }
 
     /**
@@ -445,59 +451,60 @@ class SubmissionService
      * @param  FormSubmission  $submission  The form submission.
      * @param  FormField  $field  The file field.
      * @param  UploadedFile  $file  The uploaded file.
-     * @return FormUpload The created upload record.
      *
      * @throws InvalidArgumentException If the file extension is not allowed.
+     *
+     * @return FormUpload The created upload record.
      */
-    protected function handleFileUpload(FormSubmission $submission, FormField $field, UploadedFile $file): FormUpload
+    protected function handleFileUpload( FormSubmission $submission, FormField $field, UploadedFile $file ): FormUpload
     {
-        $disk = config('artisanpack.forms.uploads.disk', 'local');
-        $directory = config('artisanpack.forms.uploads.directory', 'form-uploads');
+        $disk      = config( 'artisanpack.forms.uploads.disk', 'local' );
+        $directory = config( 'artisanpack.forms.uploads.directory', 'form-uploads' );
 
         // Validate extension against allowlist
-        $extension = $this->getValidatedExtension($file);
+        $extension = $this->getValidatedExtension( $file );
 
         // Generate a unique filename with validated extension
-        $storedName = Str::uuid()->toString().'.'.$extension;
-        $storagePath = $directory.'/'.$submission->form_id;
+        $storedName  = Str::uuid()->toString() . '.' . $extension;
+        $storagePath = $directory . '/' . $submission->form_id;
 
         // Get file size before storing (more reliable for Livewire temp files)
         $fileSize = $file->getSize();
 
         // Store the file using storeAs (works with both regular UploadedFile and Livewire's TemporaryUploadedFile)
-        $path = $file->storeAs($storagePath, $storedName, $disk);
+        $path = $file->storeAs( $storagePath, $storedName, $disk );
 
-        if ($path === false) {
-            throw new RuntimeException(__('Unable to store uploaded file.'));
+        if ( false === $path ) {
+            throw new RuntimeException( __( 'Unable to store uploaded file.' ) );
         }
 
         // Fallback: get size from stored file if original size was 0 or false
-        if (! $fileSize) {
-            $fileSize = Storage::disk($disk)->size($path);
+        if ( ! $fileSize ) {
+            $fileSize = Storage::disk( $disk )->size( $path );
         }
 
         // Create the upload record
-        $upload = FormUpload::create([
+        $upload = FormUpload::create( [
             'submission_id' => $submission->id,
-            'field_id' => $field->id,
+            'field_id'      => $field->id,
             'original_name' => $file->getClientOriginalName(),
-            'stored_name' => $storedName,
-            'disk' => $disk,
-            'path' => $path,
-            'mime_type' => $file->getMimeType() ?? 'application/octet-stream',
-            'size' => $fileSize ?: 0,
-        ]);
+            'stored_name'   => $storedName,
+            'disk'          => $disk,
+            'path'          => $path,
+            'mime_type'     => $file->getMimeType() ?? 'application/octet-stream',
+            'size'          => $fileSize ?: 0,
+        ] );
 
         // Create submission value linking to the upload
-        FormSubmissionValue::create([
+        FormSubmissionValue::create( [
             'submission_id' => $submission->id,
-            'field_id' => $field->id,
-            'field_name' => $field->name,
-            'field_label' => $field->label,
-            'field_type' => $field->type,
-            'upload_id' => $upload->id,
-            'created_at' => now(),
-        ]);
+            'field_id'      => $field->id,
+            'field_name'    => $field->name,
+            'field_label'   => $field->label,
+            'field_type'    => $field->type,
+            'upload_id'     => $upload->id,
+            'created_at'    => now(),
+        ] );
 
         return $upload;
     }
@@ -511,58 +518,59 @@ class SubmissionService
      * @since 1.0.0
      *
      * @param  UploadedFile  $file  The uploaded file.
-     * @return string The validated file extension.
      *
      * @throws InvalidArgumentException If the extension is not allowed.
+     *
+     * @return string The validated file extension.
      */
-    protected function getValidatedExtension(UploadedFile $file): string
+    protected function getValidatedExtension( UploadedFile $file ): string
     {
         // Prefer server-detected extension based on MIME type
         $extension = $file->guessExtension();
 
         // Fall back to client-provided extension if server detection fails
-        if ($extension === null || $extension === '') {
-            $extension = strtolower($file->getClientOriginalExtension());
+        if ( null === $extension || '' === $extension ) {
+            $extension = strtolower( $file->getClientOriginalExtension() );
         }
 
         // Sanitize extension (remove any non-alphanumeric characters)
-        $extension = preg_replace('/[^a-z0-9]/', '', strtolower($extension));
+        $extension = preg_replace( '/[^a-z0-9]/', '', strtolower( $extension ) );
 
-        if ($extension === null || $extension === '') {
-            throw new InvalidArgumentException(__('Unable to determine file extension.'));
+        if ( null === $extension || '' === $extension ) {
+            throw new InvalidArgumentException( __( 'Unable to determine file extension.' ) );
         }
 
         // Get allowed extensions from config
-        $allowedExtensions = config('artisanpack.forms.uploads.allowed_extensions', [
+        $allowedExtensions = config( 'artisanpack.forms.uploads.allowed_extensions', [
             'jpg', 'jpeg', 'png', 'gif', 'webp', 'svg',
             'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx',
             'txt', 'csv', 'zip', 'rar',
-        ]);
+        ] );
 
         // Require explicit null/false to allow any extension (empty array = use defaults)
-        if ($allowedExtensions === null || $allowedExtensions === false) {
+        if ( null === $allowedExtensions || false === $allowedExtensions ) {
             return $extension;
         }
 
         // If empty array, something is misconfigured - fail safely
-        if (empty($allowedExtensions)) {
+        if ( empty( $allowedExtensions ) ) {
             throw new InvalidArgumentException(
-                __('No allowed file extensions configured. Please set artisanpack.forms.uploads.allowed_extensions.'),
+                __( 'No allowed file extensions configured. Please set artisanpack.forms.uploads.allowed_extensions.' ),
             );
         }
 
         // Validate against allowlist
-        $allowedExtensions = array_map('strtolower', $allowedExtensions);
-        if (! in_array($extension, $allowedExtensions, true)) {
-            $this->logSecurityEvent('invalid_file_extension', [
+        $allowedExtensions = array_map( 'strtolower', $allowedExtensions );
+        if ( ! in_array( $extension, $allowedExtensions, true ) ) {
+            $this->logSecurityEvent( 'invalid_file_extension', [
                 'attempted_extension' => $extension,
-                'original_filename' => $file->getClientOriginalName(),
-                'mime_type' => $file->getMimeType(),
-                'ip_address' => request()->ip(),
-            ]);
+                'original_filename'   => $file->getClientOriginalName(),
+                'mime_type'           => $file->getMimeType(),
+                'ip_address'          => request()->ip(),
+            ] );
 
             throw new InvalidArgumentException(
-                __("File extension ':extension' is not allowed. Allowed extensions: :allowed", ['extension' => $extension, 'allowed' => implode(', ', $allowedExtensions)]),
+                __( "File extension ':extension' is not allowed. Allowed extensions: :allowed", ['extension' => $extension, 'allowed' => implode( ', ', $allowedExtensions )] ),
             );
         }
 
@@ -580,16 +588,16 @@ class SubmissionService
      * @param  string  $eventType  The type of security event.
      * @param  array<string, mixed>  $context  Additional context data.
      */
-    protected function logSecurityEvent(string $eventType, array $context = []): void
+    protected function logSecurityEvent( string $eventType, array $context = [] ): void
     {
-        if (! config('artisanpack.forms.security.logging_enabled', true)) {
+        if ( ! config( 'artisanpack.forms.security.logging_enabled', true ) ) {
             return;
         }
 
-        Log::warning("[Forms Security] {$eventType}", array_merge([
+        Log::warning( "[Forms Security] {$eventType}", array_merge( [
             'event_type' => $eventType,
-            'timestamp' => now()->toIso8601String(),
-        ], $context));
+            'timestamp'  => now()->toIso8601String(),
+        ], $context ) );
     }
 
     /**
@@ -601,32 +609,33 @@ class SubmissionService
      * @since 1.0.0
      *
      * @param  string  $ipAddress  The IP address to anonymize.
+     *
      * @return string The anonymized IP address.
      */
-    protected function anonymizeIpAddress(string $ipAddress): string
+    protected function anonymizeIpAddress( string $ipAddress ): string
     {
         // Handle IPv4
-        if (filter_var($ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
-            return preg_replace('/\.\d+$/', '.0', $ipAddress) ?? $ipAddress;
+        if ( filter_var( $ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+            return preg_replace( '/\.\d+$/', '.0', $ipAddress ) ?? $ipAddress;
         }
 
         // Handle IPv6 - mask the last 80 bits (10 bytes)
-        if (filter_var($ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+        if ( filter_var( $ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) ) {
             // Convert to binary representation (16 bytes)
-            $binary = @inet_pton($ipAddress);
+            $binary = @inet_pton( $ipAddress );
 
-            if ($binary === false) {
+            if ( false === $binary ) {
                 // Fallback if conversion fails
                 return $ipAddress;
             }
 
             // Zero out the last 10 bytes (80 bits) - keep first 6 bytes (48 bits / 3 groups)
-            $anonymized = substr($binary, 0, 6).str_repeat("\x00", 10);
+            $anonymized = substr( $binary, 0, 6 ) . str_repeat( "\x00", 10 );
 
             // Convert back to string representation
-            $result = @inet_ntop($anonymized);
+            $result = @inet_ntop( $anonymized );
 
-            if ($result === false) {
+            if ( false === $result ) {
                 // Fallback if conversion fails
                 return $ipAddress;
             }

--- a/src/Services/SubmissionService.php
+++ b/src/Services/SubmissionService.php
@@ -6,15 +6,13 @@
  * Business logic layer for handling form submissions including
  * validation, file uploads, spam protection, and notification triggering.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @author     Jacob Martella <support@artisanpackui.dev>
  *
  * @since      1.0.0
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace ArtisanPackUI\Forms\Services;
 
@@ -23,6 +21,7 @@ use ArtisanPackUI\Forms\Models\FormField;
 use ArtisanPackUI\Forms\Models\FormSubmission;
 use ArtisanPackUI\Forms\Models\FormSubmissionValue;
 use ArtisanPackUI\Forms\Models\FormUpload;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
@@ -39,8 +38,6 @@ use RuntimeException;
  * Business logic layer for handling form submissions including
  * validation, file uploads, spam protection, and notification triggering.
  *
- * @package    ArtisanPack_UI
- * @subpackage Forms
  *
  * @since      1.0.0
  */
@@ -64,8 +61,6 @@ class SubmissionService
      * The notification service instance.
      *
      * @since 1.0.0
-     *
-     * @var NotificationService
      */
     protected NotificationService $notificationService;
 
@@ -74,9 +69,9 @@ class SubmissionService
      *
      * @since 1.0.0
      *
-     * @param NotificationService $notificationService The notification service.
+     * @param  NotificationService  $notificationService  The notification service.
      */
-    public function __construct( NotificationService $notificationService )
+    public function __construct(NotificationService $notificationService)
     {
         $this->notificationService = $notificationService;
     }
@@ -84,80 +79,78 @@ class SubmissionService
     /**
      * Creates a new submission for a form.
      *
-     * Applies the 'forms.submission_data' filter hook to allow
+     * Applies the 'ap.forms.submissionData' filter hook to allow
      * third-party packages to modify submission data before saving.
      *
      * @since 1.0.0
      *
-     * @param Form                              $form     The form being submitted.
-     * @param array<string, mixed>              $formData The submitted form data.
-     * @param array<string, UploadedFile|null>  $files    Uploaded files keyed by field name.
-     * @param array<string, mixed>              $metadata Additional metadata (ip, user_agent, etc.).
-     *
-     * @throws RuntimeException If the submission cannot be created.
-     *
+     * @param  Form  $form  The form being submitted.
+     * @param  array<string, mixed>  $formData  The submitted form data.
+     * @param  array<string, UploadedFile|null>  $files  Uploaded files keyed by field name.
+     * @param  array<string, mixed>  $metadata  Additional metadata (ip, user_agent, etc.).
      * @return FormSubmission The created submission.
      *
+     * @throws RuntimeException If the submission cannot be created.
      */
-    public function create( Form $form, array $formData, array $files = [], array $metadata = [] ): FormSubmission
+    public function create(Form $form, array $formData, array $files = [], array $metadata = []): FormSubmission
     {
         // Apply filter hook to allow modifying submission data before saving
-        if ( function_exists( 'applyFilters' ) ) {
-            $formData = applyFilters( 'forms.submission_data', $formData, $form );
+        if (function_exists('applyFilters')) {
+            $formData = applyFilters('ap.forms.submissionData', $formData, $form);
         }
 
-        $submission = DB::transaction( function () use ( $form, $formData, $files, $metadata ): FormSubmission {
+        $submission = DB::transaction(function () use ($form, $formData, $files, $metadata): FormSubmission {
             // Create the submission record
-            $submission = FormSubmission::create( [
-                'form_id'      => $form->id,
-                'page_url'     => $metadata['page_url'] ?? null,
+            $submission = FormSubmission::create([
+                'form_id' => $form->id,
+                'page_url' => $metadata['page_url'] ?? null,
                 'referrer_url' => $metadata['referrer_url'] ?? null,
-                'ip_address'   => $metadata['ip_address'] ?? null,
-                'user_agent'   => $metadata['user_agent'] ?? null,
-                'is_read'      => false,
-                'is_spam'      => false,
-                'is_starred'   => false,
-            ] );
+                'ip_address' => $metadata['ip_address'] ?? null,
+                'user_agent' => $metadata['user_agent'] ?? null,
+                'is_read' => false,
+                'is_spam' => false,
+                'is_starred' => false,
+            ]);
 
             // Get all form fields
-            $fields = $form->fields()->get()->keyBy( 'name' );
+            $fields = $form->fields()->get()->keyBy('name');
 
             // Save each field value (except file fields which are handled separately)
-            foreach ( $formData as $fieldName => $value ) {
-                $field = $fields->get( $fieldName );
+            foreach ($formData as $fieldName => $value) {
+                $field = $fields->get($fieldName);
 
-                if ( ! $field ) {
+                if (! $field) {
                     continue;
                 }
 
                 // Skip file fields - they're handled separately in handleFileUpload()
-                if ( 'file' === $field->type ) {
+                if ($field->type === 'file') {
                     continue;
                 }
 
-                $this->saveFieldValue( $submission, $field, $value );
+                $this->saveFieldValue($submission, $field, $value);
             }
 
             // Handle file uploads
-            foreach ( $files as $fieldName => $file ) {
-                if ( ! $file instanceof UploadedFile ) {
+            foreach ($files as $fieldName => $file) {
+                if (! $file instanceof UploadedFile) {
                     continue;
                 }
 
-                $field = $fields->get( $fieldName );
+                $field = $fields->get($fieldName);
 
-                if ( ! $field || 'file' !== $field->type ) {
+                if (! $field || $field->type !== 'file') {
                     continue;
                 }
 
-                $this->handleFileUpload( $submission, $field, $file );
+                $this->handleFileUpload($submission, $field, $file);
             }
 
             return $submission;
-        } );
+        });
 
         // Send notifications after transaction completes (outside transaction to ensure submission is persisted)
-        $this->sendNotifications( $submission );
+        $this->sendNotifications($submission);
 
         return $submission;
     }
@@ -169,36 +162,35 @@ class SubmissionService
      *
      * @since 1.0.0
      *
-     * @param string|null $honeypot     The honeypot field value (should be empty).
-     * @param int|null    $formLoadedAt Timestamp when form was loaded.
-     * @param int|null    $formId       The form ID for logging context.
-     * @param string|null $ipAddress    The IP address for logging context.
-     *
+     * @param  string|null  $honeypot  The honeypot field value (should be empty).
+     * @param  int|null  $formLoadedAt  Timestamp when form was loaded.
+     * @param  int|null  $formId  The form ID for logging context.
+     * @param  string|null  $ipAddress  The IP address for logging context.
      * @return bool True if the submission appears to be spam.
      */
-    public function isSpam( ?string $honeypot, ?int $formLoadedAt, ?int $formId = null, ?string $ipAddress = null ): bool
+    public function isSpam(?string $honeypot, ?int $formLoadedAt, ?int $formId = null, ?string $ipAddress = null): bool
     {
         // Check honeypot - if filled, it's a bot
-        if ( ! empty( $honeypot ) ) {
-            $this->logSecurityEvent( 'honeypot_triggered', [
-                'form_id'        => $formId,
-                'ip_address'     => $ipAddress,
-                'honeypot_value' => Str::limit( $honeypot, 50 ),
-            ] );
+        if (! empty($honeypot)) {
+            $this->logSecurityEvent('honeypot_triggered', [
+                'form_id' => $formId,
+                'ip_address' => $ipAddress,
+                'honeypot_value' => Str::limit($honeypot, 50),
+            ]);
 
             return true;
         }
 
         // Check submission time - if too fast, it's a bot
-        if ( null !== $formLoadedAt ) {
+        if ($formLoadedAt !== null) {
             $elapsed = time() - $formLoadedAt;
-            if ( $elapsed < self::MIN_SUBMISSION_TIME ) {
-                $this->logSecurityEvent( 'submission_too_fast', [
-                    'form_id'         => $formId,
-                    'ip_address'      => $ipAddress,
+            if ($elapsed < self::MIN_SUBMISSION_TIME) {
+                $this->logSecurityEvent('submission_too_fast', [
+                    'form_id' => $formId,
+                    'ip_address' => $ipAddress,
                     'elapsed_seconds' => $elapsed,
-                    'min_required'    => self::MIN_SUBMISSION_TIME,
-                ] );
+                    'min_required' => self::MIN_SUBMISSION_TIME,
+                ]);
 
                 return true;
             }
@@ -214,24 +206,23 @@ class SubmissionService
      *
      * @since 1.0.0
      *
-     * @param string $ipAddress The IP address to check.
-     * @param int    $formId    The form ID.
-     * @param bool   $logEvent  Whether to log the rate limit event.
-     *
+     * @param  string  $ipAddress  The IP address to check.
+     * @param  int  $formId  The form ID.
+     * @param  bool  $logEvent  Whether to log the rate limit event.
      * @return bool True if the IP is rate limited.
      */
-    public function isRateLimited( string $ipAddress, int $formId, bool $logEvent = true ): bool
+    public function isRateLimited(string $ipAddress, int $formId, bool $logEvent = true): bool
     {
-        $key         = "form-submission:{$formId}:{$ipAddress}";
+        $key = "form-submission:{$formId}:{$ipAddress}";
         $maxAttempts = $this->resolveRateLimitMaxAttempts();
-        $isLimited   = RateLimiter::tooManyAttempts( $key, $maxAttempts );
+        $isLimited = RateLimiter::tooManyAttempts($key, $maxAttempts);
 
-        if ( $isLimited && $logEvent ) {
-            $this->logSecurityEvent( 'rate_limit_exceeded', [
-                'form_id'      => $formId,
-                'ip_address'   => $ipAddress,
+        if ($isLimited && $logEvent) {
+            $this->logSecurityEvent('rate_limit_exceeded', [
+                'form_id' => $formId,
+                'ip_address' => $ipAddress,
                 'max_attempts' => $maxAttempts,
-            ] );
+            ]);
         }
 
         return $isLimited;
@@ -242,16 +233,14 @@ class SubmissionService
      *
      * @since 1.0.0
      *
-     * @param string $ipAddress The IP address making the attempt.
-     * @param int    $formId    The form ID.
-     *
-     * @return void
+     * @param  string  $ipAddress  The IP address making the attempt.
+     * @param  int  $formId  The form ID.
      */
-    public function recordAttempt( string $ipAddress, int $formId ): void
+    public function recordAttempt(string $ipAddress, int $formId): void
     {
         $key = "form-submission:{$formId}:{$ipAddress}";
 
-        RateLimiter::hit( $key, $this->resolveRateLimitDecay() );
+        RateLimiter::hit($key, $this->resolveRateLimitDecay());
     }
 
     /**
@@ -259,30 +248,29 @@ class SubmissionService
      *
      * @since 1.0.0
      *
-     * @param \Illuminate\Database\Eloquent\Collection<int, FormField> $fields       The form fields.
-     * @param array<string, bool>                                       $hiddenFields Fields hidden by conditional logic.
-     *
+     * @param  Collection<int, FormField>  $fields  The form fields.
+     * @param  array<string, bool>  $hiddenFields  Fields hidden by conditional logic.
      * @return array<string, array<int, string>> The validation rules.
      */
-    public function buildValidationRules( $fields, array $hiddenFields = [] ): array
+    public function buildValidationRules($fields, array $hiddenFields = []): array
     {
         $rules = [];
 
-        foreach ( $fields as $field ) {
+        foreach ($fields as $field) {
             // Skip fields hidden by conditional logic
-            if ( isset( $hiddenFields[ $field->name ] ) && $hiddenFields[ $field->name ] ) {
+            if (isset($hiddenFields[$field->name]) && $hiddenFields[$field->name]) {
                 continue;
             }
 
             // Skip layout-only fields
-            if ( in_array( $field->type, ['heading', 'paragraph', 'divider', 'html'] ) ) {
+            if (in_array($field->type, ['heading', 'paragraph', 'divider', 'html'])) {
                 continue;
             }
 
             $fieldRules = $field->buildValidationRules();
 
-            if ( ! empty( $fieldRules ) ) {
-                $rules[ "formData.{$field->name}" ] = $fieldRules;
+            if (! empty($fieldRules)) {
+                $rules["formData.{$field->name}"] = $fieldRules;
             }
         }
 
@@ -294,40 +282,39 @@ class SubmissionService
      *
      * @since 1.0.0
      *
-     * @param \Illuminate\Database\Eloquent\Collection<int, FormField> $fields The form fields.
-     *
+     * @param  Collection<int, FormField>  $fields  The form fields.
      * @return array<string, string> The validation messages.
      */
-    public function buildValidationMessages( $fields ): array
+    public function buildValidationMessages($fields): array
     {
         $messages = [];
 
-        foreach ( $fields as $field ) {
+        foreach ($fields as $field) {
             // Skip layout-only fields
-            if ( in_array( $field->type, ['heading', 'paragraph', 'divider', 'html'] ) ) {
+            if (in_array($field->type, ['heading', 'paragraph', 'divider', 'html'])) {
                 continue;
             }
 
             $fieldKey = "formData.{$field->name}";
 
             // Required message
-            if ( $field->is_required ) {
-                $messages[ "{$fieldKey}.required" ] = __( 'The :field field is required.', ['field' => $field->label] );
+            if ($field->is_required) {
+                $messages["{$fieldKey}.required"] = __('The :field field is required.', ['field' => $field->label]);
             }
 
             // Type-specific messages
-            if ( 'email' === $field->type ) {
-                $messages[ "{$fieldKey}.email" ] = __( 'Please enter a valid email address for :field.', ['field' => $field->label] );
+            if ($field->type === 'email') {
+                $messages["{$fieldKey}.email"] = __('Please enter a valid email address for :field.', ['field' => $field->label]);
             }
 
-            if ( 'url' === $field->type ) {
-                $messages[ "{$fieldKey}.url" ] = __( 'Please enter a valid URL for :field.', ['field' => $field->label] );
+            if ($field->type === 'url') {
+                $messages["{$fieldKey}.url"] = __('Please enter a valid URL for :field.', ['field' => $field->label]);
             }
 
-            if ( 'file' === $field->type ) {
-                $messages[ "{$fieldKey}.file" ]  = __( 'Please upload a valid file for :field.', ['field' => $field->label] );
-                $messages[ "{$fieldKey}.mimes" ] = __( 'The :field must be a file of the allowed types.', ['field' => $field->label] );
-                $messages[ "{$fieldKey}.max" ]   = __( 'The :field must not exceed the maximum file size.', ['field' => $field->label] );
+            if ($field->type === 'file') {
+                $messages["{$fieldKey}.file"] = __('Please upload a valid file for :field.', ['field' => $field->label]);
+                $messages["{$fieldKey}.mimes"] = __('The :field must be a file of the allowed types.', ['field' => $field->label]);
+                $messages["{$fieldKey}.max"] = __('The :field must not exceed the maximum file size.', ['field' => $field->label]);
             }
         }
 
@@ -342,34 +329,33 @@ class SubmissionService
      *
      * @since 1.0.0
      *
-     * @param Request $request The HTTP request.
-     *
+     * @param  Request  $request  The HTTP request.
      * @return array<string, string|null> The request metadata.
      */
-    public function getRequestMetadata( Request $request ): array
+    public function getRequestMetadata(Request $request): array
     {
         $ipAddress = null;
 
         // Check if IP logging is enabled (nested under submission settings)
-        if ( config( 'artisanpack.forms.privacy.submission.include_ip', true ) ) {
+        if (config('artisanpack.forms.privacy.submission.include_ip', true)) {
             $ipAddress = $request->ip();
 
             // Anonymize IP if configured
-            if ( null !== $ipAddress && config( 'artisanpack.forms.privacy.submission.anonymize_ip', false ) ) {
-                $ipAddress = $this->anonymizeIpAddress( $ipAddress );
+            if ($ipAddress !== null && config('artisanpack.forms.privacy.submission.anonymize_ip', false)) {
+                $ipAddress = $this->anonymizeIpAddress($ipAddress);
             }
         }
 
         $userAgent = null;
-        if ( config( 'artisanpack.forms.privacy.submission.include_user_agent', true ) ) {
+        if (config('artisanpack.forms.privacy.submission.include_user_agent', true)) {
             $userAgent = $request->userAgent();
         }
 
         return [
-            'page_url'     => $request->fullUrl(),
-            'referrer_url' => $request->header( 'referer' ),
-            'ip_address'   => $ipAddress,
-            'user_agent'   => $userAgent,
+            'page_url' => $request->fullUrl(),
+            'referrer_url' => $request->header('referer'),
+            'ip_address' => $ipAddress,
+            'user_agent' => $userAgent,
         ];
     }
 
@@ -381,9 +367,9 @@ class SubmissionService
      */
     protected function resolveRateLimitMaxAttempts(): int
     {
-        $configured = config( 'artisanpack.forms.spam_protection.rate_limit.attempts' );
+        $configured = config('artisanpack.forms.spam_protection.rate_limit.attempts');
 
-        return is_numeric( $configured ) && (int) $configured > 0
+        return is_numeric($configured) && (int) $configured > 0
             ? (int) $configured
             : self::RATE_LIMIT_MAX_ATTEMPTS;
     }
@@ -396,9 +382,9 @@ class SubmissionService
      */
     protected function resolveRateLimitDecay(): int
     {
-        $configured = config( 'artisanpack.forms.spam_protection.rate_limit.decay' );
+        $configured = config('artisanpack.forms.spam_protection.rate_limit.decay');
 
-        return is_numeric( $configured ) && (int) $configured > 0
+        return is_numeric($configured) && (int) $configured > 0
             ? (int) $configured
             : 60;
     }
@@ -410,13 +396,12 @@ class SubmissionService
      *
      * @since 1.0.0
      *
-     * @param FormSubmission $submission The form submission.
-     *
+     * @param  FormSubmission  $submission  The form submission.
      * @return int Number of notifications queued.
      */
-    protected function sendNotifications( FormSubmission $submission ): int
+    protected function sendNotifications(FormSubmission $submission): int
     {
-        return $this->notificationService->sendNotifications( $submission );
+        return $this->notificationService->sendNotifications($submission);
     }
 
     /**
@@ -424,33 +409,32 @@ class SubmissionService
      *
      * @since 1.0.0
      *
-     * @param FormSubmission $submission The form submission.
-     * @param FormField      $field      The form field.
-     * @param mixed          $value      The field value.
-     *
+     * @param  FormSubmission  $submission  The form submission.
+     * @param  FormField  $field  The form field.
+     * @param  mixed  $value  The field value.
      * @return FormSubmissionValue The created submission value.
      */
-    protected function saveFieldValue( FormSubmission $submission, FormField $field, mixed $value ): FormSubmissionValue
+    protected function saveFieldValue(FormSubmission $submission, FormField $field, mixed $value): FormSubmissionValue
     {
         $data = [
             'submission_id' => $submission->id,
-            'field_id'      => $field->id,
-            'field_name'    => $field->name,
-            'field_label'   => $field->label,
-            'field_type'    => $field->type,
-            'created_at'    => now(),
+            'field_id' => $field->id,
+            'field_name' => $field->name,
+            'field_label' => $field->label,
+            'field_type' => $field->type,
+            'created_at' => now(),
         ];
 
         // Handle array values (checkbox groups, multi-select)
-        if ( is_array( $value ) ) {
+        if (is_array($value)) {
             $data['value_array'] = $value;
-            $data['value']       = null;
+            $data['value'] = null;
         } else {
-            $data['value']       = (string) $value;
+            $data['value'] = (string) $value;
             $data['value_array'] = null;
         }
 
-        return FormSubmissionValue::create( $data );
+        return FormSubmissionValue::create($data);
     }
 
     /**
@@ -458,64 +442,62 @@ class SubmissionService
      *
      * @since 1.0.0
      *
-     * @param FormSubmission $submission The form submission.
-     * @param FormField      $field      The file field.
-     * @param UploadedFile   $file       The uploaded file.
-     *
-     * @throws InvalidArgumentException If the file extension is not allowed.
-     *
+     * @param  FormSubmission  $submission  The form submission.
+     * @param  FormField  $field  The file field.
+     * @param  UploadedFile  $file  The uploaded file.
      * @return FormUpload The created upload record.
      *
+     * @throws InvalidArgumentException If the file extension is not allowed.
      */
-    protected function handleFileUpload( FormSubmission $submission, FormField $field, UploadedFile $file ): FormUpload
+    protected function handleFileUpload(FormSubmission $submission, FormField $field, UploadedFile $file): FormUpload
     {
-        $disk      = config( 'artisanpack.forms.uploads.disk', 'local' );
-        $directory = config( 'artisanpack.forms.uploads.directory', 'form-uploads' );
+        $disk = config('artisanpack.forms.uploads.disk', 'local');
+        $directory = config('artisanpack.forms.uploads.directory', 'form-uploads');
 
         // Validate extension against allowlist
-        $extension = $this->getValidatedExtension( $file );
+        $extension = $this->getValidatedExtension($file);
 
         // Generate a unique filename with validated extension
-        $storedName  = Str::uuid()->toString() . '.' . $extension;
-        $storagePath = $directory . '/' . $submission->form_id;
+        $storedName = Str::uuid()->toString().'.'.$extension;
+        $storagePath = $directory.'/'.$submission->form_id;
 
         // Get file size before storing (more reliable for Livewire temp files)
         $fileSize = $file->getSize();
 
         // Store the file using storeAs (works with both regular UploadedFile and Livewire's TemporaryUploadedFile)
-        $path = $file->storeAs( $storagePath, $storedName, $disk );
+        $path = $file->storeAs($storagePath, $storedName, $disk);
 
-        if ( false === $path ) {
-            throw new RuntimeException( __( 'Unable to store uploaded file.' ) );
+        if ($path === false) {
+            throw new RuntimeException(__('Unable to store uploaded file.'));
         }
 
         // Fallback: get size from stored file if original size was 0 or false
-        if ( ! $fileSize ) {
-            $fileSize = Storage::disk( $disk )->size( $path );
+        if (! $fileSize) {
+            $fileSize = Storage::disk($disk)->size($path);
         }
 
         // Create the upload record
-        $upload = FormUpload::create( [
+        $upload = FormUpload::create([
             'submission_id' => $submission->id,
-            'field_id'      => $field->id,
+            'field_id' => $field->id,
             'original_name' => $file->getClientOriginalName(),
-            'stored_name'   => $storedName,
-            'disk'          => $disk,
-            'path'          => $path,
-            'mime_type'     => $file->getMimeType() ?? 'application/octet-stream',
-            'size'          => $fileSize ?: 0,
-        ] );
+            'stored_name' => $storedName,
+            'disk' => $disk,
+            'path' => $path,
+            'mime_type' => $file->getMimeType() ?? 'application/octet-stream',
+            'size' => $fileSize ?: 0,
+        ]);
 
         // Create submission value linking to the upload
-        FormSubmissionValue::create( [
+        FormSubmissionValue::create([
             'submission_id' => $submission->id,
-            'field_id'      => $field->id,
-            'field_name'    => $field->name,
-            'field_label'   => $field->label,
-            'field_type'    => $field->type,
-            'upload_id'     => $upload->id,
-            'created_at'    => now(),
-        ] );
+            'field_id' => $field->id,
+            'field_name' => $field->name,
+            'field_label' => $field->label,
+            'field_type' => $field->type,
+            'upload_id' => $upload->id,
+            'created_at' => now(),
+        ]);
 
         return $upload;
     }
@@ -528,61 +510,59 @@ class SubmissionService
      *
      * @since 1.0.0
      *
-     * @param UploadedFile $file The uploaded file.
-     *
-     * @throws InvalidArgumentException If the extension is not allowed.
-     *
+     * @param  UploadedFile  $file  The uploaded file.
      * @return string The validated file extension.
      *
+     * @throws InvalidArgumentException If the extension is not allowed.
      */
-    protected function getValidatedExtension( UploadedFile $file ): string
+    protected function getValidatedExtension(UploadedFile $file): string
     {
         // Prefer server-detected extension based on MIME type
         $extension = $file->guessExtension();
 
         // Fall back to client-provided extension if server detection fails
-        if ( null === $extension || '' === $extension ) {
-            $extension = strtolower( $file->getClientOriginalExtension() );
+        if ($extension === null || $extension === '') {
+            $extension = strtolower($file->getClientOriginalExtension());
         }
 
         // Sanitize extension (remove any non-alphanumeric characters)
-        $extension = preg_replace( '/[^a-z0-9]/', '', strtolower( $extension ) );
+        $extension = preg_replace('/[^a-z0-9]/', '', strtolower($extension));
 
-        if ( null === $extension || '' === $extension ) {
-            throw new InvalidArgumentException( __( 'Unable to determine file extension.' ) );
+        if ($extension === null || $extension === '') {
+            throw new InvalidArgumentException(__('Unable to determine file extension.'));
         }
 
         // Get allowed extensions from config
-        $allowedExtensions = config( 'artisanpack.forms.uploads.allowed_extensions', [
+        $allowedExtensions = config('artisanpack.forms.uploads.allowed_extensions', [
             'jpg', 'jpeg', 'png', 'gif', 'webp', 'svg',
             'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx',
             'txt', 'csv', 'zip', 'rar',
-        ] );
+        ]);
 
         // Require explicit null/false to allow any extension (empty array = use defaults)
-        if ( null === $allowedExtensions || false === $allowedExtensions ) {
+        if ($allowedExtensions === null || $allowedExtensions === false) {
             return $extension;
         }
 
         // If empty array, something is misconfigured - fail safely
-        if ( empty( $allowedExtensions ) ) {
+        if (empty($allowedExtensions)) {
             throw new InvalidArgumentException(
-                __( 'No allowed file extensions configured. Please set artisanpack.forms.uploads.allowed_extensions.' ),
+                __('No allowed file extensions configured. Please set artisanpack.forms.uploads.allowed_extensions.'),
             );
         }
 
         // Validate against allowlist
-        $allowedExtensions = array_map( 'strtolower', $allowedExtensions );
-        if ( ! in_array( $extension, $allowedExtensions, true ) ) {
-            $this->logSecurityEvent( 'invalid_file_extension', [
+        $allowedExtensions = array_map('strtolower', $allowedExtensions);
+        if (! in_array($extension, $allowedExtensions, true)) {
+            $this->logSecurityEvent('invalid_file_extension', [
                 'attempted_extension' => $extension,
-                'original_filename'   => $file->getClientOriginalName(),
-                'mime_type'           => $file->getMimeType(),
-                'ip_address'          => request()->ip(),
-            ] );
+                'original_filename' => $file->getClientOriginalName(),
+                'mime_type' => $file->getMimeType(),
+                'ip_address' => request()->ip(),
+            ]);
 
             throw new InvalidArgumentException(
-                __( "File extension ':extension' is not allowed. Allowed extensions: :allowed", ['extension' => $extension, 'allowed' => implode( ', ', $allowedExtensions )] ),
+                __("File extension ':extension' is not allowed. Allowed extensions: :allowed", ['extension' => $extension, 'allowed' => implode(', ', $allowedExtensions)]),
             );
         }
 
@@ -597,21 +577,19 @@ class SubmissionService
      *
      * @since 1.0.0
      *
-     * @param string               $eventType The type of security event.
-     * @param array<string, mixed> $context   Additional context data.
-     *
-     * @return void
+     * @param  string  $eventType  The type of security event.
+     * @param  array<string, mixed>  $context  Additional context data.
      */
-    protected function logSecurityEvent( string $eventType, array $context = [] ): void
+    protected function logSecurityEvent(string $eventType, array $context = []): void
     {
-        if ( ! config( 'artisanpack.forms.security.logging_enabled', true ) ) {
+        if (! config('artisanpack.forms.security.logging_enabled', true)) {
             return;
         }
 
-        Log::warning( "[Forms Security] {$eventType}", array_merge( [
+        Log::warning("[Forms Security] {$eventType}", array_merge([
             'event_type' => $eventType,
-            'timestamp'  => now()->toIso8601String(),
-        ], $context ) );
+            'timestamp' => now()->toIso8601String(),
+        ], $context));
     }
 
     /**
@@ -622,34 +600,33 @@ class SubmissionService
      *
      * @since 1.0.0
      *
-     * @param string $ipAddress The IP address to anonymize.
-     *
+     * @param  string  $ipAddress  The IP address to anonymize.
      * @return string The anonymized IP address.
      */
-    protected function anonymizeIpAddress( string $ipAddress ): string
+    protected function anonymizeIpAddress(string $ipAddress): string
     {
         // Handle IPv4
-        if ( filter_var( $ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
-            return preg_replace( '/\.\d+$/', '.0', $ipAddress ) ?? $ipAddress;
+        if (filter_var($ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            return preg_replace('/\.\d+$/', '.0', $ipAddress) ?? $ipAddress;
         }
 
         // Handle IPv6 - mask the last 80 bits (10 bytes)
-        if ( filter_var( $ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) ) {
+        if (filter_var($ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
             // Convert to binary representation (16 bytes)
-            $binary = @inet_pton( $ipAddress );
+            $binary = @inet_pton($ipAddress);
 
-            if ( false === $binary ) {
+            if ($binary === false) {
                 // Fallback if conversion fails
                 return $ipAddress;
             }
 
             // Zero out the last 10 bytes (80 bits) - keep first 6 bytes (48 bits / 3 groups)
-            $anonymized = substr( $binary, 0, 6 ) . str_repeat( "\x00", 10 );
+            $anonymized = substr($binary, 0, 6).str_repeat("\x00", 10);
 
             // Convert back to string representation
-            $result = @inet_ntop( $anonymized );
+            $result = @inet_ntop($anonymized);
 
-            if ( false === $result ) {
+            if ($result === false) {
                 // Fallback if conversion fails
                 return $ipAddress;
             }

--- a/src/Support/FieldRenderer.php
+++ b/src/Support/FieldRenderer.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Field renderer that applies the ap.forms.fieldRender filter.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Forms
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Forms\Support;
+
+use ArtisanPackUI\Forms\Models\FormField;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\View;
+
+/**
+ * Renders a form field and pipes the resulting HTML through the
+ * `ap.forms.fieldRender` filter so integration packages can wrap or mutate
+ * the markup for a specific field.
+ *
+ * @since 1.3.0
+ */
+class FieldRenderer
+{
+    /**
+     * Renders a field's blade partial and applies the fieldRender filter.
+     *
+     * @since 1.3.0
+     *
+     * @param  FormField  $field  The field being rendered.
+     * @param  mixed  $value  The current field value.
+     * @param  string|null  $error  The current validation error, if any.
+     *
+     * @return string The (possibly filtered) HTML.
+     */
+    public static function render( FormField $field, mixed $value = null, ?string $error = null ): string
+    {
+        $view = 'forms::components.fields.' . $field->type;
+
+        if ( ! View::exists( $view ) ) {
+            // A custom field type registered via `ap.forms.fieldTypes` may not ship a blade
+            // partial; swallow the render so one bad type doesn't crash the whole form,
+            // and give integration packages a shot at supplying the HTML via the filter.
+            Log::warning( 'ArtisanPackUI Forms: missing field partial', [
+                'type'     => $field->type,
+                'view'     => $view,
+                'field_id' => $field->id,
+            ] );
+
+            return applyFilters( 'ap.forms.fieldRender', '', $field );
+        }
+
+        $html = View::make( $view, [
+            'field' => $field,
+            'value' => $value,
+            'error' => $error,
+        ] )->render();
+
+        return applyFilters( 'ap.forms.fieldRender', $html, $field );
+    }
+}

--- a/src/Support/FiresValidationHooks.php
+++ b/src/Support/FiresValidationHooks.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Trait firing ap.forms.beforeValidate / ap.forms.validated action hooks.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Forms
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Forms\Support;
+
+/**
+ * Adds validation-lifecycle hooks to a FormRequest.
+ *
+ * Fires the `ap.forms.beforeValidate` action just before Laravel validates
+ * the request, and the `ap.forms.validated` action once validation has
+ * succeeded.
+ *
+ * A consuming class that also defines its own `prepareForValidation` or
+ * `passedValidation` silently shadows the trait method (PHP resolves class
+ * methods over trait methods). In that case call `$this->fireBeforeValidate()`
+ * / `$this->fireValidated()` from the override — `parent::` does NOT work
+ * because the parent is `Illuminate\Foundation\Http\FormRequest`, not the trait.
+ *
+ * Note: `passedValidation` runs after validation succeeds; a subscriber that
+ * mutates the request (e.g. via `$request->merge(...)`) bypasses re-validation.
+ *
+ * @since 1.3.0
+ */
+trait FiresValidationHooks
+{
+    /**
+     * Default `prepareForValidation` hook — shadowed by any class-level override.
+     *
+     * @since 1.3.0
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->fireBeforeValidate();
+    }
+
+    /**
+     * Default `passedValidation` hook — shadowed by any class-level override.
+     *
+     * @since 1.3.0
+     */
+    protected function passedValidation(): void
+    {
+        $this->fireValidated();
+    }
+
+    /**
+     * Fires the `ap.forms.beforeValidate` action. Call this from an overriding
+     * `prepareForValidation` to keep the hook firing.
+     *
+     * @since 1.3.0
+     */
+    protected function fireBeforeValidate(): void
+    {
+        doAction( 'ap.forms.beforeValidate', $this );
+    }
+
+    /**
+     * Fires the `ap.forms.validated` action. Call this from an overriding
+     * `passedValidation` to keep the hook firing.
+     *
+     * @since 1.3.0
+     */
+    protected function fireValidated(): void
+    {
+        doAction( 'ap.forms.validated', $this, $this->validated() );
+    }
+}

--- a/src/Support/HookAliases.php
+++ b/src/Support/HookAliases.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace ArtisanPackUI\Forms\Support;
 
@@ -23,33 +23,33 @@ class HookAliases
      */
     public static function register(): void
     {
-        if (! function_exists('deprecateHook')) {
+        if ( ! function_exists( 'deprecateHook' ) ) {
             return;
         }
 
         $aliases = [
-            'forms.field_types' => 'ap.forms.fieldTypes',
-            'forms.field_categories' => 'ap.forms.fieldCategories',
-            'forms.validation_rules' => 'ap.forms.validationRules',
-            'forms.form.created' => 'ap.forms.form.created',
-            'forms.form.updated' => 'ap.forms.form.updated',
-            'forms.form.deleted' => 'ap.forms.form.deleted',
-            'forms.submission.created' => 'ap.forms.submission.created',
-            'forms.submission.updated' => 'ap.forms.submission.updated',
-            'forms.submission.deleted' => 'ap.forms.submission.deleted',
-            'forms.webhook_payload' => 'ap.forms.webhookPayload',
-            'forms.settings_tabs' => 'ap.forms.settingsTabs',
-            'forms.submission_data' => 'ap.forms.submissionData',
-            'forms.export_headers' => 'ap.forms.exportHeaders',
-            'forms.export_data' => 'ap.forms.exportData',
-            'forms.notification_recipients' => 'ap.forms.notificationRecipients',
+            'forms.field_types'              => 'ap.forms.fieldTypes',
+            'forms.field_categories'         => 'ap.forms.fieldCategories',
+            'forms.validation_rules'         => 'ap.forms.validationRules',
+            'forms.form.created'             => 'ap.forms.form.created',
+            'forms.form.updated'             => 'ap.forms.form.updated',
+            'forms.form.deleted'             => 'ap.forms.form.deleted',
+            'forms.submission.created'       => 'ap.forms.submission.created',
+            'forms.submission.updated'       => 'ap.forms.submission.updated',
+            'forms.submission.deleted'       => 'ap.forms.submission.deleted',
+            'forms.webhook_payload'          => 'ap.forms.webhookPayload',
+            'forms.settings_tabs'            => 'ap.forms.settingsTabs',
+            'forms.submission_data'          => 'ap.forms.submissionData',
+            'forms.export_headers'           => 'ap.forms.exportHeaders',
+            'forms.export_data'              => 'ap.forms.exportData',
+            'forms.notification_recipients'  => 'ap.forms.notificationRecipients',
             'forms.notification.before_send' => 'ap.forms.notification.beforeSend',
-            'forms.notification.sent' => 'ap.forms.notification.sent',
-            'forms.notification_message' => 'ap.forms.notificationMessage',
+            'forms.notification.sent'        => 'ap.forms.notification.sent',
+            'forms.notification_message'     => 'ap.forms.notificationMessage',
         ];
 
-        foreach ($aliases as $old => $new) {
-            deprecateHook($old, $new);
+        foreach ( $aliases as $old => $new ) {
+            deprecateHook( $old, $new );
         }
     }
 }

--- a/src/Support/HookAliases.php
+++ b/src/Support/HookAliases.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ArtisanPackUI\Forms\Support;
+
+/**
+ * Registers backwards-compat aliases for renamed hooks.
+ *
+ * Subscribers on the old snake_case / unprefixed name continue firing
+ * (with an info-level deprecation log) after the Wave 2 hook rename
+ * to `ap.forms.*` camelCase. Aliases will be removed in the next major
+ * version.
+ *
+ * @since 1.3.0
+ */
+class HookAliases
+{
+    /**
+     * Register deprecation aliases for renamed forms hooks.
+     *
+     * @since 1.3.0
+     */
+    public static function register(): void
+    {
+        if (! function_exists('deprecateHook')) {
+            return;
+        }
+
+        $aliases = [
+            'forms.field_types' => 'ap.forms.fieldTypes',
+            'forms.field_categories' => 'ap.forms.fieldCategories',
+            'forms.validation_rules' => 'ap.forms.validationRules',
+            'forms.form.created' => 'ap.forms.form.created',
+            'forms.form.updated' => 'ap.forms.form.updated',
+            'forms.form.deleted' => 'ap.forms.form.deleted',
+            'forms.submission.created' => 'ap.forms.submission.created',
+            'forms.submission.updated' => 'ap.forms.submission.updated',
+            'forms.submission.deleted' => 'ap.forms.submission.deleted',
+            'forms.webhook_payload' => 'ap.forms.webhookPayload',
+            'forms.settings_tabs' => 'ap.forms.settingsTabs',
+            'forms.submission_data' => 'ap.forms.submissionData',
+            'forms.export_headers' => 'ap.forms.exportHeaders',
+            'forms.export_data' => 'ap.forms.exportData',
+            'forms.notification_recipients' => 'ap.forms.notificationRecipients',
+            'forms.notification.before_send' => 'ap.forms.notification.beforeSend',
+            'forms.notification.sent' => 'ap.forms.notification.sent',
+            'forms.notification_message' => 'ap.forms.notificationMessage',
+        ];
+
+        foreach ($aliases as $old => $new) {
+            deprecateHook($old, $new);
+        }
+    }
+}

--- a/tests/Feature/Events/FormEventsTest.php
+++ b/tests/Feature/Events/FormEventsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Forms\Events\FormCreated;
 use ArtisanPackUI\Forms\Events\FormDeleted;
@@ -8,93 +8,93 @@ use ArtisanPackUI\Forms\Events\FormUpdated;
 use ArtisanPackUI\Forms\Models\Form;
 use Illuminate\Support\Facades\Event;
 
-describe( 'Form Events', function (): void {
-    describe( 'FormCreated event', function (): void {
-        it( 'dispatches FormCreated event when form is created', function (): void {
-            Event::fake( [FormCreated::class] );
+describe('Form Events', function (): void {
+    describe('FormCreated event', function (): void {
+        it('dispatches FormCreated event when form is created', function (): void {
+            Event::fake([FormCreated::class]);
 
             $form = Form::factory()->create();
 
-            Event::assertDispatched( FormCreated::class, function ( FormCreated $event ) use ( $form ) {
+            Event::assertDispatched(FormCreated::class, function (FormCreated $event) use ($form) {
                 return $event->form->id === $form->id;
-            } );
-        } );
+            });
+        });
 
-        it( 'fires forms.form.created action hook when form is created', function (): void {
-            $hookFired    = false;
+        it('fires ap.forms.form.created action hook when form is created', function (): void {
+            $hookFired = false;
             $receivedForm = null;
 
-            addAction( 'forms.form.created', function ( Form $form ) use ( &$hookFired, &$receivedForm ): void {
-                $hookFired    = true;
+            addAction('ap.forms.form.created', function (Form $form) use (&$hookFired, &$receivedForm): void {
+                $hookFired = true;
                 $receivedForm = $form;
-            } );
+            });
 
             $form = Form::factory()->create();
 
-            expect( $hookFired )->toBeTrue()
-                ->and( $receivedForm )->not->toBeNull()
-                ->and( $receivedForm->id )->toBe( $form->id );
-        } );
-    } );
+            expect($hookFired)->toBeTrue()
+                ->and($receivedForm)->not->toBeNull()
+                ->and($receivedForm->id)->toBe($form->id);
+        });
+    });
 
-    describe( 'FormUpdated event', function (): void {
-        it( 'dispatches FormUpdated event when form is updated', function (): void {
-            Event::fake( [FormUpdated::class] );
+    describe('FormUpdated event', function (): void {
+        it('dispatches FormUpdated event when form is updated', function (): void {
+            Event::fake([FormUpdated::class]);
 
             $form = Form::factory()->create();
-            $form->update( ['name' => 'Updated Form Name'] );
+            $form->update(['name' => 'Updated Form Name']);
 
-            Event::assertDispatched( FormUpdated::class, function ( FormUpdated $event ) use ( $form ) {
+            Event::assertDispatched(FormUpdated::class, function (FormUpdated $event) use ($form) {
                 return $event->form->id === $form->id;
-            } );
-        } );
+            });
+        });
 
-        it( 'fires forms.form.updated action hook when form is updated', function (): void {
-            $hookFired    = false;
+        it('fires ap.forms.form.updated action hook when form is updated', function (): void {
+            $hookFired = false;
             $receivedForm = null;
 
-            addAction( 'forms.form.updated', function ( Form $form ) use ( &$hookFired, &$receivedForm ): void {
-                $hookFired    = true;
+            addAction('ap.forms.form.updated', function (Form $form) use (&$hookFired, &$receivedForm): void {
+                $hookFired = true;
                 $receivedForm = $form;
-            } );
+            });
 
             $form = Form::factory()->create();
-            $form->update( ['name' => 'Updated Form Name'] );
+            $form->update(['name' => 'Updated Form Name']);
 
-            expect( $hookFired )->toBeTrue()
-                ->and( $receivedForm )->not->toBeNull()
-                ->and( $receivedForm->id )->toBe( $form->id );
-        } );
-    } );
+            expect($hookFired)->toBeTrue()
+                ->and($receivedForm)->not->toBeNull()
+                ->and($receivedForm->id)->toBe($form->id);
+        });
+    });
 
-    describe( 'FormDeleted event', function (): void {
-        it( 'dispatches FormDeleted event when form is deleted', function (): void {
-            Event::fake( [FormDeleted::class] );
+    describe('FormDeleted event', function (): void {
+        it('dispatches FormDeleted event when form is deleted', function (): void {
+            Event::fake([FormDeleted::class]);
 
-            $form   = Form::factory()->create();
+            $form = Form::factory()->create();
             $formId = $form->id;
             $form->delete();
 
-            Event::assertDispatched( FormDeleted::class, function ( FormDeleted $event ) use ( $formId ) {
+            Event::assertDispatched(FormDeleted::class, function (FormDeleted $event) use ($formId) {
                 return $event->form->id === $formId;
-            } );
-        } );
+            });
+        });
 
-        it( 'fires forms.form.deleted action hook when form is deleted', function (): void {
-            $hookFired      = false;
+        it('fires ap.forms.form.deleted action hook when form is deleted', function (): void {
+            $hookFired = false;
             $receivedFormId = null;
 
-            addAction( 'forms.form.deleted', function ( Form $form ) use ( &$hookFired, &$receivedFormId ): void {
-                $hookFired      = true;
+            addAction('ap.forms.form.deleted', function (Form $form) use (&$hookFired, &$receivedFormId): void {
+                $hookFired = true;
                 $receivedFormId = $form->id;
-            } );
+            });
 
-            $form   = Form::factory()->create();
+            $form = Form::factory()->create();
             $formId = $form->id;
             $form->delete();
 
-            expect( $hookFired )->toBeTrue()
-                ->and( $receivedFormId )->toBe( $formId );
+            expect($hookFired)->toBeTrue()
+                ->and($receivedFormId)->toBe($formId);
         });
     });
 });

--- a/tests/Feature/Events/FormEventsTest.php
+++ b/tests/Feature/Events/FormEventsTest.php
@@ -93,8 +93,8 @@ describe( 'Form Events', function (): void {
             $formId = $form->id;
             $form->delete();
 
-            expect( $hookFired)->toBeTrue()
-                ->and( $receivedFormId)->toBe( $formId);
+            expect( $hookFired )->toBeTrue()
+                ->and( $receivedFormId )->toBe( $formId );
         });
     });
 });

--- a/tests/Feature/Events/FormEventsTest.php
+++ b/tests/Feature/Events/FormEventsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Forms\Events\FormCreated;
 use ArtisanPackUI\Forms\Events\FormDeleted;
@@ -8,93 +8,93 @@ use ArtisanPackUI\Forms\Events\FormUpdated;
 use ArtisanPackUI\Forms\Models\Form;
 use Illuminate\Support\Facades\Event;
 
-describe('Form Events', function (): void {
-    describe('FormCreated event', function (): void {
-        it('dispatches FormCreated event when form is created', function (): void {
-            Event::fake([FormCreated::class]);
+describe( 'Form Events', function (): void {
+    describe( 'FormCreated event', function (): void {
+        it( 'dispatches FormCreated event when form is created', function (): void {
+            Event::fake( [FormCreated::class] );
 
             $form = Form::factory()->create();
 
-            Event::assertDispatched(FormCreated::class, function (FormCreated $event) use ($form) {
+            Event::assertDispatched( FormCreated::class, function ( FormCreated $event ) use ( $form ) {
                 return $event->form->id === $form->id;
-            });
-        });
+            } );
+        } );
 
-        it('fires ap.forms.form.created action hook when form is created', function (): void {
-            $hookFired = false;
+        it( 'fires ap.forms.form.created action hook when form is created', function (): void {
+            $hookFired    = false;
             $receivedForm = null;
 
-            addAction('ap.forms.form.created', function (Form $form) use (&$hookFired, &$receivedForm): void {
-                $hookFired = true;
+            addAction( 'ap.forms.form.created', function ( Form $form ) use ( &$hookFired, &$receivedForm ): void {
+                $hookFired    = true;
                 $receivedForm = $form;
-            });
+            } );
 
             $form = Form::factory()->create();
 
-            expect($hookFired)->toBeTrue()
-                ->and($receivedForm)->not->toBeNull()
-                ->and($receivedForm->id)->toBe($form->id);
-        });
-    });
+            expect( $hookFired )->toBeTrue()
+                ->and( $receivedForm )->not->toBeNull()
+                ->and( $receivedForm->id )->toBe( $form->id );
+        } );
+    } );
 
-    describe('FormUpdated event', function (): void {
-        it('dispatches FormUpdated event when form is updated', function (): void {
-            Event::fake([FormUpdated::class]);
+    describe( 'FormUpdated event', function (): void {
+        it( 'dispatches FormUpdated event when form is updated', function (): void {
+            Event::fake( [FormUpdated::class] );
 
             $form = Form::factory()->create();
-            $form->update(['name' => 'Updated Form Name']);
+            $form->update( ['name' => 'Updated Form Name'] );
 
-            Event::assertDispatched(FormUpdated::class, function (FormUpdated $event) use ($form) {
+            Event::assertDispatched( FormUpdated::class, function ( FormUpdated $event ) use ( $form ) {
                 return $event->form->id === $form->id;
-            });
-        });
+            } );
+        } );
 
-        it('fires ap.forms.form.updated action hook when form is updated', function (): void {
-            $hookFired = false;
+        it( 'fires ap.forms.form.updated action hook when form is updated', function (): void {
+            $hookFired    = false;
             $receivedForm = null;
 
-            addAction('ap.forms.form.updated', function (Form $form) use (&$hookFired, &$receivedForm): void {
-                $hookFired = true;
+            addAction( 'ap.forms.form.updated', function ( Form $form ) use ( &$hookFired, &$receivedForm ): void {
+                $hookFired    = true;
                 $receivedForm = $form;
-            });
+            } );
 
             $form = Form::factory()->create();
-            $form->update(['name' => 'Updated Form Name']);
+            $form->update( ['name' => 'Updated Form Name'] );
 
-            expect($hookFired)->toBeTrue()
-                ->and($receivedForm)->not->toBeNull()
-                ->and($receivedForm->id)->toBe($form->id);
-        });
-    });
+            expect( $hookFired )->toBeTrue()
+                ->and( $receivedForm )->not->toBeNull()
+                ->and( $receivedForm->id )->toBe( $form->id );
+        } );
+    } );
 
-    describe('FormDeleted event', function (): void {
-        it('dispatches FormDeleted event when form is deleted', function (): void {
-            Event::fake([FormDeleted::class]);
+    describe( 'FormDeleted event', function (): void {
+        it( 'dispatches FormDeleted event when form is deleted', function (): void {
+            Event::fake( [FormDeleted::class] );
 
-            $form = Form::factory()->create();
+            $form   = Form::factory()->create();
             $formId = $form->id;
             $form->delete();
 
-            Event::assertDispatched(FormDeleted::class, function (FormDeleted $event) use ($formId) {
+            Event::assertDispatched( FormDeleted::class, function ( FormDeleted $event ) use ( $formId ) {
                 return $event->form->id === $formId;
-            });
-        });
+            } );
+        } );
 
-        it('fires ap.forms.form.deleted action hook when form is deleted', function (): void {
-            $hookFired = false;
+        it( 'fires ap.forms.form.deleted action hook when form is deleted', function (): void {
+            $hookFired      = false;
             $receivedFormId = null;
 
-            addAction('ap.forms.form.deleted', function (Form $form) use (&$hookFired, &$receivedFormId): void {
-                $hookFired = true;
+            addAction( 'ap.forms.form.deleted', function ( Form $form ) use ( &$hookFired, &$receivedFormId ): void {
+                $hookFired      = true;
                 $receivedFormId = $form->id;
-            });
+            } );
 
-            $form = Form::factory()->create();
+            $form   = Form::factory()->create();
             $formId = $form->id;
             $form->delete();
 
-            expect($hookFired)->toBeTrue()
-                ->and($receivedFormId)->toBe($formId);
+            expect( $hookFired)->toBeTrue()
+                ->and( $receivedFormId)->toBe( $formId);
         });
     });
 });

--- a/tests/Feature/Events/SubmissionEventsTest.php
+++ b/tests/Feature/Events/SubmissionEventsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Forms\Events\FormSubmitted;
 use ArtisanPackUI\Forms\Events\SubmissionDeleted;
@@ -9,99 +9,99 @@ use ArtisanPackUI\Forms\Models\Form;
 use ArtisanPackUI\Forms\Models\FormSubmission;
 use Illuminate\Support\Facades\Event;
 
-describe('Submission Events', function (): void {
-    describe('FormSubmitted event', function (): void {
-        it('dispatches FormSubmitted event when submission is created', function (): void {
-            Event::fake([FormSubmitted::class]);
+describe( 'Submission Events', function (): void {
+    describe( 'FormSubmitted event', function (): void {
+        it( 'dispatches FormSubmitted event when submission is created', function (): void {
+            Event::fake( [FormSubmitted::class] );
 
-            $form = Form::factory()->create();
-            $submission = FormSubmission::factory()->for($form)->create();
+            $form       = Form::factory()->create();
+            $submission = FormSubmission::factory()->for( $form )->create();
 
-            Event::assertDispatched(FormSubmitted::class, function (FormSubmitted $event) use ($submission) {
+            Event::assertDispatched( FormSubmitted::class, function ( FormSubmitted $event ) use ( $submission ) {
                 return $event->submission->id === $submission->id;
-            });
-        });
+            } );
+        } );
 
-        it('fires ap.forms.submission.created action hook when submission is created', function (): void {
-            $hookFired = false;
+        it( 'fires ap.forms.submission.created action hook when submission is created', function (): void {
+            $hookFired          = false;
             $receivedSubmission = null;
 
-            addAction('ap.forms.submission.created', function (FormSubmission $submission) use (&$hookFired, &$receivedSubmission): void {
-                $hookFired = true;
+            addAction( 'ap.forms.submission.created', function ( FormSubmission $submission ) use ( &$hookFired, &$receivedSubmission ): void {
+                $hookFired          = true;
                 $receivedSubmission = $submission;
-            });
+            } );
 
-            $form = Form::factory()->create();
-            $submission = FormSubmission::factory()->for($form)->create();
+            $form       = Form::factory()->create();
+            $submission = FormSubmission::factory()->for( $form )->create();
 
-            expect($hookFired)->toBeTrue()
-                ->and($receivedSubmission)->not->toBeNull()
-                ->and($receivedSubmission->id)->toBe($submission->id);
-        });
-    });
+            expect( $hookFired )->toBeTrue()
+                ->and( $receivedSubmission )->not->toBeNull()
+                ->and( $receivedSubmission->id )->toBe( $submission->id );
+        } );
+    } );
 
-    describe('SubmissionUpdated event', function (): void {
-        it('dispatches SubmissionUpdated event when submission is updated', function (): void {
-            Event::fake([SubmissionUpdated::class]);
+    describe( 'SubmissionUpdated event', function (): void {
+        it( 'dispatches SubmissionUpdated event when submission is updated', function (): void {
+            Event::fake( [SubmissionUpdated::class] );
 
-            $form = Form::factory()->create();
-            $submission = FormSubmission::factory()->for($form)->create();
-            $submission->update(['is_read' => true]);
+            $form       = Form::factory()->create();
+            $submission = FormSubmission::factory()->for( $form )->create();
+            $submission->update( ['is_read' => true] );
 
-            Event::assertDispatched(SubmissionUpdated::class, function (SubmissionUpdated $event) use ($submission) {
+            Event::assertDispatched( SubmissionUpdated::class, function ( SubmissionUpdated $event ) use ( $submission ) {
                 return $event->submission->id === $submission->id;
-            });
-        });
+            } );
+        } );
 
-        it('fires ap.forms.submission.updated action hook when submission is updated', function (): void {
-            $hookFired = false;
+        it( 'fires ap.forms.submission.updated action hook when submission is updated', function (): void {
+            $hookFired          = false;
             $receivedSubmission = null;
 
-            addAction('ap.forms.submission.updated', function (FormSubmission $submission) use (&$hookFired, &$receivedSubmission): void {
-                $hookFired = true;
+            addAction( 'ap.forms.submission.updated', function ( FormSubmission $submission ) use ( &$hookFired, &$receivedSubmission ): void {
+                $hookFired          = true;
                 $receivedSubmission = $submission;
-            });
+            } );
 
-            $form = Form::factory()->create();
-            $submission = FormSubmission::factory()->for($form)->create();
-            $submission->update(['is_read' => true]);
+            $form       = Form::factory()->create();
+            $submission = FormSubmission::factory()->for( $form )->create();
+            $submission->update( ['is_read' => true] );
 
-            expect($hookFired)->toBeTrue()
-                ->and($receivedSubmission)->not->toBeNull()
-                ->and($receivedSubmission->id)->toBe($submission->id);
-        });
-    });
+            expect( $hookFired )->toBeTrue()
+                ->and( $receivedSubmission )->not->toBeNull()
+                ->and( $receivedSubmission->id )->toBe( $submission->id );
+        } );
+    } );
 
-    describe('SubmissionDeleted event', function (): void {
-        it('dispatches SubmissionDeleted event when submission is deleted', function (): void {
-            Event::fake([SubmissionDeleted::class]);
+    describe( 'SubmissionDeleted event', function (): void {
+        it( 'dispatches SubmissionDeleted event when submission is deleted', function (): void {
+            Event::fake( [SubmissionDeleted::class] );
 
-            $form = Form::factory()->create();
-            $submission = FormSubmission::factory()->for($form)->create();
+            $form         = Form::factory()->create();
+            $submission   = FormSubmission::factory()->for( $form )->create();
             $submissionId = $submission->id;
             $submission->delete();
 
-            Event::assertDispatched(SubmissionDeleted::class, function (SubmissionDeleted $event) use ($submissionId) {
+            Event::assertDispatched( SubmissionDeleted::class, function ( SubmissionDeleted $event ) use ( $submissionId ) {
                 return $event->submission->id === $submissionId;
-            });
-        });
+            } );
+        } );
 
-        it('fires ap.forms.submission.deleted action hook when submission is deleted', function (): void {
-            $hookFired = false;
+        it( 'fires ap.forms.submission.deleted action hook when submission is deleted', function (): void {
+            $hookFired            = false;
             $receivedSubmissionId = null;
 
-            addAction('ap.forms.submission.deleted', function (FormSubmission $submission) use (&$hookFired, &$receivedSubmissionId): void {
-                $hookFired = true;
+            addAction( 'ap.forms.submission.deleted', function ( FormSubmission $submission ) use ( &$hookFired, &$receivedSubmissionId ): void {
+                $hookFired            = true;
                 $receivedSubmissionId = $submission->id;
-            });
+            } );
 
-            $form = Form::factory()->create();
-            $submission = FormSubmission::factory()->for($form)->create();
+            $form         = Form::factory()->create();
+            $submission   = FormSubmission::factory()->for( $form )->create();
             $submissionId = $submission->id;
             $submission->delete();
 
-            expect($hookFired)->toBeTrue()
-                ->and($receivedSubmissionId)->toBe($submissionId);
+            expect( $hookFired)->toBeTrue()
+                ->and( $receivedSubmissionId)->toBe( $submissionId);
         });
     });
 });

--- a/tests/Feature/Events/SubmissionEventsTest.php
+++ b/tests/Feature/Events/SubmissionEventsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Forms\Events\FormSubmitted;
 use ArtisanPackUI\Forms\Events\SubmissionDeleted;
@@ -9,99 +9,99 @@ use ArtisanPackUI\Forms\Models\Form;
 use ArtisanPackUI\Forms\Models\FormSubmission;
 use Illuminate\Support\Facades\Event;
 
-describe( 'Submission Events', function (): void {
-    describe( 'FormSubmitted event', function (): void {
-        it( 'dispatches FormSubmitted event when submission is created', function (): void {
-            Event::fake( [FormSubmitted::class] );
+describe('Submission Events', function (): void {
+    describe('FormSubmitted event', function (): void {
+        it('dispatches FormSubmitted event when submission is created', function (): void {
+            Event::fake([FormSubmitted::class]);
 
-            $form       = Form::factory()->create();
-            $submission = FormSubmission::factory()->for( $form )->create();
+            $form = Form::factory()->create();
+            $submission = FormSubmission::factory()->for($form)->create();
 
-            Event::assertDispatched( FormSubmitted::class, function ( FormSubmitted $event ) use ( $submission ) {
+            Event::assertDispatched(FormSubmitted::class, function (FormSubmitted $event) use ($submission) {
                 return $event->submission->id === $submission->id;
-            } );
-        } );
+            });
+        });
 
-        it( 'fires forms.submission.created action hook when submission is created', function (): void {
-            $hookFired          = false;
+        it('fires ap.forms.submission.created action hook when submission is created', function (): void {
+            $hookFired = false;
             $receivedSubmission = null;
 
-            addAction( 'forms.submission.created', function ( FormSubmission $submission ) use ( &$hookFired, &$receivedSubmission ): void {
-                $hookFired          = true;
+            addAction('ap.forms.submission.created', function (FormSubmission $submission) use (&$hookFired, &$receivedSubmission): void {
+                $hookFired = true;
                 $receivedSubmission = $submission;
-            } );
+            });
 
-            $form       = Form::factory()->create();
-            $submission = FormSubmission::factory()->for( $form )->create();
+            $form = Form::factory()->create();
+            $submission = FormSubmission::factory()->for($form)->create();
 
-            expect( $hookFired )->toBeTrue()
-                ->and( $receivedSubmission )->not->toBeNull()
-                ->and( $receivedSubmission->id )->toBe( $submission->id );
-        } );
-    } );
+            expect($hookFired)->toBeTrue()
+                ->and($receivedSubmission)->not->toBeNull()
+                ->and($receivedSubmission->id)->toBe($submission->id);
+        });
+    });
 
-    describe( 'SubmissionUpdated event', function (): void {
-        it( 'dispatches SubmissionUpdated event when submission is updated', function (): void {
-            Event::fake( [SubmissionUpdated::class] );
+    describe('SubmissionUpdated event', function (): void {
+        it('dispatches SubmissionUpdated event when submission is updated', function (): void {
+            Event::fake([SubmissionUpdated::class]);
 
-            $form       = Form::factory()->create();
-            $submission = FormSubmission::factory()->for( $form )->create();
-            $submission->update( ['is_read' => true] );
+            $form = Form::factory()->create();
+            $submission = FormSubmission::factory()->for($form)->create();
+            $submission->update(['is_read' => true]);
 
-            Event::assertDispatched( SubmissionUpdated::class, function ( SubmissionUpdated $event ) use ( $submission ) {
+            Event::assertDispatched(SubmissionUpdated::class, function (SubmissionUpdated $event) use ($submission) {
                 return $event->submission->id === $submission->id;
-            } );
-        } );
+            });
+        });
 
-        it( 'fires forms.submission.updated action hook when submission is updated', function (): void {
-            $hookFired          = false;
+        it('fires ap.forms.submission.updated action hook when submission is updated', function (): void {
+            $hookFired = false;
             $receivedSubmission = null;
 
-            addAction( 'forms.submission.updated', function ( FormSubmission $submission ) use ( &$hookFired, &$receivedSubmission ): void {
-                $hookFired          = true;
+            addAction('ap.forms.submission.updated', function (FormSubmission $submission) use (&$hookFired, &$receivedSubmission): void {
+                $hookFired = true;
                 $receivedSubmission = $submission;
-            } );
+            });
 
-            $form       = Form::factory()->create();
-            $submission = FormSubmission::factory()->for( $form )->create();
-            $submission->update( ['is_read' => true] );
+            $form = Form::factory()->create();
+            $submission = FormSubmission::factory()->for($form)->create();
+            $submission->update(['is_read' => true]);
 
-            expect( $hookFired )->toBeTrue()
-                ->and( $receivedSubmission )->not->toBeNull()
-                ->and( $receivedSubmission->id )->toBe( $submission->id );
-        } );
-    } );
+            expect($hookFired)->toBeTrue()
+                ->and($receivedSubmission)->not->toBeNull()
+                ->and($receivedSubmission->id)->toBe($submission->id);
+        });
+    });
 
-    describe( 'SubmissionDeleted event', function (): void {
-        it( 'dispatches SubmissionDeleted event when submission is deleted', function (): void {
-            Event::fake( [SubmissionDeleted::class] );
+    describe('SubmissionDeleted event', function (): void {
+        it('dispatches SubmissionDeleted event when submission is deleted', function (): void {
+            Event::fake([SubmissionDeleted::class]);
 
-            $form         = Form::factory()->create();
-            $submission   = FormSubmission::factory()->for( $form )->create();
+            $form = Form::factory()->create();
+            $submission = FormSubmission::factory()->for($form)->create();
             $submissionId = $submission->id;
             $submission->delete();
 
-            Event::assertDispatched( SubmissionDeleted::class, function ( SubmissionDeleted $event ) use ( $submissionId ) {
+            Event::assertDispatched(SubmissionDeleted::class, function (SubmissionDeleted $event) use ($submissionId) {
                 return $event->submission->id === $submissionId;
-            } );
-        } );
+            });
+        });
 
-        it( 'fires forms.submission.deleted action hook when submission is deleted', function (): void {
-            $hookFired            = false;
+        it('fires ap.forms.submission.deleted action hook when submission is deleted', function (): void {
+            $hookFired = false;
             $receivedSubmissionId = null;
 
-            addAction( 'forms.submission.deleted', function ( FormSubmission $submission ) use ( &$hookFired, &$receivedSubmissionId ): void {
-                $hookFired            = true;
+            addAction('ap.forms.submission.deleted', function (FormSubmission $submission) use (&$hookFired, &$receivedSubmissionId): void {
+                $hookFired = true;
                 $receivedSubmissionId = $submission->id;
-            } );
+            });
 
-            $form         = Form::factory()->create();
-            $submission   = FormSubmission::factory()->for( $form )->create();
+            $form = Form::factory()->create();
+            $submission = FormSubmission::factory()->for($form)->create();
             $submissionId = $submission->id;
             $submission->delete();
 
-            expect( $hookFired )->toBeTrue()
-                ->and( $receivedSubmissionId )->toBe( $submissionId );
+            expect($hookFired)->toBeTrue()
+                ->and($receivedSubmissionId)->toBe($submissionId);
         });
     });
 });

--- a/tests/Feature/Events/SubmissionEventsTest.php
+++ b/tests/Feature/Events/SubmissionEventsTest.php
@@ -100,8 +100,8 @@ describe( 'Submission Events', function (): void {
             $submissionId = $submission->id;
             $submission->delete();
 
-            expect( $hookFired)->toBeTrue()
-                ->and( $receivedSubmissionId)->toBe( $submissionId);
+            expect( $hookFired )->toBeTrue()
+                ->and( $receivedSubmissionId )->toBe( $submissionId );
         });
     });
 });

--- a/tests/Feature/Integrations/FilterHooksTest.php
+++ b/tests/Feature/Integrations/FilterHooksTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Forms\Config\FieldTypes;
 use ArtisanPackUI\Forms\Models\Form;
@@ -9,196 +9,196 @@ use ArtisanPackUI\Forms\Services\ExportService;
 use ArtisanPackUI\Forms\Services\IntegrationService;
 use ArtisanPackUI\Forms\Services\SubmissionService;
 
-beforeEach(function (): void {
+beforeEach( function (): void {
     // Reset any registered filters between tests
-    if (function_exists('removeAllFilters')) {
-        removeAllFilters('ap.forms.fieldTypes');
-        removeAllFilters('ap.forms.fieldCategories');
-        removeAllFilters('ap.forms.validationRules');
-        removeAllFilters('ap.forms.submissionData');
-        removeAllFilters('ap.forms.exportHeaders');
-        removeAllFilters('ap.forms.exportData');
-        removeAllFilters('ap.forms.settingsTabs');
+    if ( function_exists( 'removeAllFilters' ) ) {
+        removeAllFilters( 'ap.forms.fieldTypes' );
+        removeAllFilters( 'ap.forms.fieldCategories' );
+        removeAllFilters( 'ap.forms.validationRules' );
+        removeAllFilters( 'ap.forms.submissionData' );
+        removeAllFilters( 'ap.forms.exportHeaders' );
+        removeAllFilters( 'ap.forms.exportData' );
+        removeAllFilters( 'ap.forms.settingsTabs' );
     }
-});
+} );
 
-describe('Filter Hooks', function (): void {
-    describe('ap.forms.fieldTypes filter', function (): void {
-        it('allows registering custom field types', function (): void {
-            if (! function_exists('addFilter')) {
-                $this->markTestSkipped('Hook system not available');
+describe( 'Filter Hooks', function (): void {
+    describe( 'ap.forms.fieldTypes filter', function (): void {
+        it( 'allows registering custom field types', function (): void {
+            if ( ! function_exists( 'addFilter' ) ) {
+                $this->markTestSkipped( 'Hook system not available' );
             }
 
-            addFilter('ap.forms.fieldTypes', function (array $types): array {
+            addFilter( 'ap.forms.fieldTypes', function ( array $types ): array {
                 $types['custom_rating'] = [
-                    'label' => 'Star Rating',
-                    'icon' => 'o-star',
-                    'category' => 'advanced',
-                    'has_options' => false,
-                    'supports_placeholder' => false,
+                    'label'                  => 'Star Rating',
+                    'icon'                   => 'o-star',
+                    'category'               => 'advanced',
+                    'has_options'            => false,
+                    'supports_placeholder'   => false,
                     'supports_default_value' => true,
-                    'validation_options' => ['min', 'max'],
-                    'defaults' => [
+                    'validation_options'     => ['min', 'max'],
+                    'defaults'               => [
                         'label' => 'Rating',
                     ],
                 ];
 
                 return $types;
-            });
+            } );
 
             $types = FieldTypes::getTypes();
 
-            expect($types)->toHaveKey('custom_rating')
-                ->and($types['custom_rating']['label'])->toBe('Star Rating');
-        });
+            expect( $types )->toHaveKey( 'custom_rating' )
+                ->and( $types['custom_rating']['label'] )->toBe( 'Star Rating' );
+        } );
 
-        it('can modify existing field types', function (): void {
-            if (! function_exists('addFilter')) {
-                $this->markTestSkipped('Hook system not available');
+        it( 'can modify existing field types', function (): void {
+            if ( ! function_exists( 'addFilter' ) ) {
+                $this->markTestSkipped( 'Hook system not available' );
             }
 
-            addFilter('ap.forms.fieldTypes', function (array $types): array {
+            addFilter( 'ap.forms.fieldTypes', function ( array $types ): array {
                 $types['text']['label'] = 'Modified Text Input';
 
                 return $types;
-            });
+            } );
 
             $types = FieldTypes::getTypes();
 
-            expect($types['text']['label'])->toBe('Modified Text Input');
-        });
-    });
+            expect( $types['text']['label'] )->toBe( 'Modified Text Input' );
+        } );
+    } );
 
-    describe('ap.forms.fieldCategories filter', function (): void {
-        it('allows registering custom field categories', function (): void {
-            if (! function_exists('addFilter')) {
-                $this->markTestSkipped('Hook system not available');
+    describe( 'ap.forms.fieldCategories filter', function (): void {
+        it( 'allows registering custom field categories', function (): void {
+            if ( ! function_exists( 'addFilter' ) ) {
+                $this->markTestSkipped( 'Hook system not available' );
             }
 
-            addFilter('ap.forms.fieldCategories', function (array $categories): array {
+            addFilter( 'ap.forms.fieldCategories', function ( array $categories ): array {
                 $categories['custom'] = [
-                    'label' => 'Custom Fields',
+                    'label'  => 'Custom Fields',
                     'fields' => ['custom_rating'],
                 ];
 
                 return $categories;
-            });
+            } );
 
             $categories = FieldTypes::getCategoriesFiltered();
 
-            expect($categories)->toHaveKey('custom')
-                ->and($categories['custom']['label'])->toBe('Custom Fields');
-        });
-    });
+            expect( $categories )->toHaveKey( 'custom' )
+                ->and( $categories['custom']['label'] )->toBe( 'Custom Fields' );
+        } );
+    } );
 
-    describe('ap.forms.validationRules filter', function (): void {
-        it('allows modifying validation rules for a field', function (): void {
-            if (! function_exists('addFilter')) {
-                $this->markTestSkipped('Hook system not available');
+    describe( 'ap.forms.validationRules filter', function (): void {
+        it( 'allows modifying validation rules for a field', function (): void {
+            if ( ! function_exists( 'addFilter' ) ) {
+                $this->markTestSkipped( 'Hook system not available' );
             }
 
-            addFilter('ap.forms.validationRules', function (array $rules, FormField $field): array {
+            addFilter( 'ap.forms.validationRules', function ( array $rules, FormField $field ): array {
                 // Add a custom rule for email fields
-                if ($field->type === 'email') {
+                if ( 'email' === $field->type ) {
                     $rules[] = 'ends_with:@example.com';
                 }
 
                 return $rules;
-            });
+            } );
 
-            $form = Form::factory()->create();
-            $field = FormField::factory()->for($form)->create([
-                'type' => 'email',
+            $form  = Form::factory()->create();
+            $field = FormField::factory()->for( $form )->create( [
+                'type'        => 'email',
                 'is_required' => true,
-            ]);
+            ] );
 
             $rules = $field->buildValidationRules();
 
-            expect($rules)->toContain('email')
-                ->and($rules)->toContain('ends_with:@example.com');
-        });
-    });
+            expect( $rules )->toContain( 'email' )
+                ->and( $rules )->toContain( 'ends_with:@example.com' );
+        } );
+    } );
 
-    describe('ap.forms.submissionData filter', function (): void {
-        it('allows modifying submission data before saving', function (): void {
-            if (! function_exists('addFilter')) {
-                $this->markTestSkipped('Hook system not available');
+    describe( 'ap.forms.submissionData filter', function (): void {
+        it( 'allows modifying submission data before saving', function (): void {
+            if ( ! function_exists( 'addFilter' ) ) {
+                $this->markTestSkipped( 'Hook system not available' );
             }
 
-            addFilter('ap.forms.submissionData', function (array $data, Form $form): array {
+            addFilter( 'ap.forms.submissionData', function ( array $data, Form $form ): array {
                 // Add a tracking field to all submissions
-                $data['_tracking_id'] = 'TRACK-'.uniqid();
+                $data['_tracking_id'] = 'TRACK-' . uniqid();
 
                 return $data;
-            });
+            } );
 
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->create(['name' => 'name', 'type' => 'text']);
+            FormField::factory()->for( $form )->create( ['name' => 'name', 'type' => 'text'] );
 
-            $service = app(SubmissionService::class);
+            $service = app( SubmissionService::class );
 
             // Note: The filter modifies the data before processing
             // but in practice, the tracking_id would need to be stored
             // This test verifies the filter is called
-            $submission = $service->create($form, ['name' => 'Test User'], [], []);
+            $submission = $service->create( $form, ['name' => 'Test User'], [], [] );
 
-            expect($submission)->not->toBeNull();
-        });
-    });
+            expect( $submission )->not->toBeNull();
+        } );
+    } );
 
-    describe('ap.forms.exportHeaders filter', function (): void {
-        it('allows modifying export headers', function (): void {
-            if (! function_exists('addFilter')) {
-                $this->markTestSkipped('Hook system not available');
+    describe( 'ap.forms.exportHeaders filter', function (): void {
+        it( 'allows modifying export headers', function (): void {
+            if ( ! function_exists( 'addFilter' ) ) {
+                $this->markTestSkipped( 'Hook system not available' );
             }
 
-            addFilter('ap.forms.exportHeaders', function (array $headers, Form $form): array {
+            addFilter( 'ap.forms.exportHeaders', function ( array $headers, Form $form ): array {
                 $headers[] = 'Custom Column';
 
                 return $headers;
-            });
+            } );
 
-            $form = Form::factory()->create();
-            $service = app(ExportService::class);
+            $form    = Form::factory()->create();
+            $service = app( ExportService::class );
 
-            $headers = $service->buildHeaders($form);
+            $headers = $service->buildHeaders( $form );
 
-            expect($headers)->toContain('Custom Column');
-        });
-    });
+            expect( $headers )->toContain( 'Custom Column' );
+        } );
+    } );
 
-    describe('ap.forms.settingsTabs filter', function (): void {
-        it('allows registering custom settings tabs', function (): void {
-            if (! function_exists('addFilter')) {
-                $this->markTestSkipped('Hook system not available');
+    describe( 'ap.forms.settingsTabs filter', function (): void {
+        it( 'allows registering custom settings tabs', function (): void {
+            if ( ! function_exists( 'addFilter' ) ) {
+                $this->markTestSkipped( 'Hook system not available' );
             }
 
-            addFilter('ap.forms.settingsTabs', function (array $tabs): array {
+            addFilter( 'ap.forms.settingsTabs', function ( array $tabs ): array {
                 $tabs[] = [
-                    'id' => 'mailchimp',
-                    'label' => 'Mailchimp',
-                    'icon' => 'o-envelope',
-                    'component' => 'mailchimp-settings',
+                    'id'          => 'mailchimp',
+                    'label'       => 'Mailchimp',
+                    'icon'        => 'o-envelope',
+                    'component'   => 'mailchimp-settings',
                     'description' => 'Configure Mailchimp integration',
                 ];
 
                 return $tabs;
-            });
+            } );
 
-            $service = app(IntegrationService::class);
-            $tabs = $service->getSettingsTabs();
+            $service = app( IntegrationService::class );
+            $tabs    = $service->getSettingsTabs();
 
-            expect($tabs)->toHaveCount(1)
-                ->and($tabs[0]['id'])->toBe('mailchimp')
-                ->and($tabs[0]['label'])->toBe('Mailchimp');
+            expect( $tabs )->toHaveCount( 1 )
+                ->and( $tabs[0]['id'] )->toBe( 'mailchimp' )
+                ->and( $tabs[0]['label'])->toBe( 'Mailchimp');
         });
 
-        it('returns empty array when no tabs registered', function (): void {
-            $service = app(IntegrationService::class);
-            $tabs = $service->getSettingsTabs();
+        it( 'returns empty array when no tabs registered', function (): void {
+            $service = app( IntegrationService::class);
+            $tabs    = $service->getSettingsTabs();
 
-            expect($tabs)->toBeArray()
-                ->and($tabs)->toBeEmpty();
+            expect( $tabs)->toBeArray()
+                ->and( $tabs)->toBeEmpty();
         });
     });
 });

--- a/tests/Feature/Integrations/FilterHooksTest.php
+++ b/tests/Feature/Integrations/FilterHooksTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Forms\Config\FieldTypes;
 use ArtisanPackUI\Forms\Models\Form;
@@ -9,196 +9,196 @@ use ArtisanPackUI\Forms\Services\ExportService;
 use ArtisanPackUI\Forms\Services\IntegrationService;
 use ArtisanPackUI\Forms\Services\SubmissionService;
 
-beforeEach( function (): void {
+beforeEach(function (): void {
     // Reset any registered filters between tests
-    if ( function_exists( 'removeAllFilters' ) ) {
-        removeAllFilters( 'forms.field_types' );
-        removeAllFilters( 'forms.field_categories' );
-        removeAllFilters( 'forms.validation_rules' );
-        removeAllFilters( 'forms.submission_data' );
-        removeAllFilters( 'forms.export_headers' );
-        removeAllFilters( 'forms.export_data' );
-        removeAllFilters( 'forms.settings_tabs' );
+    if (function_exists('removeAllFilters')) {
+        removeAllFilters('ap.forms.fieldTypes');
+        removeAllFilters('ap.forms.fieldCategories');
+        removeAllFilters('ap.forms.validationRules');
+        removeAllFilters('ap.forms.submissionData');
+        removeAllFilters('ap.forms.exportHeaders');
+        removeAllFilters('ap.forms.exportData');
+        removeAllFilters('ap.forms.settingsTabs');
     }
-} );
+});
 
-describe( 'Filter Hooks', function (): void {
-    describe( 'forms.field_types filter', function (): void {
-        it( 'allows registering custom field types', function (): void {
-            if ( ! function_exists( 'addFilter' ) ) {
-                $this->markTestSkipped( 'Hook system not available' );
+describe('Filter Hooks', function (): void {
+    describe('ap.forms.fieldTypes filter', function (): void {
+        it('allows registering custom field types', function (): void {
+            if (! function_exists('addFilter')) {
+                $this->markTestSkipped('Hook system not available');
             }
 
-            addFilter( 'forms.field_types', function ( array $types ): array {
+            addFilter('ap.forms.fieldTypes', function (array $types): array {
                 $types['custom_rating'] = [
-                    'label'                  => 'Star Rating',
-                    'icon'                   => 'o-star',
-                    'category'               => 'advanced',
-                    'has_options'            => false,
-                    'supports_placeholder'   => false,
+                    'label' => 'Star Rating',
+                    'icon' => 'o-star',
+                    'category' => 'advanced',
+                    'has_options' => false,
+                    'supports_placeholder' => false,
                     'supports_default_value' => true,
-                    'validation_options'     => ['min', 'max'],
-                    'defaults'               => [
+                    'validation_options' => ['min', 'max'],
+                    'defaults' => [
                         'label' => 'Rating',
                     ],
                 ];
 
                 return $types;
-            } );
+            });
 
             $types = FieldTypes::getTypes();
 
-            expect( $types )->toHaveKey( 'custom_rating' )
-                ->and( $types['custom_rating']['label'] )->toBe( 'Star Rating' );
-        } );
+            expect($types)->toHaveKey('custom_rating')
+                ->and($types['custom_rating']['label'])->toBe('Star Rating');
+        });
 
-        it( 'can modify existing field types', function (): void {
-            if ( ! function_exists( 'addFilter' ) ) {
-                $this->markTestSkipped( 'Hook system not available' );
+        it('can modify existing field types', function (): void {
+            if (! function_exists('addFilter')) {
+                $this->markTestSkipped('Hook system not available');
             }
 
-            addFilter( 'forms.field_types', function ( array $types ): array {
+            addFilter('ap.forms.fieldTypes', function (array $types): array {
                 $types['text']['label'] = 'Modified Text Input';
 
                 return $types;
-            } );
+            });
 
             $types = FieldTypes::getTypes();
 
-            expect( $types['text']['label'] )->toBe( 'Modified Text Input' );
-        } );
-    } );
+            expect($types['text']['label'])->toBe('Modified Text Input');
+        });
+    });
 
-    describe( 'forms.field_categories filter', function (): void {
-        it( 'allows registering custom field categories', function (): void {
-            if ( ! function_exists( 'addFilter' ) ) {
-                $this->markTestSkipped( 'Hook system not available' );
+    describe('ap.forms.fieldCategories filter', function (): void {
+        it('allows registering custom field categories', function (): void {
+            if (! function_exists('addFilter')) {
+                $this->markTestSkipped('Hook system not available');
             }
 
-            addFilter( 'forms.field_categories', function ( array $categories ): array {
+            addFilter('ap.forms.fieldCategories', function (array $categories): array {
                 $categories['custom'] = [
-                    'label'  => 'Custom Fields',
+                    'label' => 'Custom Fields',
                     'fields' => ['custom_rating'],
                 ];
 
                 return $categories;
-            } );
+            });
 
             $categories = FieldTypes::getCategoriesFiltered();
 
-            expect( $categories )->toHaveKey( 'custom' )
-                ->and( $categories['custom']['label'] )->toBe( 'Custom Fields' );
-        } );
-    } );
+            expect($categories)->toHaveKey('custom')
+                ->and($categories['custom']['label'])->toBe('Custom Fields');
+        });
+    });
 
-    describe( 'forms.validation_rules filter', function (): void {
-        it( 'allows modifying validation rules for a field', function (): void {
-            if ( ! function_exists( 'addFilter' ) ) {
-                $this->markTestSkipped( 'Hook system not available' );
+    describe('ap.forms.validationRules filter', function (): void {
+        it('allows modifying validation rules for a field', function (): void {
+            if (! function_exists('addFilter')) {
+                $this->markTestSkipped('Hook system not available');
             }
 
-            addFilter( 'forms.validation_rules', function ( array $rules, FormField $field ): array {
+            addFilter('ap.forms.validationRules', function (array $rules, FormField $field): array {
                 // Add a custom rule for email fields
-                if ( 'email' === $field->type ) {
+                if ($field->type === 'email') {
                     $rules[] = 'ends_with:@example.com';
                 }
 
                 return $rules;
-            } );
+            });
 
-            $form  = Form::factory()->create();
-            $field = FormField::factory()->for( $form )->create( [
-                'type'        => 'email',
+            $form = Form::factory()->create();
+            $field = FormField::factory()->for($form)->create([
+                'type' => 'email',
                 'is_required' => true,
-            ] );
+            ]);
 
             $rules = $field->buildValidationRules();
 
-            expect( $rules )->toContain( 'email' )
-                ->and( $rules )->toContain( 'ends_with:@example.com' );
-        } );
-    } );
+            expect($rules)->toContain('email')
+                ->and($rules)->toContain('ends_with:@example.com');
+        });
+    });
 
-    describe( 'forms.submission_data filter', function (): void {
-        it( 'allows modifying submission data before saving', function (): void {
-            if ( ! function_exists( 'addFilter' ) ) {
-                $this->markTestSkipped( 'Hook system not available' );
+    describe('ap.forms.submissionData filter', function (): void {
+        it('allows modifying submission data before saving', function (): void {
+            if (! function_exists('addFilter')) {
+                $this->markTestSkipped('Hook system not available');
             }
 
-            addFilter( 'forms.submission_data', function ( array $data, Form $form ): array {
+            addFilter('ap.forms.submissionData', function (array $data, Form $form): array {
                 // Add a tracking field to all submissions
-                $data['_tracking_id'] = 'TRACK-' . uniqid();
+                $data['_tracking_id'] = 'TRACK-'.uniqid();
 
                 return $data;
-            } );
+            });
 
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->create( ['name' => 'name', 'type' => 'text'] );
+            FormField::factory()->for($form)->create(['name' => 'name', 'type' => 'text']);
 
-            $service = app( SubmissionService::class );
+            $service = app(SubmissionService::class);
 
             // Note: The filter modifies the data before processing
             // but in practice, the tracking_id would need to be stored
             // This test verifies the filter is called
-            $submission = $service->create( $form, ['name' => 'Test User'], [], [] );
+            $submission = $service->create($form, ['name' => 'Test User'], [], []);
 
-            expect( $submission )->not->toBeNull();
-        } );
-    } );
+            expect($submission)->not->toBeNull();
+        });
+    });
 
-    describe( 'forms.export_headers filter', function (): void {
-        it( 'allows modifying export headers', function (): void {
-            if ( ! function_exists( 'addFilter' ) ) {
-                $this->markTestSkipped( 'Hook system not available' );
+    describe('ap.forms.exportHeaders filter', function (): void {
+        it('allows modifying export headers', function (): void {
+            if (! function_exists('addFilter')) {
+                $this->markTestSkipped('Hook system not available');
             }
 
-            addFilter( 'forms.export_headers', function ( array $headers, Form $form ): array {
+            addFilter('ap.forms.exportHeaders', function (array $headers, Form $form): array {
                 $headers[] = 'Custom Column';
 
                 return $headers;
-            } );
+            });
 
-            $form    = Form::factory()->create();
-            $service = app( ExportService::class );
+            $form = Form::factory()->create();
+            $service = app(ExportService::class);
 
-            $headers = $service->buildHeaders( $form );
+            $headers = $service->buildHeaders($form);
 
-            expect( $headers )->toContain( 'Custom Column' );
-        } );
-    } );
+            expect($headers)->toContain('Custom Column');
+        });
+    });
 
-    describe( 'forms.settings_tabs filter', function (): void {
-        it( 'allows registering custom settings tabs', function (): void {
-            if ( ! function_exists( 'addFilter' ) ) {
-                $this->markTestSkipped( 'Hook system not available' );
+    describe('ap.forms.settingsTabs filter', function (): void {
+        it('allows registering custom settings tabs', function (): void {
+            if (! function_exists('addFilter')) {
+                $this->markTestSkipped('Hook system not available');
             }
 
-            addFilter( 'forms.settings_tabs', function ( array $tabs ): array {
+            addFilter('ap.forms.settingsTabs', function (array $tabs): array {
                 $tabs[] = [
-                    'id'          => 'mailchimp',
-                    'label'       => 'Mailchimp',
-                    'icon'        => 'o-envelope',
-                    'component'   => 'mailchimp-settings',
+                    'id' => 'mailchimp',
+                    'label' => 'Mailchimp',
+                    'icon' => 'o-envelope',
+                    'component' => 'mailchimp-settings',
                     'description' => 'Configure Mailchimp integration',
                 ];
 
                 return $tabs;
-            } );
+            });
 
-            $service = app( IntegrationService::class );
-            $tabs    = $service->getSettingsTabs();
+            $service = app(IntegrationService::class);
+            $tabs = $service->getSettingsTabs();
 
-            expect( $tabs )->toHaveCount( 1 )
-                ->and( $tabs[0]['id'] )->toBe( 'mailchimp' )
-                ->and( $tabs[0]['label'] )->toBe( 'Mailchimp' );
-        } );
+            expect($tabs)->toHaveCount(1)
+                ->and($tabs[0]['id'])->toBe('mailchimp')
+                ->and($tabs[0]['label'])->toBe('Mailchimp');
+        });
 
-        it( 'returns empty array when no tabs registered', function (): void {
-            $service = app( IntegrationService::class );
-            $tabs    = $service->getSettingsTabs();
+        it('returns empty array when no tabs registered', function (): void {
+            $service = app(IntegrationService::class);
+            $tabs = $service->getSettingsTabs();
 
-            expect( $tabs )->toBeArray()
-                ->and( $tabs )->toBeEmpty();
-        } );
+            expect($tabs)->toBeArray()
+                ->and($tabs)->toBeEmpty();
+        });
     });
 });

--- a/tests/Feature/Integrations/FilterHooksTest.php
+++ b/tests/Feature/Integrations/FilterHooksTest.php
@@ -190,15 +190,15 @@ describe( 'Filter Hooks', function (): void {
 
             expect( $tabs )->toHaveCount( 1 )
                 ->and( $tabs[0]['id'] )->toBe( 'mailchimp' )
-                ->and( $tabs[0]['label'])->toBe( 'Mailchimp');
-        });
+                ->and( $tabs[0]['label'] )->toBe( 'Mailchimp' );
+        } );
 
         it( 'returns empty array when no tabs registered', function (): void {
-            $service = app( IntegrationService::class);
+            $service = app( IntegrationService::class );
             $tabs    = $service->getSettingsTabs();
 
-            expect( $tabs)->toBeArray()
-                ->and( $tabs)->toBeEmpty();
+            expect( $tabs )->toBeArray()
+                ->and( $tabs )->toBeEmpty();
         });
     });
 });

--- a/tests/Feature/Integrations/FilterHooksTest.php
+++ b/tests/Feature/Integrations/FilterHooksTest.php
@@ -199,6 +199,6 @@ describe( 'Filter Hooks', function (): void {
 
             expect( $tabs )->toBeArray()
                 ->and( $tabs )->toBeEmpty();
-        });
+        } );
     });
 });

--- a/tests/Feature/Integrations/WaveFiveHooksTest.php
+++ b/tests/Feature/Integrations/WaveFiveHooksTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Forms\Http\Requests\StoreFormRequest;
+use ArtisanPackUI\Forms\Mail\FormSubmissionNotification;
+use ArtisanPackUI\Forms\Models\FormField;
+use ArtisanPackUI\Forms\Models\FormNotification;
+use ArtisanPackUI\Forms\Models\FormSubmission;
+use ArtisanPackUI\Forms\Services\IntegrationService;
+use ArtisanPackUI\Forms\Support\FieldRenderer;
+use ArtisanPackUI\Forms\Support\FiresValidationHooks;
+use Illuminate\Foundation\Http\FormRequest;
+
+class FiresValidationHooksTestRequest extends FormRequest
+{
+    use FiresValidationHooks;
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return ['name' => ['required', 'string']];
+    }
+}
+
+class FiresValidationHooksOverrideRequest extends FormRequest
+{
+    use FiresValidationHooks;
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return ['name' => ['required', 'string']];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->fireBeforeValidate();
+    }
+
+    protected function passedValidation(): void
+    {
+        $this->fireValidated();
+    }
+}
+
+beforeEach( function (): void {
+    if ( ! function_exists( 'removeAllFilters' ) ) {
+        $this->markTestSkipped( 'Hook system not available' );
+    }
+
+    foreach ( [
+        'ap.forms.beforeValidate',
+        'ap.forms.validated',
+        'ap.forms.fieldRender',
+        'ap.forms.integrationRegistered',
+        'ap.forms.notificationSubject',
+        'ap.forms.notificationBody',
+    ] as $hook ) {
+        removeAllFilters( $hook );
+    }
+} );
+
+describe( 'Wave 5 hooks', function (): void {
+    describe( 'ap.forms.beforeValidate action', function (): void {
+        it( 'fires before FormRequest validation runs', function (): void {
+            $captured = null;
+
+            addAction( 'ap.forms.beforeValidate', function ( $request ) use ( &$captured ): void {
+                $captured = $request;
+            } );
+
+            $request = FiresValidationHooksTestRequest::create( '/test', 'POST', [
+                'name' => 'Sample Form',
+            ] );
+            $request->setContainer( app() )->setRedirector( app( 'redirect' ) );
+            $request->validateResolved();
+
+            expect( $captured )->toBeInstanceOf( FiresValidationHooksTestRequest::class );
+        } );
+    } );
+
+    describe( 'ap.forms.validated action', function (): void {
+        it( 'fires after FormRequest validation succeeds with the validated payload', function (): void {
+            $capturedRequest   = null;
+            $capturedValidated = null;
+
+            addAction( 'ap.forms.validated', function ( $request, array $validated ) use ( &$capturedRequest, &$capturedValidated ): void {
+                $capturedRequest   = $request;
+                $capturedValidated = $validated;
+            } );
+
+            $request = FiresValidationHooksTestRequest::create( '/test', 'POST', [
+                'name' => 'Sample Form',
+            ] );
+            $request->setContainer( app() )->setRedirector( app( 'redirect' ) );
+            $request->validateResolved();
+
+            expect( $capturedRequest )->toBeInstanceOf( FiresValidationHooksTestRequest::class );
+            expect( $capturedValidated )->toBe( ['name' => 'Sample Form'] );
+        } );
+    } );
+
+    describe( 'ap.forms.fieldRender filter', function (): void {
+        it( 'allows integration packages to mutate the rendered field HTML', function (): void {
+            $field = FormField::factory()->create( [
+                'type'  => 'text',
+                'label' => 'First Name',
+                'name'  => 'first_name',
+            ] );
+
+            addFilter( 'ap.forms.fieldRender', function ( string $html, FormField $filtered ): string {
+                return '<div data-wrapped="' . $filtered->name . '">' . $html . '</div>';
+            } );
+
+            $rendered = FieldRenderer::render( $field );
+
+            expect( $rendered )->toContain( 'data-wrapped="first_name"' );
+        } );
+
+        it( 'passes the field instance to subscribers', function (): void {
+            $field    = FormField::factory()->create( ['type' => 'text'] );
+            $received = null;
+
+            addFilter( 'ap.forms.fieldRender', function ( string $html, FormField $filtered ) use ( &$received ): string {
+                $received = $filtered;
+
+                return $html;
+            } );
+
+            FieldRenderer::render( $field );
+
+            expect( $received )->not->toBeNull();
+            expect( $received->id )->toBe( $field->id );
+        } );
+    } );
+
+    describe( 'ap.forms.integrationRegistered action', function (): void {
+        it( 'fires with the slug and config passed to registerIntegration()', function (): void {
+            $slug   = null;
+            $config = null;
+
+            addAction( 'ap.forms.integrationRegistered', function ( string $capturedSlug, array $capturedConfig ) use ( &$slug, &$config ): void {
+                $slug   = $capturedSlug;
+                $config = $capturedConfig;
+            } );
+
+            app( IntegrationService::class )->registerIntegration( 'mailchimp', [
+                'label' => 'Mailchimp',
+                'icon'  => 'o-envelope',
+            ] );
+
+            expect( $slug )->toBe( 'mailchimp' );
+            expect( $config )->toBe( ['label' => 'Mailchimp', 'icon' => 'o-envelope'] );
+        } );
+    } );
+
+    describe( 'ap.forms.notificationSubject filter', function (): void {
+        it( 'lets subscribers rewrite the outgoing email subject', function (): void {
+            $notification = FormNotification::factory()->create( [
+                'subject' => 'New submission',
+                'message' => 'Hello',
+            ] );
+            $submission = FormSubmission::factory()->for( $notification->form )->create();
+
+            $capturedNotification = null;
+            $capturedSubmission   = null;
+
+            addFilter(
+                'ap.forms.notificationSubject',
+                function ( string $subject, FormNotification $n, FormSubmission $s ) use ( &$capturedNotification, &$capturedSubmission ): string {
+                    $capturedNotification = $n;
+                    $capturedSubmission   = $s;
+
+                    return '[PREFIX] ' . $subject;
+                },
+            );
+
+            $mail     = new FormSubmissionNotification( $notification, $submission );
+            $envelope = $mail->envelope();
+
+            expect( $envelope->subject )->toBe( '[PREFIX] New submission' );
+            expect( $capturedNotification?->id )->toBe( $notification->id );
+            expect( $capturedSubmission?->id )->toBe( $submission->id );
+        } );
+    } );
+
+    describe( 'ap.forms.notificationBody filter', function (): void {
+        it( 'lets subscribers rewrite the outgoing email body', function (): void {
+            $notification = FormNotification::factory()->create( [
+                'subject' => 'Hi',
+                'message' => 'Original body',
+            ] );
+            $submission = FormSubmission::factory()->for( $notification->form )->create();
+
+            $capturedNotification = null;
+            $capturedSubmission   = null;
+
+            addFilter(
+                'ap.forms.notificationBody',
+                function ( string $body, FormNotification $n, FormSubmission $s ) use ( &$capturedNotification, &$capturedSubmission ): string {
+                    $capturedNotification = $n;
+                    $capturedSubmission   = $s;
+
+                    return $body . ' (appended)';
+                },
+            );
+
+            $mail = new FormSubmissionNotification( $notification, $submission );
+
+            $reflection = new ReflectionProperty( $mail, 'parsedMessage' );
+            expect( $reflection->getValue( $mail ) )->toBe( 'Original body (appended)' );
+            expect( $capturedNotification?->id )->toBe( $notification->id );
+            expect( $capturedSubmission?->id )->toBe( $submission->id );
+        } );
+    } );
+
+    describe( 'trait shadowing', function (): void {
+        it( 'still fires both hooks when the FormRequest overrides both lifecycle methods and delegates to the trait helpers', function (): void {
+            $beforeFired    = 0;
+            $validatedFired = 0;
+
+            addAction( 'ap.forms.beforeValidate', function () use ( &$beforeFired ): void {
+                $beforeFired++;
+            } );
+
+            addAction( 'ap.forms.validated', function () use ( &$validatedFired ): void {
+                $validatedFired++;
+            } );
+
+            $request = FiresValidationHooksOverrideRequest::create( '/test', 'POST', [
+                'name' => 'Sample',
+            ] );
+            $request->setContainer( app() )->setRedirector( app( 'redirect' ) );
+            $request->validateResolved();
+
+            expect( $beforeFired )->toBe( 1 );
+            expect( $validatedFired )->toBe( 1 );
+        } );
+
+        it( 'fires ap.forms.beforeValidate from a real overriding FormRequest (StoreFormRequest)', function (): void {
+            // StoreFormRequest overrides prepareForValidation() to normalize slug — the trait
+            // method would be silently shadowed if the override didn't delegate to fireBeforeValidate().
+            $captured = null;
+
+            addAction( 'ap.forms.beforeValidate', function ( $request ) use ( &$captured ): void {
+                $captured = $request;
+            } );
+
+            $request = StoreFormRequest::create( '/forms', 'POST', [
+                'name' => 'Sample Form',
+            ] );
+            $request->setContainer( app() )->setRedirector( app( 'redirect' ) );
+
+            // Skip authorize()/validate() and drive prepareForValidation directly — the
+            // hook must fire regardless of downstream authorization outcome.
+            $reflection = new ReflectionMethod( $request, 'prepareForValidation' );
+            $reflection->invoke( $request );
+
+            expect( $captured )->toBeInstanceOf( StoreFormRequest::class );
+        } );
+    } );
+} );

--- a/tests/Feature/Integrations/WebhookTest.php
+++ b/tests/Feature/Integrations/WebhookTest.php
@@ -227,13 +227,13 @@ describe( 'Webhook Integration', function (): void {
 
 afterEach( function (): void {
     // Reset config after each test
-    config( ['artisanpack.forms.webhooks.enabled' => false]);
-    config( ['artisanpack.forms.webhooks.url' => null]);
-    config( ['artisanpack.forms.privacy.include_ip_address' => false]);
-    config( ['artisanpack.forms.privacy.include_user_agent' => false]);
+    config( ['artisanpack.forms.webhooks.enabled' => false] );
+    config( ['artisanpack.forms.webhooks.url' => null] );
+    config( ['artisanpack.forms.privacy.include_ip_address' => false] );
+    config( ['artisanpack.forms.privacy.include_user_agent' => false] );
 
     // Reset filters
-    if ( function_exists( 'removeAllFilters')) {
+    if ( function_exists( 'removeAllFilters' ) ) {
         removeAllFilters( 'ap.forms.webhookPayload');
     }
 });

--- a/tests/Feature/Integrations/WebhookTest.php
+++ b/tests/Feature/Integrations/WebhookTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Forms\Events\FormSubmitted;
 use ArtisanPackUI\Forms\Jobs\SendWebhook;
@@ -12,228 +12,228 @@ use ArtisanPackUI\Forms\Models\FormSubmissionValue;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 
-describe( 'Webhook Integration', function (): void {
-    describe( 'SendWebhook job', function (): void {
-        it( 'builds correct payload structure', function (): void {
-            $form       = Form::factory()->create( ['name' => 'Contact Form'] );
-            $field      = FormField::factory()->for( $form )->create( ['name' => 'email', 'type' => 'email'] );
-            $submission = FormSubmission::factory()->for( $form )->create( [
+describe('Webhook Integration', function (): void {
+    describe('SendWebhook job', function (): void {
+        it('builds correct payload structure', function (): void {
+            $form = Form::factory()->create(['name' => 'Contact Form']);
+            $field = FormField::factory()->for($form)->create(['name' => 'email', 'type' => 'email']);
+            $submission = FormSubmission::factory()->for($form)->create([
                 'page_url' => 'https://example.com/contact',
-            ] );
-            FormSubmissionValue::factory()->for( $submission, 'submission' )->create( [
-                'field_id'   => $field->id,
+            ]);
+            FormSubmissionValue::factory()->for($submission, 'submission')->create([
+                'field_id' => $field->id,
                 'field_name' => 'email',
-                'value'      => 'test@example.com',
-            ] );
+                'value' => 'test@example.com',
+            ]);
 
-            Http::fake( [
-                'https://webhook.example.com/*' => Http::response( ['success' => true], 200 ),
-            ] );
+            Http::fake([
+                'https://webhook.example.com/*' => Http::response(['success' => true], 200),
+            ]);
 
-            $job = new SendWebhook( $submission, 'https://webhook.example.com/endpoint' );
+            $job = new SendWebhook($submission, 'https://webhook.example.com/endpoint');
             $job->handle();
 
-            Http::assertSent( function ( $request ) use ( $submission ) {
+            Http::assertSent(function ($request) use ($submission) {
                 $payload = $request->data();
 
-                return 'submission.created' === $payload['event']
-                    && 'Contact Form' === $payload['form']['name']
+                return $payload['event'] === 'submission.created'
+                    && $payload['form']['name'] === 'Contact Form'
                     && $payload['submission']['id'] === $submission->id
-                    && isset( $payload['submission']['data'] );
-            } );
-        } );
+                    && isset($payload['submission']['data']);
+            });
+        });
 
-        it( 'includes signature header when secret is configured', function (): void {
-            $form       = Form::factory()->create();
-            $submission = FormSubmission::factory()->for( $form )->create();
+        it('includes signature header when secret is configured', function (): void {
+            $form = Form::factory()->create();
+            $submission = FormSubmission::factory()->for($form)->create();
 
-            Http::fake( [
-                '*' => Http::response( ['success' => true], 200 ),
-            ] );
+            Http::fake([
+                '*' => Http::response(['success' => true], 200),
+            ]);
 
-            $job = new SendWebhook( $submission, 'https://webhook.example.com/endpoint', 'my-secret-key' );
+            $job = new SendWebhook($submission, 'https://webhook.example.com/endpoint', 'my-secret-key');
             $job->handle();
 
-            Http::assertSent( function ( $request ) {
-                return $request->hasHeader( 'X-Forms-Signature' )
-                    && $request->hasHeader( 'X-Forms-Signature-256' );
-            } );
-        } );
+            Http::assertSent(function ($request) {
+                return $request->hasHeader('X-Forms-Signature')
+                    && $request->hasHeader('X-Forms-Signature-256');
+            });
+        });
 
-        it( 'logs success on successful webhook', function (): void {
-            $form       = Form::factory()->create();
-            $submission = FormSubmission::factory()->for( $form )->create();
+        it('logs success on successful webhook', function (): void {
+            $form = Form::factory()->create();
+            $submission = FormSubmission::factory()->for($form)->create();
 
-            Http::fake( [
-                '*' => Http::response( ['success' => true], 200 ),
-            ] );
+            Http::fake([
+                '*' => Http::response(['success' => true], 200),
+            ]);
 
-            $job = new SendWebhook( $submission, 'https://webhook.example.com/endpoint' );
+            $job = new SendWebhook($submission, 'https://webhook.example.com/endpoint');
             $job->handle();
 
             // If we get here without exception, it was successful
-            expect( true )->toBeTrue();
-        } );
+            expect(true)->toBeTrue();
+        });
 
-        it( 'throws exception on server error to trigger retry', function (): void {
-            $form       = Form::factory()->create();
-            $submission = FormSubmission::factory()->for( $form )->create();
+        it('throws exception on server error to trigger retry', function (): void {
+            $form = Form::factory()->create();
+            $submission = FormSubmission::factory()->for($form)->create();
 
-            Http::fake( [
-                '*' => Http::response( ['error' => 'Server error'], 500 ),
-            ] );
+            Http::fake([
+                '*' => Http::response(['error' => 'Server error'], 500),
+            ]);
 
-            $job = new SendWebhook( $submission, 'https://webhook.example.com/endpoint' );
+            $job = new SendWebhook($submission, 'https://webhook.example.com/endpoint');
 
-            expect( fn () => $job->handle() )->toThrow( RuntimeException::class );
-        } );
+            expect(fn () => $job->handle())->toThrow(RuntimeException::class);
+        });
 
-        it( 'applies forms.webhook_payload filter', function (): void {
-            if ( ! function_exists( 'addFilter' ) ) {
-                $this->markTestSkipped( 'Hook system not available' );
+        it('applies ap.forms.webhookPayload filter', function (): void {
+            if (! function_exists('addFilter')) {
+                $this->markTestSkipped('Hook system not available');
             }
 
-            addFilter( 'forms.webhook_payload', function ( array $payload, FormSubmission $submission ): array {
+            addFilter('ap.forms.webhookPayload', function (array $payload, FormSubmission $submission): array {
                 $payload['custom_field'] = 'custom_value';
 
                 return $payload;
-            } );
+            });
 
-            $form       = Form::factory()->create();
-            $submission = FormSubmission::factory()->for( $form )->create();
+            $form = Form::factory()->create();
+            $submission = FormSubmission::factory()->for($form)->create();
 
-            Http::fake( [
-                '*' => Http::response( ['success' => true], 200 ),
-            ] );
+            Http::fake([
+                '*' => Http::response(['success' => true], 200),
+            ]);
 
-            $job = new SendWebhook( $submission, 'https://webhook.example.com/endpoint' );
+            $job = new SendWebhook($submission, 'https://webhook.example.com/endpoint');
             $job->handle();
 
-            Http::assertSent( function ( $request ) {
+            Http::assertSent(function ($request) {
                 $payload = $request->data();
 
-                return isset( $payload['custom_field'] ) && 'custom_value' === $payload['custom_field'];
-            } );
-        } );
+                return isset($payload['custom_field']) && $payload['custom_field'] === 'custom_value';
+            });
+        });
 
-        it( 'excludes PII from payload by default', function (): void {
-            $form       = Form::factory()->create();
-            $submission = FormSubmission::factory()->for( $form )->create( [
+        it('excludes PII from payload by default', function (): void {
+            $form = Form::factory()->create();
+            $submission = FormSubmission::factory()->for($form)->create([
                 'ip_address' => '192.168.1.1',
                 'user_agent' => 'Mozilla/5.0',
-            ] );
+            ]);
 
-            Http::fake( [
-                '*' => Http::response( ['success' => true], 200 ),
-            ] );
+            Http::fake([
+                '*' => Http::response(['success' => true], 200),
+            ]);
 
-            $job = new SendWebhook( $submission, 'https://webhook.example.com/endpoint' );
+            $job = new SendWebhook($submission, 'https://webhook.example.com/endpoint');
             $job->handle();
 
-            Http::assertSent( function ( $request ) {
+            Http::assertSent(function ($request) {
                 $payload = $request->data();
 
-                return ! isset( $payload['submission']['metadata']['ip_address'] )
-                    && ! isset( $payload['submission']['metadata']['user_agent'] );
-            } );
-        } );
+                return ! isset($payload['submission']['metadata']['ip_address'])
+                    && ! isset($payload['submission']['metadata']['user_agent']);
+            });
+        });
 
-        it( 'includes PII in payload when privacy settings are enabled', function (): void {
-            config( ['artisanpack.forms.privacy.include_ip_address' => true] );
-            config( ['artisanpack.forms.privacy.include_user_agent' => true] );
+        it('includes PII in payload when privacy settings are enabled', function (): void {
+            config(['artisanpack.forms.privacy.include_ip_address' => true]);
+            config(['artisanpack.forms.privacy.include_user_agent' => true]);
 
-            $form       = Form::factory()->create();
-            $submission = FormSubmission::factory()->for( $form )->create( [
+            $form = Form::factory()->create();
+            $submission = FormSubmission::factory()->for($form)->create([
                 'ip_address' => '192.168.1.1',
                 'user_agent' => 'Mozilla/5.0',
-            ] );
+            ]);
 
-            Http::fake( [
-                '*' => Http::response( ['success' => true], 200 ),
-            ] );
+            Http::fake([
+                '*' => Http::response(['success' => true], 200),
+            ]);
 
-            $job = new SendWebhook( $submission, 'https://webhook.example.com/endpoint' );
+            $job = new SendWebhook($submission, 'https://webhook.example.com/endpoint');
             $job->handle();
 
-            Http::assertSent( function ( $request ) {
+            Http::assertSent(function ($request) {
                 $payload = $request->data();
 
-                return '192.168.1.1' === $payload['submission']['metadata']['ip_address']
-                    && 'Mozilla/5.0' === $payload['submission']['metadata']['user_agent'];
-            } );
-        } );
-    } );
+                return $payload['submission']['metadata']['ip_address'] === '192.168.1.1'
+                    && $payload['submission']['metadata']['user_agent'] === 'Mozilla/5.0';
+            });
+        });
+    });
 
-    describe( 'SendWebhookOnSubmission listener', function (): void {
-        it( 'dispatches webhook job when global webhook is enabled', function (): void {
+    describe('SendWebhookOnSubmission listener', function (): void {
+        it('dispatches webhook job when global webhook is enabled', function (): void {
             Queue::fake();
 
-            config( ['artisanpack.forms.webhooks.enabled' => true] );
-            config( ['artisanpack.forms.webhooks.url' => 'https://webhook.example.com/endpoint'] );
+            config(['artisanpack.forms.webhooks.enabled' => true]);
+            config(['artisanpack.forms.webhooks.url' => 'https://webhook.example.com/endpoint']);
 
-            $form       = Form::factory()->create();
-            $submission = FormSubmission::factory()->for( $form )->create();
+            $form = Form::factory()->create();
+            $submission = FormSubmission::factory()->for($form)->create();
 
             $listener = new SendWebhookOnSubmission;
-            $listener->handle( new FormSubmitted( $submission ) );
+            $listener->handle(new FormSubmitted($submission));
 
-            Queue::assertPushed( SendWebhook::class, function ( SendWebhook $job ) use ( $submission ) {
+            Queue::assertPushed(SendWebhook::class, function (SendWebhook $job) use ($submission) {
                 return $job->submission->id === $submission->id
-                    && 'https://webhook.example.com/endpoint' === $job->url;
-            } );
-        } );
+                    && $job->url === 'https://webhook.example.com/endpoint';
+            });
+        });
 
-        it( 'does not dispatch webhook job when global webhook is disabled', function (): void {
+        it('does not dispatch webhook job when global webhook is disabled', function (): void {
             Queue::fake();
 
-            config( ['artisanpack.forms.webhooks.enabled' => false] );
+            config(['artisanpack.forms.webhooks.enabled' => false]);
 
-            $form       = Form::factory()->create();
-            $submission = FormSubmission::factory()->for( $form )->create();
+            $form = Form::factory()->create();
+            $submission = FormSubmission::factory()->for($form)->create();
 
             $listener = new SendWebhookOnSubmission;
-            $listener->handle( new FormSubmitted( $submission ) );
+            $listener->handle(new FormSubmitted($submission));
 
-            Queue::assertNotPushed( SendWebhook::class );
-        } );
+            Queue::assertNotPushed(SendWebhook::class);
+        });
 
-        it( 'dispatches webhook job for form-specific webhook configuration', function (): void {
+        it('dispatches webhook job for form-specific webhook configuration', function (): void {
             Queue::fake();
 
-            config( ['artisanpack.forms.webhooks.enabled' => false] ); // Global disabled
+            config(['artisanpack.forms.webhooks.enabled' => false]); // Global disabled
 
-            $form = Form::factory()->create( [
+            $form = Form::factory()->create([
                 'settings' => [
                     'webhook' => [
                         'enabled' => true,
-                        'url'     => 'https://form-specific-webhook.example.com/endpoint',
-                        'secret'  => 'form-secret',
+                        'url' => 'https://form-specific-webhook.example.com/endpoint',
+                        'secret' => 'form-secret',
                     ],
                 ],
-            ] );
-            $submission = FormSubmission::factory()->for( $form )->create();
+            ]);
+            $submission = FormSubmission::factory()->for($form)->create();
 
             $listener = new SendWebhookOnSubmission;
-            $listener->handle( new FormSubmitted( $submission ) );
+            $listener->handle(new FormSubmitted($submission));
 
-            Queue::assertPushed( SendWebhook::class, function ( SendWebhook $job ) use ( $submission ) {
+            Queue::assertPushed(SendWebhook::class, function (SendWebhook $job) use ($submission) {
                 return $job->submission->id === $submission->id
-                    && 'https://form-specific-webhook.example.com/endpoint' === $job->url
-                    && 'form-secret' === $job->secret;
-            } );
-        } );
-    } );
-} );
+                    && $job->url === 'https://form-specific-webhook.example.com/endpoint'
+                    && $job->secret === 'form-secret';
+            });
+        });
+    });
+});
 
-afterEach( function (): void {
+afterEach(function (): void {
     // Reset config after each test
-    config( ['artisanpack.forms.webhooks.enabled' => false] );
-    config( ['artisanpack.forms.webhooks.url' => null] );
-    config( ['artisanpack.forms.privacy.include_ip_address' => false] );
-    config( ['artisanpack.forms.privacy.include_user_agent' => false] );
+    config(['artisanpack.forms.webhooks.enabled' => false]);
+    config(['artisanpack.forms.webhooks.url' => null]);
+    config(['artisanpack.forms.privacy.include_ip_address' => false]);
+    config(['artisanpack.forms.privacy.include_user_agent' => false]);
 
     // Reset filters
-    if ( function_exists( 'removeAllFilters' ) ) {
-        removeAllFilters( 'forms.webhook_payload');
+    if (function_exists('removeAllFilters')) {
+        removeAllFilters('ap.forms.webhookPayload');
     }
 });

--- a/tests/Feature/Integrations/WebhookTest.php
+++ b/tests/Feature/Integrations/WebhookTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Forms\Events\FormSubmitted;
 use ArtisanPackUI\Forms\Jobs\SendWebhook;
@@ -12,228 +12,228 @@ use ArtisanPackUI\Forms\Models\FormSubmissionValue;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 
-describe('Webhook Integration', function (): void {
-    describe('SendWebhook job', function (): void {
-        it('builds correct payload structure', function (): void {
-            $form = Form::factory()->create(['name' => 'Contact Form']);
-            $field = FormField::factory()->for($form)->create(['name' => 'email', 'type' => 'email']);
-            $submission = FormSubmission::factory()->for($form)->create([
+describe( 'Webhook Integration', function (): void {
+    describe( 'SendWebhook job', function (): void {
+        it( 'builds correct payload structure', function (): void {
+            $form       = Form::factory()->create( ['name' => 'Contact Form'] );
+            $field      = FormField::factory()->for( $form )->create( ['name' => 'email', 'type' => 'email'] );
+            $submission = FormSubmission::factory()->for( $form )->create( [
                 'page_url' => 'https://example.com/contact',
-            ]);
-            FormSubmissionValue::factory()->for($submission, 'submission')->create([
-                'field_id' => $field->id,
+            ] );
+            FormSubmissionValue::factory()->for( $submission, 'submission' )->create( [
+                'field_id'   => $field->id,
                 'field_name' => 'email',
-                'value' => 'test@example.com',
-            ]);
+                'value'      => 'test@example.com',
+            ] );
 
-            Http::fake([
-                'https://webhook.example.com/*' => Http::response(['success' => true], 200),
-            ]);
+            Http::fake( [
+                'https://webhook.example.com/*' => Http::response( ['success' => true], 200 ),
+            ] );
 
-            $job = new SendWebhook($submission, 'https://webhook.example.com/endpoint');
+            $job = new SendWebhook( $submission, 'https://webhook.example.com/endpoint' );
             $job->handle();
 
-            Http::assertSent(function ($request) use ($submission) {
+            Http::assertSent( function ( $request ) use ( $submission ) {
                 $payload = $request->data();
 
-                return $payload['event'] === 'submission.created'
-                    && $payload['form']['name'] === 'Contact Form'
+                return 'submission.created' === $payload['event']
+                    && 'Contact Form' === $payload['form']['name']
                     && $payload['submission']['id'] === $submission->id
-                    && isset($payload['submission']['data']);
-            });
-        });
+                    && isset( $payload['submission']['data'] );
+            } );
+        } );
 
-        it('includes signature header when secret is configured', function (): void {
-            $form = Form::factory()->create();
-            $submission = FormSubmission::factory()->for($form)->create();
+        it( 'includes signature header when secret is configured', function (): void {
+            $form       = Form::factory()->create();
+            $submission = FormSubmission::factory()->for( $form )->create();
 
-            Http::fake([
-                '*' => Http::response(['success' => true], 200),
-            ]);
+            Http::fake( [
+                '*' => Http::response( ['success' => true], 200 ),
+            ] );
 
-            $job = new SendWebhook($submission, 'https://webhook.example.com/endpoint', 'my-secret-key');
+            $job = new SendWebhook( $submission, 'https://webhook.example.com/endpoint', 'my-secret-key' );
             $job->handle();
 
-            Http::assertSent(function ($request) {
-                return $request->hasHeader('X-Forms-Signature')
-                    && $request->hasHeader('X-Forms-Signature-256');
-            });
-        });
+            Http::assertSent( function ( $request ) {
+                return $request->hasHeader( 'X-Forms-Signature' )
+                    && $request->hasHeader( 'X-Forms-Signature-256' );
+            } );
+        } );
 
-        it('logs success on successful webhook', function (): void {
-            $form = Form::factory()->create();
-            $submission = FormSubmission::factory()->for($form)->create();
+        it( 'logs success on successful webhook', function (): void {
+            $form       = Form::factory()->create();
+            $submission = FormSubmission::factory()->for( $form )->create();
 
-            Http::fake([
-                '*' => Http::response(['success' => true], 200),
-            ]);
+            Http::fake( [
+                '*' => Http::response( ['success' => true], 200 ),
+            ] );
 
-            $job = new SendWebhook($submission, 'https://webhook.example.com/endpoint');
+            $job = new SendWebhook( $submission, 'https://webhook.example.com/endpoint' );
             $job->handle();
 
             // If we get here without exception, it was successful
-            expect(true)->toBeTrue();
-        });
+            expect( true )->toBeTrue();
+        } );
 
-        it('throws exception on server error to trigger retry', function (): void {
-            $form = Form::factory()->create();
-            $submission = FormSubmission::factory()->for($form)->create();
+        it( 'throws exception on server error to trigger retry', function (): void {
+            $form       = Form::factory()->create();
+            $submission = FormSubmission::factory()->for( $form )->create();
 
-            Http::fake([
-                '*' => Http::response(['error' => 'Server error'], 500),
-            ]);
+            Http::fake( [
+                '*' => Http::response( ['error' => 'Server error'], 500 ),
+            ] );
 
-            $job = new SendWebhook($submission, 'https://webhook.example.com/endpoint');
+            $job = new SendWebhook( $submission, 'https://webhook.example.com/endpoint' );
 
-            expect(fn () => $job->handle())->toThrow(RuntimeException::class);
-        });
+            expect( fn () => $job->handle() )->toThrow( RuntimeException::class );
+        } );
 
-        it('applies ap.forms.webhookPayload filter', function (): void {
-            if (! function_exists('addFilter')) {
-                $this->markTestSkipped('Hook system not available');
+        it( 'applies ap.forms.webhookPayload filter', function (): void {
+            if ( ! function_exists( 'addFilter' ) ) {
+                $this->markTestSkipped( 'Hook system not available' );
             }
 
-            addFilter('ap.forms.webhookPayload', function (array $payload, FormSubmission $submission): array {
+            addFilter( 'ap.forms.webhookPayload', function ( array $payload, FormSubmission $submission ): array {
                 $payload['custom_field'] = 'custom_value';
 
                 return $payload;
-            });
+            } );
 
-            $form = Form::factory()->create();
-            $submission = FormSubmission::factory()->for($form)->create();
+            $form       = Form::factory()->create();
+            $submission = FormSubmission::factory()->for( $form )->create();
 
-            Http::fake([
-                '*' => Http::response(['success' => true], 200),
-            ]);
+            Http::fake( [
+                '*' => Http::response( ['success' => true], 200 ),
+            ] );
 
-            $job = new SendWebhook($submission, 'https://webhook.example.com/endpoint');
+            $job = new SendWebhook( $submission, 'https://webhook.example.com/endpoint' );
             $job->handle();
 
-            Http::assertSent(function ($request) {
+            Http::assertSent( function ( $request ) {
                 $payload = $request->data();
 
-                return isset($payload['custom_field']) && $payload['custom_field'] === 'custom_value';
-            });
-        });
+                return isset( $payload['custom_field'] ) && 'custom_value' === $payload['custom_field'];
+            } );
+        } );
 
-        it('excludes PII from payload by default', function (): void {
-            $form = Form::factory()->create();
-            $submission = FormSubmission::factory()->for($form)->create([
+        it( 'excludes PII from payload by default', function (): void {
+            $form       = Form::factory()->create();
+            $submission = FormSubmission::factory()->for( $form )->create( [
                 'ip_address' => '192.168.1.1',
                 'user_agent' => 'Mozilla/5.0',
-            ]);
+            ] );
 
-            Http::fake([
-                '*' => Http::response(['success' => true], 200),
-            ]);
+            Http::fake( [
+                '*' => Http::response( ['success' => true], 200 ),
+            ] );
 
-            $job = new SendWebhook($submission, 'https://webhook.example.com/endpoint');
+            $job = new SendWebhook( $submission, 'https://webhook.example.com/endpoint' );
             $job->handle();
 
-            Http::assertSent(function ($request) {
+            Http::assertSent( function ( $request ) {
                 $payload = $request->data();
 
-                return ! isset($payload['submission']['metadata']['ip_address'])
-                    && ! isset($payload['submission']['metadata']['user_agent']);
-            });
-        });
+                return ! isset( $payload['submission']['metadata']['ip_address'] )
+                    && ! isset( $payload['submission']['metadata']['user_agent'] );
+            } );
+        } );
 
-        it('includes PII in payload when privacy settings are enabled', function (): void {
-            config(['artisanpack.forms.privacy.include_ip_address' => true]);
-            config(['artisanpack.forms.privacy.include_user_agent' => true]);
+        it( 'includes PII in payload when privacy settings are enabled', function (): void {
+            config( ['artisanpack.forms.privacy.include_ip_address' => true] );
+            config( ['artisanpack.forms.privacy.include_user_agent' => true] );
 
-            $form = Form::factory()->create();
-            $submission = FormSubmission::factory()->for($form)->create([
+            $form       = Form::factory()->create();
+            $submission = FormSubmission::factory()->for( $form )->create( [
                 'ip_address' => '192.168.1.1',
                 'user_agent' => 'Mozilla/5.0',
-            ]);
+            ] );
 
-            Http::fake([
-                '*' => Http::response(['success' => true], 200),
-            ]);
+            Http::fake( [
+                '*' => Http::response( ['success' => true], 200 ),
+            ] );
 
-            $job = new SendWebhook($submission, 'https://webhook.example.com/endpoint');
+            $job = new SendWebhook( $submission, 'https://webhook.example.com/endpoint' );
             $job->handle();
 
-            Http::assertSent(function ($request) {
+            Http::assertSent( function ( $request ) {
                 $payload = $request->data();
 
-                return $payload['submission']['metadata']['ip_address'] === '192.168.1.1'
-                    && $payload['submission']['metadata']['user_agent'] === 'Mozilla/5.0';
-            });
-        });
-    });
+                return '192.168.1.1' === $payload['submission']['metadata']['ip_address']
+                    && 'Mozilla/5.0' === $payload['submission']['metadata']['user_agent'];
+            } );
+        } );
+    } );
 
-    describe('SendWebhookOnSubmission listener', function (): void {
-        it('dispatches webhook job when global webhook is enabled', function (): void {
+    describe( 'SendWebhookOnSubmission listener', function (): void {
+        it( 'dispatches webhook job when global webhook is enabled', function (): void {
             Queue::fake();
 
-            config(['artisanpack.forms.webhooks.enabled' => true]);
-            config(['artisanpack.forms.webhooks.url' => 'https://webhook.example.com/endpoint']);
+            config( ['artisanpack.forms.webhooks.enabled' => true] );
+            config( ['artisanpack.forms.webhooks.url' => 'https://webhook.example.com/endpoint'] );
 
-            $form = Form::factory()->create();
-            $submission = FormSubmission::factory()->for($form)->create();
+            $form       = Form::factory()->create();
+            $submission = FormSubmission::factory()->for( $form )->create();
 
             $listener = new SendWebhookOnSubmission;
-            $listener->handle(new FormSubmitted($submission));
+            $listener->handle( new FormSubmitted( $submission ) );
 
-            Queue::assertPushed(SendWebhook::class, function (SendWebhook $job) use ($submission) {
+            Queue::assertPushed( SendWebhook::class, function ( SendWebhook $job ) use ( $submission ) {
                 return $job->submission->id === $submission->id
-                    && $job->url === 'https://webhook.example.com/endpoint';
-            });
-        });
+                    && 'https://webhook.example.com/endpoint' === $job->url;
+            } );
+        } );
 
-        it('does not dispatch webhook job when global webhook is disabled', function (): void {
+        it( 'does not dispatch webhook job when global webhook is disabled', function (): void {
             Queue::fake();
 
-            config(['artisanpack.forms.webhooks.enabled' => false]);
+            config( ['artisanpack.forms.webhooks.enabled' => false] );
 
-            $form = Form::factory()->create();
-            $submission = FormSubmission::factory()->for($form)->create();
+            $form       = Form::factory()->create();
+            $submission = FormSubmission::factory()->for( $form )->create();
 
             $listener = new SendWebhookOnSubmission;
-            $listener->handle(new FormSubmitted($submission));
+            $listener->handle( new FormSubmitted( $submission ) );
 
-            Queue::assertNotPushed(SendWebhook::class);
-        });
+            Queue::assertNotPushed( SendWebhook::class );
+        } );
 
-        it('dispatches webhook job for form-specific webhook configuration', function (): void {
+        it( 'dispatches webhook job for form-specific webhook configuration', function (): void {
             Queue::fake();
 
-            config(['artisanpack.forms.webhooks.enabled' => false]); // Global disabled
+            config( ['artisanpack.forms.webhooks.enabled' => false] ); // Global disabled
 
-            $form = Form::factory()->create([
+            $form = Form::factory()->create( [
                 'settings' => [
                     'webhook' => [
                         'enabled' => true,
-                        'url' => 'https://form-specific-webhook.example.com/endpoint',
-                        'secret' => 'form-secret',
+                        'url'     => 'https://form-specific-webhook.example.com/endpoint',
+                        'secret'  => 'form-secret',
                     ],
                 ],
-            ]);
-            $submission = FormSubmission::factory()->for($form)->create();
+            ] );
+            $submission = FormSubmission::factory()->for( $form )->create();
 
             $listener = new SendWebhookOnSubmission;
-            $listener->handle(new FormSubmitted($submission));
+            $listener->handle( new FormSubmitted( $submission ) );
 
-            Queue::assertPushed(SendWebhook::class, function (SendWebhook $job) use ($submission) {
+            Queue::assertPushed( SendWebhook::class, function ( SendWebhook $job ) use ( $submission ) {
                 return $job->submission->id === $submission->id
-                    && $job->url === 'https://form-specific-webhook.example.com/endpoint'
-                    && $job->secret === 'form-secret';
-            });
-        });
-    });
-});
+                    && 'https://form-specific-webhook.example.com/endpoint' === $job->url
+                    && 'form-secret' === $job->secret;
+            } );
+        } );
+    } );
+} );
 
-afterEach(function (): void {
+afterEach( function (): void {
     // Reset config after each test
-    config(['artisanpack.forms.webhooks.enabled' => false]);
-    config(['artisanpack.forms.webhooks.url' => null]);
-    config(['artisanpack.forms.privacy.include_ip_address' => false]);
-    config(['artisanpack.forms.privacy.include_user_agent' => false]);
+    config( ['artisanpack.forms.webhooks.enabled' => false]);
+    config( ['artisanpack.forms.webhooks.url' => null]);
+    config( ['artisanpack.forms.privacy.include_ip_address' => false]);
+    config( ['artisanpack.forms.privacy.include_user_agent' => false]);
 
     // Reset filters
-    if (function_exists('removeAllFilters')) {
-        removeAllFilters('ap.forms.webhookPayload');
+    if ( function_exists( 'removeAllFilters')) {
+        removeAllFilters( 'ap.forms.webhookPayload');
     }
 });

--- a/tests/Feature/Services/ExportServiceTest.php
+++ b/tests/Feature/Services/ExportServiceTest.php
@@ -229,6 +229,6 @@ afterEach( function (): void {
 
     if ( function_exists( 'removeAllFilters' ) ) {
         removeAllFilters( 'ap.forms.exportHeaders' );
-        removeAllFilters( 'ap.forms.exportData');
+        removeAllFilters( 'ap.forms.exportData' );
     }
 });

--- a/tests/Feature/Services/ExportServiceTest.php
+++ b/tests/Feature/Services/ExportServiceTest.php
@@ -213,22 +213,22 @@ describe( 'ExportService', function (): void {
             } );
 
             $form = Form::factory()->create();
-            FormSubmission::factory()->for( $form)->create();
+            FormSubmission::factory()->for( $form )->create();
 
             $submissions = $form->submissions()->get();
-            $data        = $this->service->exportToJson( $form, $submissions);
+            $data        = $this->service->exportToJson( $form, $submissions );
 
-            expect( $data[0]['custom_json_field'])->toBe( 'custom_value');
-        });
-    });
-});
+            expect( $data[0]['custom_json_field'] )->toBe( 'custom_value' );
+        } );
+    } );
+} );
 
 afterEach( function (): void {
     // Reset privacy config
-    config( ['artisanpack.forms.privacy.include_ip_address' => false]);
+    config( ['artisanpack.forms.privacy.include_ip_address' => false] );
 
-    if ( function_exists( 'removeAllFilters')) {
-        removeAllFilters( 'ap.forms.exportHeaders');
+    if ( function_exists( 'removeAllFilters' ) ) {
+        removeAllFilters( 'ap.forms.exportHeaders' );
         removeAllFilters( 'ap.forms.exportData');
     }
 });

--- a/tests/Feature/Services/ExportServiceTest.php
+++ b/tests/Feature/Services/ExportServiceTest.php
@@ -1,233 +1,234 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Forms\Models\Form;
 use ArtisanPackUI\Forms\Models\FormField;
 use ArtisanPackUI\Forms\Models\FormSubmission;
 use ArtisanPackUI\Forms\Models\FormSubmissionValue;
 use ArtisanPackUI\Forms\Services\ExportService;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
-beforeEach( function (): void {
-    $this->service = app( ExportService::class );
-} );
+beforeEach(function (): void {
+    $this->service = app(ExportService::class);
+});
 
-describe( 'ExportService', function (): void {
-    describe( 'buildHeaders', function (): void {
-        it( 'includes standard headers', function (): void {
+describe('ExportService', function (): void {
+    describe('buildHeaders', function (): void {
+        it('includes standard headers', function (): void {
             $form = Form::factory()->create();
 
-            $headers = $this->service->buildHeaders( $form );
+            $headers = $this->service->buildHeaders($form);
 
-            expect( $headers )->toContain( 'Submission ID' )
-                ->and( $headers )->toContain( 'Submission Number' )
-                ->and( $headers )->toContain( 'Submitted At' )
-                ->and( $headers )->toContain( 'Page URL' )
-                ->and( $headers )->toContain( 'Is Read' )
-                ->and( $headers )->toContain( 'Is Spam' )
-                ->and( $headers )->toContain( 'Is Starred' );
+            expect($headers)->toContain('Submission ID')
+                ->and($headers)->toContain('Submission Number')
+                ->and($headers)->toContain('Submitted At')
+                ->and($headers)->toContain('Page URL')
+                ->and($headers)->toContain('Is Read')
+                ->and($headers)->toContain('Is Spam')
+                ->and($headers)->toContain('Is Starred');
 
             // IP Address should NOT be included by default (privacy)
-            expect( $headers )->not->toContain( 'IP Address' );
-        } );
+            expect($headers)->not->toContain('IP Address');
+        });
 
-        it( 'includes ip address header when privacy setting is enabled', function (): void {
-            config( ['artisanpack.forms.privacy.include_ip_address' => true] );
+        it('includes ip address header when privacy setting is enabled', function (): void {
+            config(['artisanpack.forms.privacy.include_ip_address' => true]);
 
-            $form    = Form::factory()->create();
-            $headers = $this->service->buildHeaders( $form );
-
-            expect( $headers )->toContain( 'IP Address' );
-        } );
-
-        it( 'includes field labels as headers', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->create( ['label' => 'Full Name', 'type' => 'text', 'sort_order' => 1] );
-            FormField::factory()->for( $form )->create( ['label' => 'Email Address', 'type' => 'email', 'sort_order' => 2] );
+            $headers = $this->service->buildHeaders($form);
 
-            $headers = $this->service->buildHeaders( $form );
+            expect($headers)->toContain('IP Address');
+        });
 
-            expect( $headers )->toContain( 'Full Name' )
-                ->and( $headers )->toContain( 'Email Address' );
-        } );
-
-        it( 'excludes layout fields from headers', function (): void {
+        it('includes field labels as headers', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->create( ['label' => 'Name', 'type' => 'text'] );
-            FormField::factory()->for( $form )->create( ['label' => 'Section Header', 'type' => 'heading'] );
+            FormField::factory()->for($form)->create(['label' => 'Full Name', 'type' => 'text', 'sort_order' => 1]);
+            FormField::factory()->for($form)->create(['label' => 'Email Address', 'type' => 'email', 'sort_order' => 2]);
 
-            $headers = $this->service->buildHeaders( $form );
+            $headers = $this->service->buildHeaders($form);
 
-            expect( $headers )->toContain( 'Name' )
-                ->and( $headers )->not->toContain( 'Section Header' );
-        } );
+            expect($headers)->toContain('Full Name')
+                ->and($headers)->toContain('Email Address');
+        });
 
-        it( 'applies forms.export_headers filter', function (): void {
-            if ( ! function_exists( 'addFilter' ) ) {
-                $this->markTestSkipped( 'Hook system not available' );
+        it('excludes layout fields from headers', function (): void {
+            $form = Form::factory()->create();
+            FormField::factory()->for($form)->create(['label' => 'Name', 'type' => 'text']);
+            FormField::factory()->for($form)->create(['label' => 'Section Header', 'type' => 'heading']);
+
+            $headers = $this->service->buildHeaders($form);
+
+            expect($headers)->toContain('Name')
+                ->and($headers)->not->toContain('Section Header');
+        });
+
+        it('applies ap.forms.exportHeaders filter', function (): void {
+            if (! function_exists('addFilter')) {
+                $this->markTestSkipped('Hook system not available');
             }
 
-            addFilter( 'forms.export_headers', function ( array $headers, Form $form ): array {
+            addFilter('ap.forms.exportHeaders', function (array $headers, Form $form): array {
                 $headers[] = 'Custom Integration Column';
 
                 return $headers;
-            } );
+            });
 
-            $form    = Form::factory()->create();
-            $headers = $this->service->buildHeaders( $form );
+            $form = Form::factory()->create();
+            $headers = $this->service->buildHeaders($form);
 
-            expect( $headers )->toContain( 'Custom Integration Column' );
-        } );
-    } );
+            expect($headers)->toContain('Custom Integration Column');
+        });
+    });
 
-    describe( 'buildRow', function (): void {
-        it( 'builds row with submission data', function (): void {
-            $form       = Form::factory()->create();
-            $field      = FormField::factory()->for( $form )->create( ['name' => 'email', 'label' => 'Email', 'type' => 'email'] );
-            $submission = FormSubmission::factory()->for( $form )->create( [
-                'page_url'   => 'https://example.com',
+    describe('buildRow', function (): void {
+        it('builds row with submission data', function (): void {
+            $form = Form::factory()->create();
+            $field = FormField::factory()->for($form)->create(['name' => 'email', 'label' => 'Email', 'type' => 'email']);
+            $submission = FormSubmission::factory()->for($form)->create([
+                'page_url' => 'https://example.com',
                 'ip_address' => '192.168.1.1',
-                'is_read'    => true,
-                'is_spam'    => false,
+                'is_read' => true,
+                'is_spam' => false,
                 'is_starred' => true,
-            ] );
-            FormSubmissionValue::factory()->for( $submission, 'submission' )->create( [
-                'field_id'   => $field->id,
+            ]);
+            FormSubmissionValue::factory()->for($submission, 'submission')->create([
+                'field_id' => $field->id,
                 'field_name' => 'email',
-                'value'      => 'test@example.com',
-            ] );
+                'value' => 'test@example.com',
+            ]);
 
-            $fields = $form->fields()->orderBy( 'sort_order' )->get();
-            $row    = $this->service->buildRow( $form, $submission, $fields );
+            $fields = $form->fields()->orderBy('sort_order')->get();
+            $row = $this->service->buildRow($form, $submission, $fields);
 
-            expect( $row )->toContain( (string) $submission->id )
-                ->and( $row )->toContain( $submission->submission_number )
-                ->and( $row )->toContain( 'test@example.com' )
-                ->and( $row )->toContain( 'https://example.com' )
-                ->and( $row )->toContain( '1' ) // is_read (default: stable 1/0 values)
-                ->and( $row )->toContain( '0' );  // is_spam (default: stable 1/0 values)
+            expect($row)->toContain((string) $submission->id)
+                ->and($row)->toContain($submission->submission_number)
+                ->and($row)->toContain('test@example.com')
+                ->and($row)->toContain('https://example.com')
+                ->and($row)->toContain('1') // is_read (default: stable 1/0 values)
+                ->and($row)->toContain('0');  // is_spam (default: stable 1/0 values)
 
             // IP address should NOT be included by default (privacy)
-            expect( $row )->not->toContain( '192.168.1.1' );
-        } );
+            expect($row)->not->toContain('192.168.1.1');
+        });
 
-        it( 'includes ip address when privacy setting is enabled', function (): void {
-            config( ['artisanpack.forms.privacy.include_ip_address' => true] );
+        it('includes ip address when privacy setting is enabled', function (): void {
+            config(['artisanpack.forms.privacy.include_ip_address' => true]);
 
-            $form       = Form::factory()->create();
-            $submission = FormSubmission::factory()->for( $form )->create( [
+            $form = Form::factory()->create();
+            $submission = FormSubmission::factory()->for($form)->create([
                 'ip_address' => '192.168.1.1',
-            ] );
+            ]);
 
-            $fields = $form->fields()->orderBy( 'sort_order' )->get();
-            $row    = $this->service->buildRow( $form, $submission, $fields );
+            $fields = $form->fields()->orderBy('sort_order')->get();
+            $row = $this->service->buildRow($form, $submission, $fields);
 
-            expect( $row )->toContain( '192.168.1.1' );
-        } );
+            expect($row)->toContain('192.168.1.1');
+        });
 
-        it( 'applies forms.export_data filter', function (): void {
-            if ( ! function_exists( 'addFilter' ) ) {
-                $this->markTestSkipped( 'Hook system not available' );
+        it('applies ap.forms.exportData filter', function (): void {
+            if (! function_exists('addFilter')) {
+                $this->markTestSkipped('Hook system not available');
             }
 
-            addFilter( 'forms.export_data', function ( array $row, FormSubmission $submission ): array {
+            addFilter('ap.forms.exportData', function (array $row, FormSubmission $submission): array {
                 $row[] = 'Added by integration';
 
                 return $row;
-            } );
+            });
 
-            $form       = Form::factory()->create();
-            $submission = FormSubmission::factory()->for( $form )->create();
-            $fields     = $form->fields()->orderBy( 'sort_order' )->get();
-
-            $row = $this->service->buildRow( $form, $submission, $fields );
-
-            expect( $row )->toContain( 'Added by integration' );
-        } );
-    } );
-
-    describe( 'buildRows', function (): void {
-        it( 'builds rows for multiple submissions', function (): void {
             $form = Form::factory()->create();
-            FormSubmission::factory()->for( $form )->count( 3 )->create();
+            $submission = FormSubmission::factory()->for($form)->create();
+            $fields = $form->fields()->orderBy('sort_order')->get();
+
+            $row = $this->service->buildRow($form, $submission, $fields);
+
+            expect($row)->toContain('Added by integration');
+        });
+    });
+
+    describe('buildRows', function (): void {
+        it('builds rows for multiple submissions', function (): void {
+            $form = Form::factory()->create();
+            FormSubmission::factory()->for($form)->count(3)->create();
 
             $submissions = $form->submissions()->get();
-            $rows        = $this->service->buildRows( $form, $submissions );
+            $rows = $this->service->buildRows($form, $submissions);
 
-            expect( $rows )->toHaveCount( 3 );
-        } );
-    } );
+            expect($rows)->toHaveCount(3);
+        });
+    });
 
-    describe( 'exportToCsv', function (): void {
-        it( 'returns a streamed response', function (): void {
-            $form        = Form::factory()->create();
+    describe('exportToCsv', function (): void {
+        it('returns a streamed response', function (): void {
+            $form = Form::factory()->create();
             $submissions = $form->submissions()->get();
 
-            $response = $this->service->exportToCsv( $form, $submissions );
+            $response = $this->service->exportToCsv($form, $submissions);
 
-            expect( $response )->toBeInstanceOf( Symfony\Component\HttpFoundation\StreamedResponse::class )
-                ->and( $response->headers->get( 'Content-Type' ) )->toBe( 'text/csv' );
-        } );
+            expect($response)->toBeInstanceOf(StreamedResponse::class)
+                ->and($response->headers->get('Content-Type'))->toBe('text/csv');
+        });
 
-        it( 'uses custom filename when provided', function (): void {
-            $form        = Form::factory()->create();
+        it('uses custom filename when provided', function (): void {
+            $form = Form::factory()->create();
             $submissions = $form->submissions()->get();
 
-            $response = $this->service->exportToCsv( $form, $submissions, 'custom-export.csv' );
+            $response = $this->service->exportToCsv($form, $submissions, 'custom-export.csv');
 
-            expect( $response->headers->get( 'Content-Disposition' ) )->toContain( 'custom-export.csv' );
-        } );
-    } );
+            expect($response->headers->get('Content-Disposition'))->toContain('custom-export.csv');
+        });
+    });
 
-    describe( 'exportToJson', function (): void {
-        it( 'returns array of submission data', function (): void {
-            $form       = Form::factory()->create();
-            $field      = FormField::factory()->for( $form )->create( ['name' => 'name', 'type' => 'text'] );
-            $submission = FormSubmission::factory()->for( $form )->create();
-            FormSubmissionValue::factory()->for( $submission, 'submission' )->create( [
-                'field_id'   => $field->id,
+    describe('exportToJson', function (): void {
+        it('returns array of submission data', function (): void {
+            $form = Form::factory()->create();
+            $field = FormField::factory()->for($form)->create(['name' => 'name', 'type' => 'text']);
+            $submission = FormSubmission::factory()->for($form)->create();
+            FormSubmissionValue::factory()->for($submission, 'submission')->create([
+                'field_id' => $field->id,
                 'field_name' => 'name',
-                'value'      => 'Test User',
-            ] );
+                'value' => 'Test User',
+            ]);
 
             $submissions = $form->submissions()->get();
-            $data        = $this->service->exportToJson( $form, $submissions );
+            $data = $this->service->exportToJson($form, $submissions);
 
-            expect( $data )->toHaveCount( 1 )
-                ->and( $data[0]['id'] )->toBe( $submission->id )
-                ->and( $data[0]['submission_number'] )->toBe( $submission->submission_number )
-                ->and( $data[0] )->toHaveKey( 'data' )
-                ->and( $data[0] )->toHaveKey( 'metadata' );
-        } );
+            expect($data)->toHaveCount(1)
+                ->and($data[0]['id'])->toBe($submission->id)
+                ->and($data[0]['submission_number'])->toBe($submission->submission_number)
+                ->and($data[0])->toHaveKey('data')
+                ->and($data[0])->toHaveKey('metadata');
+        });
 
-        it( 'applies forms.export_data filter to JSON export', function (): void {
-            if ( ! function_exists( 'addFilter' ) ) {
-                $this->markTestSkipped( 'Hook system not available' );
+        it('applies ap.forms.exportData filter to JSON export', function (): void {
+            if (! function_exists('addFilter')) {
+                $this->markTestSkipped('Hook system not available');
             }
 
-            addFilter( 'forms.export_data', function ( array $data, FormSubmission $submission ): array {
+            addFilter('ap.forms.exportData', function (array $data, FormSubmission $submission): array {
                 $data['custom_json_field'] = 'custom_value';
 
                 return $data;
-            } );
+            });
 
             $form = Form::factory()->create();
-            FormSubmission::factory()->for( $form )->create();
+            FormSubmission::factory()->for($form)->create();
 
             $submissions = $form->submissions()->get();
-            $data        = $this->service->exportToJson( $form, $submissions );
+            $data = $this->service->exportToJson($form, $submissions);
 
-            expect( $data[0]['custom_json_field'] )->toBe( 'custom_value' );
-        } );
-    } );
-} );
+            expect($data[0]['custom_json_field'])->toBe('custom_value');
+        });
+    });
+});
 
-afterEach( function (): void {
+afterEach(function (): void {
     // Reset privacy config
-    config( ['artisanpack.forms.privacy.include_ip_address' => false] );
+    config(['artisanpack.forms.privacy.include_ip_address' => false]);
 
-    if ( function_exists( 'removeAllFilters' ) ) {
-        removeAllFilters( 'forms.export_headers' );
-        removeAllFilters( 'forms.export_data' );
+    if (function_exists('removeAllFilters')) {
+        removeAllFilters('ap.forms.exportHeaders');
+        removeAllFilters('ap.forms.exportData');
     }
 });

--- a/tests/Feature/Services/ExportServiceTest.php
+++ b/tests/Feature/Services/ExportServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Forms\Models\Form;
 use ArtisanPackUI\Forms\Models\FormField;
@@ -9,226 +9,226 @@ use ArtisanPackUI\Forms\Models\FormSubmissionValue;
 use ArtisanPackUI\Forms\Services\ExportService;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
-beforeEach(function (): void {
-    $this->service = app(ExportService::class);
-});
+beforeEach( function (): void {
+    $this->service = app( ExportService::class );
+} );
 
-describe('ExportService', function (): void {
-    describe('buildHeaders', function (): void {
-        it('includes standard headers', function (): void {
+describe( 'ExportService', function (): void {
+    describe( 'buildHeaders', function (): void {
+        it( 'includes standard headers', function (): void {
             $form = Form::factory()->create();
 
-            $headers = $this->service->buildHeaders($form);
+            $headers = $this->service->buildHeaders( $form );
 
-            expect($headers)->toContain('Submission ID')
-                ->and($headers)->toContain('Submission Number')
-                ->and($headers)->toContain('Submitted At')
-                ->and($headers)->toContain('Page URL')
-                ->and($headers)->toContain('Is Read')
-                ->and($headers)->toContain('Is Spam')
-                ->and($headers)->toContain('Is Starred');
+            expect( $headers )->toContain( 'Submission ID' )
+                ->and( $headers )->toContain( 'Submission Number' )
+                ->and( $headers )->toContain( 'Submitted At' )
+                ->and( $headers )->toContain( 'Page URL' )
+                ->and( $headers )->toContain( 'Is Read' )
+                ->and( $headers )->toContain( 'Is Spam' )
+                ->and( $headers )->toContain( 'Is Starred' );
 
             // IP Address should NOT be included by default (privacy)
-            expect($headers)->not->toContain('IP Address');
-        });
+            expect( $headers )->not->toContain( 'IP Address' );
+        } );
 
-        it('includes ip address header when privacy setting is enabled', function (): void {
-            config(['artisanpack.forms.privacy.include_ip_address' => true]);
+        it( 'includes ip address header when privacy setting is enabled', function (): void {
+            config( ['artisanpack.forms.privacy.include_ip_address' => true] );
 
+            $form    = Form::factory()->create();
+            $headers = $this->service->buildHeaders( $form );
+
+            expect( $headers )->toContain( 'IP Address' );
+        } );
+
+        it( 'includes field labels as headers', function (): void {
             $form = Form::factory()->create();
-            $headers = $this->service->buildHeaders($form);
+            FormField::factory()->for( $form )->create( ['label' => 'Full Name', 'type' => 'text', 'sort_order' => 1] );
+            FormField::factory()->for( $form )->create( ['label' => 'Email Address', 'type' => 'email', 'sort_order' => 2] );
 
-            expect($headers)->toContain('IP Address');
-        });
+            $headers = $this->service->buildHeaders( $form );
 
-        it('includes field labels as headers', function (): void {
+            expect( $headers )->toContain( 'Full Name' )
+                ->and( $headers )->toContain( 'Email Address' );
+        } );
+
+        it( 'excludes layout fields from headers', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->create(['label' => 'Full Name', 'type' => 'text', 'sort_order' => 1]);
-            FormField::factory()->for($form)->create(['label' => 'Email Address', 'type' => 'email', 'sort_order' => 2]);
+            FormField::factory()->for( $form )->create( ['label' => 'Name', 'type' => 'text'] );
+            FormField::factory()->for( $form )->create( ['label' => 'Section Header', 'type' => 'heading'] );
 
-            $headers = $this->service->buildHeaders($form);
+            $headers = $this->service->buildHeaders( $form );
 
-            expect($headers)->toContain('Full Name')
-                ->and($headers)->toContain('Email Address');
-        });
+            expect( $headers )->toContain( 'Name' )
+                ->and( $headers )->not->toContain( 'Section Header' );
+        } );
 
-        it('excludes layout fields from headers', function (): void {
-            $form = Form::factory()->create();
-            FormField::factory()->for($form)->create(['label' => 'Name', 'type' => 'text']);
-            FormField::factory()->for($form)->create(['label' => 'Section Header', 'type' => 'heading']);
-
-            $headers = $this->service->buildHeaders($form);
-
-            expect($headers)->toContain('Name')
-                ->and($headers)->not->toContain('Section Header');
-        });
-
-        it('applies ap.forms.exportHeaders filter', function (): void {
-            if (! function_exists('addFilter')) {
-                $this->markTestSkipped('Hook system not available');
+        it( 'applies ap.forms.exportHeaders filter', function (): void {
+            if ( ! function_exists( 'addFilter' ) ) {
+                $this->markTestSkipped( 'Hook system not available' );
             }
 
-            addFilter('ap.forms.exportHeaders', function (array $headers, Form $form): array {
+            addFilter( 'ap.forms.exportHeaders', function ( array $headers, Form $form ): array {
                 $headers[] = 'Custom Integration Column';
 
                 return $headers;
-            });
+            } );
 
-            $form = Form::factory()->create();
-            $headers = $this->service->buildHeaders($form);
+            $form    = Form::factory()->create();
+            $headers = $this->service->buildHeaders( $form );
 
-            expect($headers)->toContain('Custom Integration Column');
-        });
-    });
+            expect( $headers )->toContain( 'Custom Integration Column' );
+        } );
+    } );
 
-    describe('buildRow', function (): void {
-        it('builds row with submission data', function (): void {
-            $form = Form::factory()->create();
-            $field = FormField::factory()->for($form)->create(['name' => 'email', 'label' => 'Email', 'type' => 'email']);
-            $submission = FormSubmission::factory()->for($form)->create([
-                'page_url' => 'https://example.com',
+    describe( 'buildRow', function (): void {
+        it( 'builds row with submission data', function (): void {
+            $form       = Form::factory()->create();
+            $field      = FormField::factory()->for( $form )->create( ['name' => 'email', 'label' => 'Email', 'type' => 'email'] );
+            $submission = FormSubmission::factory()->for( $form )->create( [
+                'page_url'   => 'https://example.com',
                 'ip_address' => '192.168.1.1',
-                'is_read' => true,
-                'is_spam' => false,
+                'is_read'    => true,
+                'is_spam'    => false,
                 'is_starred' => true,
-            ]);
-            FormSubmissionValue::factory()->for($submission, 'submission')->create([
-                'field_id' => $field->id,
+            ] );
+            FormSubmissionValue::factory()->for( $submission, 'submission' )->create( [
+                'field_id'   => $field->id,
                 'field_name' => 'email',
-                'value' => 'test@example.com',
-            ]);
+                'value'      => 'test@example.com',
+            ] );
 
-            $fields = $form->fields()->orderBy('sort_order')->get();
-            $row = $this->service->buildRow($form, $submission, $fields);
+            $fields = $form->fields()->orderBy( 'sort_order' )->get();
+            $row    = $this->service->buildRow( $form, $submission, $fields );
 
-            expect($row)->toContain((string) $submission->id)
-                ->and($row)->toContain($submission->submission_number)
-                ->and($row)->toContain('test@example.com')
-                ->and($row)->toContain('https://example.com')
-                ->and($row)->toContain('1') // is_read (default: stable 1/0 values)
-                ->and($row)->toContain('0');  // is_spam (default: stable 1/0 values)
+            expect( $row )->toContain( (string) $submission->id )
+                ->and( $row )->toContain( $submission->submission_number )
+                ->and( $row )->toContain( 'test@example.com' )
+                ->and( $row )->toContain( 'https://example.com' )
+                ->and( $row )->toContain( '1' ) // is_read (default: stable 1/0 values)
+                ->and( $row )->toContain( '0' );  // is_spam (default: stable 1/0 values)
 
             // IP address should NOT be included by default (privacy)
-            expect($row)->not->toContain('192.168.1.1');
-        });
+            expect( $row )->not->toContain( '192.168.1.1' );
+        } );
 
-        it('includes ip address when privacy setting is enabled', function (): void {
-            config(['artisanpack.forms.privacy.include_ip_address' => true]);
+        it( 'includes ip address when privacy setting is enabled', function (): void {
+            config( ['artisanpack.forms.privacy.include_ip_address' => true] );
 
-            $form = Form::factory()->create();
-            $submission = FormSubmission::factory()->for($form)->create([
+            $form       = Form::factory()->create();
+            $submission = FormSubmission::factory()->for( $form )->create( [
                 'ip_address' => '192.168.1.1',
-            ]);
+            ] );
 
-            $fields = $form->fields()->orderBy('sort_order')->get();
-            $row = $this->service->buildRow($form, $submission, $fields);
+            $fields = $form->fields()->orderBy( 'sort_order' )->get();
+            $row    = $this->service->buildRow( $form, $submission, $fields );
 
-            expect($row)->toContain('192.168.1.1');
-        });
+            expect( $row )->toContain( '192.168.1.1' );
+        } );
 
-        it('applies ap.forms.exportData filter', function (): void {
-            if (! function_exists('addFilter')) {
-                $this->markTestSkipped('Hook system not available');
+        it( 'applies ap.forms.exportData filter', function (): void {
+            if ( ! function_exists( 'addFilter' ) ) {
+                $this->markTestSkipped( 'Hook system not available' );
             }
 
-            addFilter('ap.forms.exportData', function (array $row, FormSubmission $submission): array {
+            addFilter( 'ap.forms.exportData', function ( array $row, FormSubmission $submission ): array {
                 $row[] = 'Added by integration';
 
                 return $row;
-            });
+            } );
 
+            $form       = Form::factory()->create();
+            $submission = FormSubmission::factory()->for( $form )->create();
+            $fields     = $form->fields()->orderBy( 'sort_order' )->get();
+
+            $row = $this->service->buildRow( $form, $submission, $fields );
+
+            expect( $row )->toContain( 'Added by integration' );
+        } );
+    } );
+
+    describe( 'buildRows', function (): void {
+        it( 'builds rows for multiple submissions', function (): void {
             $form = Form::factory()->create();
-            $submission = FormSubmission::factory()->for($form)->create();
-            $fields = $form->fields()->orderBy('sort_order')->get();
-
-            $row = $this->service->buildRow($form, $submission, $fields);
-
-            expect($row)->toContain('Added by integration');
-        });
-    });
-
-    describe('buildRows', function (): void {
-        it('builds rows for multiple submissions', function (): void {
-            $form = Form::factory()->create();
-            FormSubmission::factory()->for($form)->count(3)->create();
+            FormSubmission::factory()->for( $form )->count( 3 )->create();
 
             $submissions = $form->submissions()->get();
-            $rows = $this->service->buildRows($form, $submissions);
+            $rows        = $this->service->buildRows( $form, $submissions );
 
-            expect($rows)->toHaveCount(3);
-        });
-    });
+            expect( $rows )->toHaveCount( 3 );
+        } );
+    } );
 
-    describe('exportToCsv', function (): void {
-        it('returns a streamed response', function (): void {
-            $form = Form::factory()->create();
+    describe( 'exportToCsv', function (): void {
+        it( 'returns a streamed response', function (): void {
+            $form        = Form::factory()->create();
             $submissions = $form->submissions()->get();
 
-            $response = $this->service->exportToCsv($form, $submissions);
+            $response = $this->service->exportToCsv( $form, $submissions );
 
-            expect($response)->toBeInstanceOf(StreamedResponse::class)
-                ->and($response->headers->get('Content-Type'))->toBe('text/csv');
-        });
+            expect( $response )->toBeInstanceOf( StreamedResponse::class )
+                ->and( $response->headers->get( 'Content-Type' ) )->toBe( 'text/csv' );
+        } );
 
-        it('uses custom filename when provided', function (): void {
-            $form = Form::factory()->create();
+        it( 'uses custom filename when provided', function (): void {
+            $form        = Form::factory()->create();
             $submissions = $form->submissions()->get();
 
-            $response = $this->service->exportToCsv($form, $submissions, 'custom-export.csv');
+            $response = $this->service->exportToCsv( $form, $submissions, 'custom-export.csv' );
 
-            expect($response->headers->get('Content-Disposition'))->toContain('custom-export.csv');
-        });
-    });
+            expect( $response->headers->get( 'Content-Disposition' ) )->toContain( 'custom-export.csv' );
+        } );
+    } );
 
-    describe('exportToJson', function (): void {
-        it('returns array of submission data', function (): void {
-            $form = Form::factory()->create();
-            $field = FormField::factory()->for($form)->create(['name' => 'name', 'type' => 'text']);
-            $submission = FormSubmission::factory()->for($form)->create();
-            FormSubmissionValue::factory()->for($submission, 'submission')->create([
-                'field_id' => $field->id,
+    describe( 'exportToJson', function (): void {
+        it( 'returns array of submission data', function (): void {
+            $form       = Form::factory()->create();
+            $field      = FormField::factory()->for( $form )->create( ['name' => 'name', 'type' => 'text'] );
+            $submission = FormSubmission::factory()->for( $form )->create();
+            FormSubmissionValue::factory()->for( $submission, 'submission' )->create( [
+                'field_id'   => $field->id,
                 'field_name' => 'name',
-                'value' => 'Test User',
-            ]);
+                'value'      => 'Test User',
+            ] );
 
             $submissions = $form->submissions()->get();
-            $data = $this->service->exportToJson($form, $submissions);
+            $data        = $this->service->exportToJson( $form, $submissions );
 
-            expect($data)->toHaveCount(1)
-                ->and($data[0]['id'])->toBe($submission->id)
-                ->and($data[0]['submission_number'])->toBe($submission->submission_number)
-                ->and($data[0])->toHaveKey('data')
-                ->and($data[0])->toHaveKey('metadata');
-        });
+            expect( $data )->toHaveCount( 1 )
+                ->and( $data[0]['id'] )->toBe( $submission->id )
+                ->and( $data[0]['submission_number'] )->toBe( $submission->submission_number )
+                ->and( $data[0] )->toHaveKey( 'data' )
+                ->and( $data[0] )->toHaveKey( 'metadata' );
+        } );
 
-        it('applies ap.forms.exportData filter to JSON export', function (): void {
-            if (! function_exists('addFilter')) {
-                $this->markTestSkipped('Hook system not available');
+        it( 'applies ap.forms.exportData filter to JSON export', function (): void {
+            if ( ! function_exists( 'addFilter' ) ) {
+                $this->markTestSkipped( 'Hook system not available' );
             }
 
-            addFilter('ap.forms.exportData', function (array $data, FormSubmission $submission): array {
+            addFilter( 'ap.forms.exportData', function ( array $data, FormSubmission $submission ): array {
                 $data['custom_json_field'] = 'custom_value';
 
                 return $data;
-            });
+            } );
 
             $form = Form::factory()->create();
-            FormSubmission::factory()->for($form)->create();
+            FormSubmission::factory()->for( $form)->create();
 
             $submissions = $form->submissions()->get();
-            $data = $this->service->exportToJson($form, $submissions);
+            $data        = $this->service->exportToJson( $form, $submissions);
 
-            expect($data[0]['custom_json_field'])->toBe('custom_value');
+            expect( $data[0]['custom_json_field'])->toBe( 'custom_value');
         });
     });
 });
 
-afterEach(function (): void {
+afterEach( function (): void {
     // Reset privacy config
-    config(['artisanpack.forms.privacy.include_ip_address' => false]);
+    config( ['artisanpack.forms.privacy.include_ip_address' => false]);
 
-    if (function_exists('removeAllFilters')) {
-        removeAllFilters('ap.forms.exportHeaders');
-        removeAllFilters('ap.forms.exportData');
+    if ( function_exists( 'removeAllFilters')) {
+        removeAllFilters( 'ap.forms.exportHeaders');
+        removeAllFilters( 'ap.forms.exportData');
     }
 });

--- a/tests/Feature/Services/IntegrationServiceTest.php
+++ b/tests/Feature/Services/IntegrationServiceTest.php
@@ -1,33 +1,33 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Forms\Models\Form;
 use ArtisanPackUI\Forms\Services\IntegrationService;
 
-beforeEach(function (): void {
-    $this->service = app(IntegrationService::class);
-});
+beforeEach( function (): void {
+    $this->service = app( IntegrationService::class );
+} );
 
-describe('IntegrationService', function (): void {
-    describe('integration settings', function (): void {
-        it('sets integration settings for a form', function (): void {
+describe( 'IntegrationService', function (): void {
+    describe( 'integration settings', function (): void {
+        it( 'sets integration settings for a form', function (): void {
             $form = Form::factory()->create();
 
-            $this->service->setIntegrationSettings($form, 'mailchimp', [
+            $this->service->setIntegrationSettings( $form, 'mailchimp', [
                 'api_key' => 'test-api-key',
                 'list_id' => 'test-list-id',
-            ]);
+            ] );
 
             $form->refresh();
 
-            expect($form->settings['integrations']['mailchimp'])->toBeArray()
-                ->and($form->settings['integrations']['mailchimp']['api_key'])->toBe('test-api-key')
-                ->and($form->settings['integrations']['mailchimp']['list_id'])->toBe('test-list-id');
-        });
+            expect( $form->settings['integrations']['mailchimp'] )->toBeArray()
+                ->and( $form->settings['integrations']['mailchimp']['api_key'] )->toBe( 'test-api-key' )
+                ->and( $form->settings['integrations']['mailchimp']['list_id'] )->toBe( 'test-list-id' );
+        } );
 
-        it('gets integration setting for a form', function (): void {
-            $form = Form::factory()->create([
+        it( 'gets integration setting for a form', function (): void {
+            $form = Form::factory()->create( [
                 'settings' => [
                     'integrations' => [
                         'mailchimp' => [
@@ -36,19 +36,19 @@ describe('IntegrationService', function (): void {
                         ],
                     ],
                 ],
-            ]);
+            ] );
 
-            $apiKey = $this->service->getIntegrationSetting($form, 'mailchimp', 'api_key');
-            $listId = $this->service->getIntegrationSetting($form, 'mailchimp', 'list_id');
-            $missing = $this->service->getIntegrationSetting($form, 'mailchimp', 'missing', 'default');
+            $apiKey  = $this->service->getIntegrationSetting( $form, 'mailchimp', 'api_key' );
+            $listId  = $this->service->getIntegrationSetting( $form, 'mailchimp', 'list_id' );
+            $missing = $this->service->getIntegrationSetting( $form, 'mailchimp', 'missing', 'default' );
 
-            expect($apiKey)->toBe('test-api-key')
-                ->and($listId)->toBe('test-list-id')
-                ->and($missing)->toBe('default');
-        });
+            expect( $apiKey )->toBe( 'test-api-key' )
+                ->and( $listId )->toBe( 'test-list-id' )
+                ->and( $missing )->toBe( 'default' );
+        } );
 
-        it('gets all provider settings when key is null', function (): void {
-            $form = Form::factory()->create([
+        it( 'gets all provider settings when key is null', function (): void {
+            $form = Form::factory()->create( [
                 'settings' => [
                     'integrations' => [
                         'mailchimp' => [
@@ -57,17 +57,17 @@ describe('IntegrationService', function (): void {
                         ],
                     ],
                 ],
-            ]);
+            ] );
 
-            $allSettings = $this->service->getIntegrationSetting($form, 'mailchimp');
+            $allSettings = $this->service->getIntegrationSetting( $form, 'mailchimp' );
 
-            expect($allSettings)->toBeArray()
-                ->and($allSettings['api_key'])->toBe('test-api-key')
-                ->and($allSettings['list_id'])->toBe('test-list-id');
-        });
+            expect( $allSettings )->toBeArray()
+                ->and( $allSettings['api_key'] )->toBe( 'test-api-key' )
+                ->and( $allSettings['list_id'] )->toBe( 'test-list-id' );
+        } );
 
-        it('updates a specific integration setting', function (): void {
-            $form = Form::factory()->create([
+        it( 'updates a specific integration setting', function (): void {
+            $form = Form::factory()->create( [
                 'settings' => [
                     'integrations' => [
                         'mailchimp' => [
@@ -75,97 +75,97 @@ describe('IntegrationService', function (): void {
                         ],
                     ],
                 ],
-            ]);
+            ] );
 
-            $this->service->updateIntegrationSetting($form, 'mailchimp', 'api_key', 'new-key');
+            $this->service->updateIntegrationSetting( $form, 'mailchimp', 'api_key', 'new-key' );
             $form->refresh();
 
-            expect($form->settings['integrations']['mailchimp']['api_key'])->toBe('new-key');
-        });
+            expect( $form->settings['integrations']['mailchimp']['api_key'] )->toBe( 'new-key' );
+        } );
 
-        it('removes integration settings for a provider', function (): void {
-            $form = Form::factory()->create([
+        it( 'removes integration settings for a provider', function (): void {
+            $form = Form::factory()->create( [
                 'settings' => [
                     'integrations' => [
-                        'mailchimp' => ['api_key' => 'test'],
+                        'mailchimp'  => ['api_key' => 'test'],
                         'convertkit' => ['api_key' => 'test'],
                     ],
                 ],
-            ]);
+            ] );
 
-            $this->service->removeIntegrationSettings($form, 'mailchimp');
+            $this->service->removeIntegrationSettings( $form, 'mailchimp' );
             $form->refresh();
 
-            expect($form->settings['integrations'])->not->toHaveKey('mailchimp')
-                ->and($form->settings['integrations'])->toHaveKey('convertkit');
-        });
+            expect( $form->settings['integrations'] )->not->toHaveKey( 'mailchimp' )
+                ->and( $form->settings['integrations'] )->toHaveKey( 'convertkit' );
+        } );
 
-        it('checks if form has integration configured', function (): void {
-            $form = Form::factory()->create([
+        it( 'checks if form has integration configured', function (): void {
+            $form = Form::factory()->create( [
                 'settings' => [
                     'integrations' => [
                         'mailchimp' => ['api_key' => 'test'],
                     ],
                 ],
-            ]);
+            ] );
 
-            expect($this->service->hasIntegration($form, 'mailchimp'))->toBeTrue()
-                ->and($this->service->hasIntegration($form, 'convertkit'))->toBeFalse();
-        });
+            expect( $this->service->hasIntegration( $form, 'mailchimp' ) )->toBeTrue()
+                ->and( $this->service->hasIntegration( $form, 'convertkit' ) )->toBeFalse();
+        } );
 
-        it('gets list of configured providers', function (): void {
-            $form = Form::factory()->create([
+        it( 'gets list of configured providers', function (): void {
+            $form = Form::factory()->create( [
                 'settings' => [
                     'integrations' => [
-                        'mailchimp' => ['api_key' => 'test'],
-                        'convertkit' => ['api_key' => 'test'],
+                        'mailchimp'      => ['api_key' => 'test'],
+                        'convertkit'     => ['api_key' => 'test'],
                         'empty_provider' => [],
                     ],
                 ],
-            ]);
+            ] );
 
-            $providers = $this->service->getConfiguredProviders($form);
+            $providers = $this->service->getConfiguredProviders( $form );
 
-            expect($providers)->toContain('mailchimp')
-                ->and($providers)->toContain('convertkit')
-                ->and($providers)->not->toContain('empty_provider');
-        });
-    });
+            expect( $providers )->toContain( 'mailchimp' )
+                ->and( $providers )->toContain( 'convertkit' )
+                ->and( $providers )->not->toContain( 'empty_provider' );
+        } );
+    } );
 
-    describe('settings tabs', function (): void {
-        it('returns registered tabs from filter hook', function (): void {
-            if (! function_exists('addFilter')) {
-                $this->markTestSkipped('Hook system not available');
+    describe( 'settings tabs', function (): void {
+        it( 'returns registered tabs from filter hook', function (): void {
+            if ( ! function_exists( 'addFilter' ) ) {
+                $this->markTestSkipped( 'Hook system not available' );
             }
 
-            addFilter('ap.forms.settingsTabs', function (array $tabs): array {
+            addFilter( 'ap.forms.settingsTabs', function ( array $tabs ): array {
                 $tabs[] = [
-                    'id' => 'tab1',
-                    'label' => 'Tab 1',
-                    'icon' => 'o-cog',
+                    'id'        => 'tab1',
+                    'label'     => 'Tab 1',
+                    'icon'      => 'o-cog',
                     'component' => 'tab-1-component',
                 ];
                 $tabs[] = [
-                    'id' => 'tab2',
-                    'label' => 'Tab 2',
-                    'icon' => 'o-envelope',
+                    'id'        => 'tab2',
+                    'label'     => 'Tab 2',
+                    'icon'      => 'o-envelope',
                     'component' => 'tab-2-component',
                 ];
 
                 return $tabs;
-            });
+            } );
 
             $tabs = $this->service->getSettingsTabs();
 
-            expect($tabs)->toHaveCount(2)
-                ->and($tabs[0]['id'])->toBe('tab1')
-                ->and($tabs[1]['id'])->toBe('tab2');
+            expect( $tabs )->toHaveCount( 2 )
+                ->and( $tabs[0]['id'] )->toBe( 'tab1' )
+                ->and( $tabs[1]['id'])->toBe( 'tab2');
         });
     });
 });
 
-afterEach(function (): void {
-    if (function_exists('removeAllFilters')) {
-        removeAllFilters('ap.forms.settingsTabs');
+afterEach( function (): void {
+    if ( function_exists( 'removeAllFilters')) {
+        removeAllFilters( 'ap.forms.settingsTabs');
     }
 });

--- a/tests/Feature/Services/IntegrationServiceTest.php
+++ b/tests/Feature/Services/IntegrationServiceTest.php
@@ -159,13 +159,13 @@ describe( 'IntegrationService', function (): void {
 
             expect( $tabs )->toHaveCount( 2 )
                 ->and( $tabs[0]['id'] )->toBe( 'tab1' )
-                ->and( $tabs[1]['id'])->toBe( 'tab2');
-        });
-    });
-});
+                ->and( $tabs[1]['id'] )->toBe( 'tab2' );
+        } );
+    } );
+} );
 
 afterEach( function (): void {
-    if ( function_exists( 'removeAllFilters')) {
-        removeAllFilters( 'ap.forms.settingsTabs');
+    if ( function_exists( 'removeAllFilters' ) ) {
+        removeAllFilters( 'ap.forms.settingsTabs' );
     }
 });

--- a/tests/Feature/Services/IntegrationServiceTest.php
+++ b/tests/Feature/Services/IntegrationServiceTest.php
@@ -1,33 +1,33 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Forms\Models\Form;
 use ArtisanPackUI\Forms\Services\IntegrationService;
 
-beforeEach( function (): void {
-    $this->service = app( IntegrationService::class );
-} );
+beforeEach(function (): void {
+    $this->service = app(IntegrationService::class);
+});
 
-describe( 'IntegrationService', function (): void {
-    describe( 'integration settings', function (): void {
-        it( 'sets integration settings for a form', function (): void {
+describe('IntegrationService', function (): void {
+    describe('integration settings', function (): void {
+        it('sets integration settings for a form', function (): void {
             $form = Form::factory()->create();
 
-            $this->service->setIntegrationSettings( $form, 'mailchimp', [
+            $this->service->setIntegrationSettings($form, 'mailchimp', [
                 'api_key' => 'test-api-key',
                 'list_id' => 'test-list-id',
-            ] );
+            ]);
 
             $form->refresh();
 
-            expect( $form->settings['integrations']['mailchimp'] )->toBeArray()
-                ->and( $form->settings['integrations']['mailchimp']['api_key'] )->toBe( 'test-api-key' )
-                ->and( $form->settings['integrations']['mailchimp']['list_id'] )->toBe( 'test-list-id' );
-        } );
+            expect($form->settings['integrations']['mailchimp'])->toBeArray()
+                ->and($form->settings['integrations']['mailchimp']['api_key'])->toBe('test-api-key')
+                ->and($form->settings['integrations']['mailchimp']['list_id'])->toBe('test-list-id');
+        });
 
-        it( 'gets integration setting for a form', function (): void {
-            $form = Form::factory()->create( [
+        it('gets integration setting for a form', function (): void {
+            $form = Form::factory()->create([
                 'settings' => [
                     'integrations' => [
                         'mailchimp' => [
@@ -36,19 +36,19 @@ describe( 'IntegrationService', function (): void {
                         ],
                     ],
                 ],
-            ] );
+            ]);
 
-            $apiKey  = $this->service->getIntegrationSetting( $form, 'mailchimp', 'api_key' );
-            $listId  = $this->service->getIntegrationSetting( $form, 'mailchimp', 'list_id' );
-            $missing = $this->service->getIntegrationSetting( $form, 'mailchimp', 'missing', 'default' );
+            $apiKey = $this->service->getIntegrationSetting($form, 'mailchimp', 'api_key');
+            $listId = $this->service->getIntegrationSetting($form, 'mailchimp', 'list_id');
+            $missing = $this->service->getIntegrationSetting($form, 'mailchimp', 'missing', 'default');
 
-            expect( $apiKey )->toBe( 'test-api-key' )
-                ->and( $listId )->toBe( 'test-list-id' )
-                ->and( $missing )->toBe( 'default' );
-        } );
+            expect($apiKey)->toBe('test-api-key')
+                ->and($listId)->toBe('test-list-id')
+                ->and($missing)->toBe('default');
+        });
 
-        it( 'gets all provider settings when key is null', function (): void {
-            $form = Form::factory()->create( [
+        it('gets all provider settings when key is null', function (): void {
+            $form = Form::factory()->create([
                 'settings' => [
                     'integrations' => [
                         'mailchimp' => [
@@ -57,17 +57,17 @@ describe( 'IntegrationService', function (): void {
                         ],
                     ],
                 ],
-            ] );
+            ]);
 
-            $allSettings = $this->service->getIntegrationSetting( $form, 'mailchimp' );
+            $allSettings = $this->service->getIntegrationSetting($form, 'mailchimp');
 
-            expect( $allSettings )->toBeArray()
-                ->and( $allSettings['api_key'] )->toBe( 'test-api-key' )
-                ->and( $allSettings['list_id'] )->toBe( 'test-list-id' );
-        } );
+            expect($allSettings)->toBeArray()
+                ->and($allSettings['api_key'])->toBe('test-api-key')
+                ->and($allSettings['list_id'])->toBe('test-list-id');
+        });
 
-        it( 'updates a specific integration setting', function (): void {
-            $form = Form::factory()->create( [
+        it('updates a specific integration setting', function (): void {
+            $form = Form::factory()->create([
                 'settings' => [
                     'integrations' => [
                         'mailchimp' => [
@@ -75,97 +75,97 @@ describe( 'IntegrationService', function (): void {
                         ],
                     ],
                 ],
-            ] );
+            ]);
 
-            $this->service->updateIntegrationSetting( $form, 'mailchimp', 'api_key', 'new-key' );
+            $this->service->updateIntegrationSetting($form, 'mailchimp', 'api_key', 'new-key');
             $form->refresh();
 
-            expect( $form->settings['integrations']['mailchimp']['api_key'] )->toBe( 'new-key' );
-        } );
+            expect($form->settings['integrations']['mailchimp']['api_key'])->toBe('new-key');
+        });
 
-        it( 'removes integration settings for a provider', function (): void {
-            $form = Form::factory()->create( [
+        it('removes integration settings for a provider', function (): void {
+            $form = Form::factory()->create([
                 'settings' => [
                     'integrations' => [
-                        'mailchimp'  => ['api_key' => 'test'],
+                        'mailchimp' => ['api_key' => 'test'],
                         'convertkit' => ['api_key' => 'test'],
                     ],
                 ],
-            ] );
+            ]);
 
-            $this->service->removeIntegrationSettings( $form, 'mailchimp' );
+            $this->service->removeIntegrationSettings($form, 'mailchimp');
             $form->refresh();
 
-            expect( $form->settings['integrations'] )->not->toHaveKey( 'mailchimp' )
-                ->and( $form->settings['integrations'] )->toHaveKey( 'convertkit' );
-        } );
+            expect($form->settings['integrations'])->not->toHaveKey('mailchimp')
+                ->and($form->settings['integrations'])->toHaveKey('convertkit');
+        });
 
-        it( 'checks if form has integration configured', function (): void {
-            $form = Form::factory()->create( [
+        it('checks if form has integration configured', function (): void {
+            $form = Form::factory()->create([
                 'settings' => [
                     'integrations' => [
                         'mailchimp' => ['api_key' => 'test'],
                     ],
                 ],
-            ] );
+            ]);
 
-            expect( $this->service->hasIntegration( $form, 'mailchimp' ) )->toBeTrue()
-                ->and( $this->service->hasIntegration( $form, 'convertkit' ) )->toBeFalse();
-        } );
+            expect($this->service->hasIntegration($form, 'mailchimp'))->toBeTrue()
+                ->and($this->service->hasIntegration($form, 'convertkit'))->toBeFalse();
+        });
 
-        it( 'gets list of configured providers', function (): void {
-            $form = Form::factory()->create( [
+        it('gets list of configured providers', function (): void {
+            $form = Form::factory()->create([
                 'settings' => [
                     'integrations' => [
-                        'mailchimp'      => ['api_key' => 'test'],
-                        'convertkit'     => ['api_key' => 'test'],
+                        'mailchimp' => ['api_key' => 'test'],
+                        'convertkit' => ['api_key' => 'test'],
                         'empty_provider' => [],
                     ],
                 ],
-            ] );
+            ]);
 
-            $providers = $this->service->getConfiguredProviders( $form );
+            $providers = $this->service->getConfiguredProviders($form);
 
-            expect( $providers )->toContain( 'mailchimp' )
-                ->and( $providers )->toContain( 'convertkit' )
-                ->and( $providers )->not->toContain( 'empty_provider' );
-        } );
-    } );
+            expect($providers)->toContain('mailchimp')
+                ->and($providers)->toContain('convertkit')
+                ->and($providers)->not->toContain('empty_provider');
+        });
+    });
 
-    describe( 'settings tabs', function (): void {
-        it( 'returns registered tabs from filter hook', function (): void {
-            if ( ! function_exists( 'addFilter' ) ) {
-                $this->markTestSkipped( 'Hook system not available' );
+    describe('settings tabs', function (): void {
+        it('returns registered tabs from filter hook', function (): void {
+            if (! function_exists('addFilter')) {
+                $this->markTestSkipped('Hook system not available');
             }
 
-            addFilter( 'forms.settings_tabs', function ( array $tabs ): array {
+            addFilter('ap.forms.settingsTabs', function (array $tabs): array {
                 $tabs[] = [
-                    'id'        => 'tab1',
-                    'label'     => 'Tab 1',
-                    'icon'      => 'o-cog',
+                    'id' => 'tab1',
+                    'label' => 'Tab 1',
+                    'icon' => 'o-cog',
                     'component' => 'tab-1-component',
                 ];
                 $tabs[] = [
-                    'id'        => 'tab2',
-                    'label'     => 'Tab 2',
-                    'icon'      => 'o-envelope',
+                    'id' => 'tab2',
+                    'label' => 'Tab 2',
+                    'icon' => 'o-envelope',
                     'component' => 'tab-2-component',
                 ];
 
                 return $tabs;
-            } );
+            });
 
             $tabs = $this->service->getSettingsTabs();
 
-            expect( $tabs )->toHaveCount( 2 )
-                ->and( $tabs[0]['id'] )->toBe( 'tab1' )
-                ->and( $tabs[1]['id'] )->toBe( 'tab2' );
-        } );
-    } );
-} );
+            expect($tabs)->toHaveCount(2)
+                ->and($tabs[0]['id'])->toBe('tab1')
+                ->and($tabs[1]['id'])->toBe('tab2');
+        });
+    });
+});
 
-afterEach( function (): void {
-    if ( function_exists( 'removeAllFilters' ) ) {
-        removeAllFilters( 'forms.settings_tabs' );
+afterEach(function (): void {
+    if (function_exists('removeAllFilters')) {
+        removeAllFilters('ap.forms.settingsTabs');
     }
-} );
+});

--- a/tests/Feature/Services/IntegrationServiceTest.php
+++ b/tests/Feature/Services/IntegrationServiceTest.php
@@ -168,4 +168,4 @@ afterEach( function (): void {
     if ( function_exists( 'removeAllFilters' ) ) {
         removeAllFilters( 'ap.forms.settingsTabs' );
     }
-});
+} );

--- a/tests/Feature/Services/SubmissionServiceTest.php
+++ b/tests/Feature/Services/SubmissionServiceTest.php
@@ -420,4 +420,4 @@ afterEach( function (): void {
     if ( function_exists( 'removeAllFilters' ) ) {
         removeAllFilters( 'ap.forms.submissionData' );
     }
-});
+} );

--- a/tests/Feature/Services/SubmissionServiceTest.php
+++ b/tests/Feature/Services/SubmissionServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Forms\Models\Form;
 use ArtisanPackUI\Forms\Models\FormField;
@@ -12,412 +12,412 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Storage;
 
-beforeEach(function (): void {
-    $this->service = app(SubmissionService::class);
-    Storage::fake('local');
-});
+beforeEach( function (): void {
+    $this->service = app( SubmissionService::class );
+    Storage::fake( 'local' );
+} );
 
-describe('SubmissionService', function (): void {
-    describe('create submission', function (): void {
-        it('creates a submission with form data', function (): void {
+describe( 'SubmissionService', function (): void {
+    describe( 'create submission', function (): void {
+        it( 'creates a submission with form data', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->create([
-                'name' => 'name',
+            FormField::factory()->for( $form )->create( [
+                'name'  => 'name',
                 'label' => 'Name',
-                'type' => 'text',
-            ]);
+                'type'  => 'text',
+            ] );
 
-            $submission = $this->service->create($form, [
+            $submission = $this->service->create( $form, [
                 'name' => 'John Doe',
-            ]);
+            ] );
 
-            expect($submission)->toBeInstanceOf(FormSubmission::class)
-                ->and($submission->form_id)->toBe($form->id)
-                ->and($submission->getValue('name'))->toBe('John Doe');
-        });
+            expect( $submission )->toBeInstanceOf( FormSubmission::class )
+                ->and( $submission->form_id )->toBe( $form->id )
+                ->and( $submission->getValue( 'name' ) )->toBe( 'John Doe' );
+        } );
 
-        it('creates submission values for each field', function (): void {
+        it( 'creates submission values for each field', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->create(['name' => 'name', 'label' => 'Name', 'type' => 'text']);
-            FormField::factory()->for($form)->create(['name' => 'email', 'label' => 'Email', 'type' => 'email']);
+            FormField::factory()->for( $form )->create( ['name' => 'name', 'label' => 'Name', 'type' => 'text'] );
+            FormField::factory()->for( $form )->create( ['name' => 'email', 'label' => 'Email', 'type' => 'email'] );
 
-            $submission = $this->service->create($form, [
-                'name' => 'John Doe',
+            $submission = $this->service->create( $form, [
+                'name'  => 'John Doe',
                 'email' => 'john@example.com',
-            ]);
+            ] );
 
-            expect($submission->values)->toHaveCount(2)
-                ->and($submission->getValue('name'))->toBe('John Doe')
-                ->and($submission->getValue('email'))->toBe('john@example.com');
-        });
+            expect( $submission->values )->toHaveCount( 2 )
+                ->and( $submission->getValue( 'name' ) )->toBe( 'John Doe' )
+                ->and( $submission->getValue( 'email' ) )->toBe( 'john@example.com' );
+        } );
 
-        it('stores metadata with submission', function (): void {
+        it( 'stores metadata with submission', function (): void {
             $form = Form::factory()->create();
 
-            $submission = $this->service->create($form, [], [], [
-                'page_url' => 'https://example.com/contact',
+            $submission = $this->service->create( $form, [], [], [
+                'page_url'     => 'https://example.com/contact',
                 'referrer_url' => 'https://google.com',
-                'ip_address' => '192.168.1.100',
-                'user_agent' => 'Mozilla/5.0',
-            ]);
+                'ip_address'   => '192.168.1.100',
+                'user_agent'   => 'Mozilla/5.0',
+            ] );
 
-            expect($submission->page_url)->toBe('https://example.com/contact')
-                ->and($submission->referrer_url)->toBe('https://google.com')
-                ->and($submission->ip_address)->toBe('192.168.1.100')
-                ->and($submission->user_agent)->toBe('Mozilla/5.0');
-        });
+            expect( $submission->page_url )->toBe( 'https://example.com/contact' )
+                ->and( $submission->referrer_url )->toBe( 'https://google.com' )
+                ->and( $submission->ip_address )->toBe( '192.168.1.100' )
+                ->and( $submission->user_agent )->toBe( 'Mozilla/5.0' );
+        } );
 
-        it('handles array values for checkbox groups', function (): void {
+        it( 'handles array values for checkbox groups', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->create([
-                'name' => 'interests',
+            FormField::factory()->for( $form )->create( [
+                'name'  => 'interests',
                 'label' => 'Interests',
-                'type' => 'checkbox_group',
-            ]);
+                'type'  => 'checkbox_group',
+            ] );
 
-            $submission = $this->service->create($form, [
+            $submission = $this->service->create( $form, [
                 'interests' => ['sports', 'music', 'reading'],
-            ]);
+            ] );
 
-            $value = FormSubmissionValue::where('submission_id', $submission->id)
-                ->where('field_name', 'interests')
+            $value = FormSubmissionValue::where( 'submission_id', $submission->id )
+                ->where( 'field_name', 'interests' )
                 ->first();
 
-            expect($value->value_array)->toBe(['sports', 'music', 'reading']);
-        });
+            expect( $value->value_array )->toBe( ['sports', 'music', 'reading'] );
+        } );
 
-        it('ignores fields not in form', function (): void {
+        it( 'ignores fields not in form', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->create(['name' => 'name', 'type' => 'text']);
+            FormField::factory()->for( $form )->create( ['name' => 'name', 'type' => 'text'] );
 
-            $submission = $this->service->create($form, [
-                'name' => 'John Doe',
+            $submission = $this->service->create( $form, [
+                'name'          => 'John Doe',
                 'unknown_field' => 'should be ignored',
-            ]);
+            ] );
 
-            expect($submission->values)->toHaveCount(1);
-        });
-    });
+            expect( $submission->values )->toHaveCount( 1 );
+        } );
+    } );
 
-    describe('file uploads', function (): void {
-        it('handles file upload', function (): void {
+    describe( 'file uploads', function (): void {
+        it( 'handles file upload', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->file()->create(['name' => 'document']);
+            FormField::factory()->for( $form )->file()->create( ['name' => 'document'] );
 
-            $file = UploadedFile::fake()->create('test.pdf', 100);
+            $file = UploadedFile::fake()->create( 'test.pdf', 100 );
 
-            $submission = $this->service->create($form, [], [
+            $submission = $this->service->create( $form, [], [
                 'document' => $file,
-            ]);
+            ] );
 
-            expect($submission->uploads)->toHaveCount(1);
+            expect( $submission->uploads )->toHaveCount( 1 );
 
             $upload = $submission->uploads->first();
-            expect($upload->original_name)->toBe('test.pdf')
-                ->and($upload->mime_type)->toBe('application/pdf');
-        });
+            expect( $upload->original_name )->toBe( 'test.pdf' )
+                ->and( $upload->mime_type )->toBe( 'application/pdf' );
+        } );
 
-        it('stores file on configured disk', function (): void {
+        it( 'stores file on configured disk', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->file()->create(['name' => 'document']);
+            FormField::factory()->for( $form )->file()->create( ['name' => 'document'] );
 
-            $file = UploadedFile::fake()->create('test.pdf', 100);
+            $file = UploadedFile::fake()->create( 'test.pdf', 100 );
 
-            $submission = $this->service->create($form, [], [
+            $submission = $this->service->create( $form, [], [
                 'document' => $file,
-            ]);
+            ] );
 
             $upload = $submission->uploads->first();
-            expect(Storage::disk($upload->disk)->exists($upload->path))->toBeTrue();
-        });
+            expect( Storage::disk( $upload->disk )->exists( $upload->path ) )->toBeTrue();
+        } );
 
-        it('creates submission value linking to upload', function (): void {
-            $form = Form::factory()->create();
-            $field = FormField::factory()->for($form)->file()->create(['name' => 'document']);
+        it( 'creates submission value linking to upload', function (): void {
+            $form  = Form::factory()->create();
+            $field = FormField::factory()->for( $form )->file()->create( ['name' => 'document'] );
 
-            $file = UploadedFile::fake()->create('test.pdf', 100);
+            $file = UploadedFile::fake()->create( 'test.pdf', 100 );
 
-            $submission = $this->service->create($form, [], [
+            $submission = $this->service->create( $form, [], [
                 'document' => $file,
-            ]);
+            ] );
 
-            $value = FormSubmissionValue::where('submission_id', $submission->id)
-                ->where('field_id', $field->id)
+            $value = FormSubmissionValue::where( 'submission_id', $submission->id )
+                ->where( 'field_id', $field->id )
                 ->first();
 
-            expect($value->upload_id)->not->toBeNull();
-        });
+            expect( $value->upload_id )->not->toBeNull();
+        } );
 
-        it('validates file extension against allowlist', function (): void {
-            config(['artisanpack.forms.uploads.allowed_extensions' => ['pdf', 'doc']]);
-
-            $form = Form::factory()->create();
-            FormField::factory()->for($form)->file()->create(['name' => 'document']);
-
-            $file = UploadedFile::fake()->create('test.exe', 100);
-
-            expect(fn () => $this->service->create($form, [], ['document' => $file]))
-                ->toThrow(InvalidArgumentException::class);
-        });
-
-        it('allows file when extension is in allowlist', function (): void {
-            config(['artisanpack.forms.uploads.allowed_extensions' => ['pdf', 'doc']]);
+        it( 'validates file extension against allowlist', function (): void {
+            config( ['artisanpack.forms.uploads.allowed_extensions' => ['pdf', 'doc']] );
 
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->file()->create(['name' => 'document']);
+            FormField::factory()->for( $form )->file()->create( ['name' => 'document'] );
 
-            $file = UploadedFile::fake()->create('test.pdf', 100);
+            $file = UploadedFile::fake()->create( 'test.exe', 100 );
 
-            $submission = $this->service->create($form, [], ['document' => $file]);
+            expect( fn () => $this->service->create( $form, [], ['document' => $file] ) )
+                ->toThrow( InvalidArgumentException::class );
+        } );
 
-            expect($submission->uploads)->toHaveCount(1);
-        });
+        it( 'allows file when extension is in allowlist', function (): void {
+            config( ['artisanpack.forms.uploads.allowed_extensions' => ['pdf', 'doc']] );
 
-        it('skips non-file field types for file uploads', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->text()->create(['name' => 'name']);
+            FormField::factory()->for( $form )->file()->create( ['name' => 'document'] );
 
-            $file = UploadedFile::fake()->create('test.pdf', 100);
+            $file = UploadedFile::fake()->create( 'test.pdf', 100 );
 
-            $submission = $this->service->create($form, ['name' => 'Test'], [
+            $submission = $this->service->create( $form, [], ['document' => $file] );
+
+            expect( $submission->uploads )->toHaveCount( 1 );
+        } );
+
+        it( 'skips non-file field types for file uploads', function (): void {
+            $form = Form::factory()->create();
+            FormField::factory()->for( $form )->text()->create( ['name' => 'name'] );
+
+            $file = UploadedFile::fake()->create( 'test.pdf', 100 );
+
+            $submission = $this->service->create( $form, ['name' => 'Test'], [
                 'name' => $file, // Passing file to non-file field
-            ]);
+            ] );
 
-            expect($submission->uploads)->toHaveCount(0);
-        });
-    });
+            expect( $submission->uploads )->toHaveCount( 0 );
+        } );
+    } );
 
-    describe('spam detection', function (): void {
-        it('detects spam when honeypot is filled', function (): void {
-            expect($this->service->isSpam('spam-value', null))->toBeTrue()
-                ->and($this->service->isSpam('', null))->toBeFalse()
-                ->and($this->service->isSpam(null, null))->toBeFalse();
-        });
+    describe( 'spam detection', function (): void {
+        it( 'detects spam when honeypot is filled', function (): void {
+            expect( $this->service->isSpam( 'spam-value', null ) )->toBeTrue()
+                ->and( $this->service->isSpam( '', null ) )->toBeFalse()
+                ->and( $this->service->isSpam( null, null ) )->toBeFalse();
+        } );
 
-        it('detects spam when submission is too fast', function (): void {
+        it( 'detects spam when submission is too fast', function (): void {
             $now = time();
 
             // 1 second ago - too fast
-            expect($this->service->isSpam('', $now - 1))->toBeTrue();
+            expect( $this->service->isSpam( '', $now - 1 ) )->toBeTrue();
 
             // 2 seconds ago - still too fast (< 3 seconds)
-            expect($this->service->isSpam('', $now - 2))->toBeTrue();
+            expect( $this->service->isSpam( '', $now - 2 ) )->toBeTrue();
 
             // 3 seconds ago - borderline, should pass (>= 3 seconds passes)
-            expect($this->service->isSpam('', $now - 3))->toBeFalse();
+            expect( $this->service->isSpam( '', $now - 3 ) )->toBeFalse();
 
             // 10 seconds ago - definitely ok
-            expect($this->service->isSpam('', $now - 10))->toBeFalse();
-        });
+            expect( $this->service->isSpam( '', $now - 10 ) )->toBeFalse();
+        } );
 
-        it('allows submission when both checks pass', function (): void {
+        it( 'allows submission when both checks pass', function (): void {
             $now = time();
 
-            expect($this->service->isSpam('', $now - 10))->toBeFalse();
-        });
+            expect( $this->service->isSpam( '', $now - 10 ) )->toBeFalse();
+        } );
 
-        it('detects spam when both honeypot and time fail', function (): void {
+        it( 'detects spam when both honeypot and time fail', function (): void {
             $now = time();
 
-            expect($this->service->isSpam('bot-filled', $now))->toBeTrue();
-        });
+            expect( $this->service->isSpam( 'bot-filled', $now ) )->toBeTrue();
+        } );
 
-        it('handles null formLoadedAt', function (): void {
+        it( 'handles null formLoadedAt', function (): void {
             // When formLoadedAt is null, only honeypot is checked
-            expect($this->service->isSpam('', null))->toBeFalse()
-                ->and($this->service->isSpam('spam', null))->toBeTrue();
-        });
-    });
+            expect( $this->service->isSpam( '', null ) )->toBeFalse()
+                ->and( $this->service->isSpam( 'spam', null ) )->toBeTrue();
+        } );
+    } );
 
-    describe('rate limiting', function (): void {
-        beforeEach(function (): void {
-            RateLimiter::clear('form-submission:1:192.168.1.1');
-        });
+    describe( 'rate limiting', function (): void {
+        beforeEach( function (): void {
+            RateLimiter::clear( 'form-submission:1:192.168.1.1' );
+        } );
 
-        it('is not rate limited initially', function (): void {
-            expect($this->service->isRateLimited('192.168.1.1', 1))->toBeFalse();
-        });
+        it( 'is not rate limited initially', function (): void {
+            expect( $this->service->isRateLimited( '192.168.1.1', 1 ) )->toBeFalse();
+        } );
 
-        it('records submission attempts', function (): void {
-            $this->service->recordAttempt('192.168.1.1', 1);
-            $this->service->recordAttempt('192.168.1.1', 1);
+        it( 'records submission attempts', function (): void {
+            $this->service->recordAttempt( '192.168.1.1', 1 );
+            $this->service->recordAttempt( '192.168.1.1', 1 );
 
             // Still under limit
-            expect($this->service->isRateLimited('192.168.1.1', 1))->toBeFalse();
-        });
+            expect( $this->service->isRateLimited( '192.168.1.1', 1 ) )->toBeFalse();
+        } );
 
-        it('rate limits after max attempts', function (): void {
+        it( 'rate limits after max attempts', function (): void {
             // Record 5 attempts (the limit)
-            for ($i = 0; $i < 5; $i++) {
-                $this->service->recordAttempt('192.168.1.1', 1);
+            for ( $i = 0; $i < 5; $i++ ) {
+                $this->service->recordAttempt( '192.168.1.1', 1 );
             }
 
             // 6th attempt should be rate limited
-            expect($this->service->isRateLimited('192.168.1.1', 1))->toBeTrue();
-        });
+            expect( $this->service->isRateLimited( '192.168.1.1', 1 ) )->toBeTrue();
+        } );
 
-        it('rate limits per IP and form', function (): void {
+        it( 'rate limits per IP and form', function (): void {
             // Max out one IP/form combo
-            for ($i = 0; $i < 5; $i++) {
-                $this->service->recordAttempt('192.168.1.1', 1);
+            for ( $i = 0; $i < 5; $i++ ) {
+                $this->service->recordAttempt( '192.168.1.1', 1 );
             }
 
-            expect($this->service->isRateLimited('192.168.1.1', 1))->toBeTrue();
+            expect( $this->service->isRateLimited( '192.168.1.1', 1 ) )->toBeTrue();
 
             // Different IP should not be limited
-            expect($this->service->isRateLimited('192.168.1.2', 1))->toBeFalse();
+            expect( $this->service->isRateLimited( '192.168.1.2', 1 ) )->toBeFalse();
 
             // Different form should not be limited
-            expect($this->service->isRateLimited('192.168.1.1', 2))->toBeFalse();
-        });
-    });
+            expect( $this->service->isRateLimited( '192.168.1.1', 2 ) )->toBeFalse();
+        } );
+    } );
 
-    describe('validation rules', function (): void {
-        it('builds validation rules for required fields', function (): void {
-            $form = Form::factory()->create();
-            $field = FormField::factory()->for($form)->required()->create([
+    describe( 'validation rules', function (): void {
+        it( 'builds validation rules for required fields', function (): void {
+            $form  = Form::factory()->create();
+            $field = FormField::factory()->for( $form )->required()->create( [
                 'name' => 'name',
                 'type' => 'text',
-            ]);
+            ] );
 
-            $rules = $this->service->buildValidationRules($form->fields);
+            $rules = $this->service->buildValidationRules( $form->fields );
 
-            expect($rules)->toHaveKey('formData.name')
-                ->and($rules['formData.name'])->toContain('required');
-        });
+            expect( $rules )->toHaveKey( 'formData.name' )
+                ->and( $rules['formData.name'] )->toContain( 'required' );
+        } );
 
-        it('excludes hidden fields from validation', function (): void {
+        it( 'excludes hidden fields from validation', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->required()->create(['name' => 'visible', 'type' => 'text']);
-            FormField::factory()->for($form)->required()->create(['name' => 'hidden', 'type' => 'text']);
+            FormField::factory()->for( $form )->required()->create( ['name' => 'visible', 'type' => 'text'] );
+            FormField::factory()->for( $form )->required()->create( ['name' => 'hidden', 'type' => 'text'] );
 
             $hiddenFields = ['hidden' => true];
 
-            $rules = $this->service->buildValidationRules($form->fields, $hiddenFields);
+            $rules = $this->service->buildValidationRules( $form->fields, $hiddenFields );
 
-            expect($rules)->toHaveKey('formData.visible')
-                ->and($rules)->not->toHaveKey('formData.hidden');
-        });
+            expect( $rules )->toHaveKey( 'formData.visible' )
+                ->and( $rules )->not->toHaveKey( 'formData.hidden' );
+        } );
 
-        it('excludes layout fields from validation', function (): void {
+        it( 'excludes layout fields from validation', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->create(['name' => 'text_field', 'type' => 'text']);
-            FormField::factory()->for($form)->create(['name' => 'heading', 'type' => 'heading']);
-            FormField::factory()->for($form)->create(['name' => 'paragraph', 'type' => 'paragraph']);
-            FormField::factory()->for($form)->create(['name' => 'divider', 'type' => 'divider']);
+            FormField::factory()->for( $form )->create( ['name' => 'text_field', 'type' => 'text'] );
+            FormField::factory()->for( $form )->create( ['name' => 'heading', 'type' => 'heading'] );
+            FormField::factory()->for( $form )->create( ['name' => 'paragraph', 'type' => 'paragraph'] );
+            FormField::factory()->for( $form )->create( ['name' => 'divider', 'type' => 'divider'] );
 
-            $rules = $this->service->buildValidationRules($form->fields);
+            $rules = $this->service->buildValidationRules( $form->fields );
 
-            expect($rules)->toHaveKey('formData.text_field')
-                ->and($rules)->not->toHaveKey('formData.heading')
-                ->and($rules)->not->toHaveKey('formData.paragraph')
-                ->and($rules)->not->toHaveKey('formData.divider');
-        });
+            expect( $rules )->toHaveKey( 'formData.text_field' )
+                ->and( $rules )->not->toHaveKey( 'formData.heading' )
+                ->and( $rules )->not->toHaveKey( 'formData.paragraph' )
+                ->and( $rules )->not->toHaveKey( 'formData.divider' );
+        } );
 
-        it('includes type-specific validation rules', function (): void {
+        it( 'includes type-specific validation rules', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->email()->create();
+            FormField::factory()->for( $form )->email()->create();
 
-            $rules = $this->service->buildValidationRules($form->fields);
+            $rules = $this->service->buildValidationRules( $form->fields );
 
-            expect($rules['formData.email'])->toContain('email');
-        });
-    });
+            expect( $rules['formData.email'] )->toContain( 'email' );
+        } );
+    } );
 
-    describe('validation messages', function (): void {
-        it('builds custom messages for required fields', function (): void {
+    describe( 'validation messages', function (): void {
+        it( 'builds custom messages for required fields', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->required()->create([
-                'name' => 'name',
+            FormField::factory()->for( $form )->required()->create( [
+                'name'  => 'name',
                 'label' => 'Full Name',
-                'type' => 'text',
-            ]);
+                'type'  => 'text',
+            ] );
 
-            $messages = $this->service->buildValidationMessages($form->fields);
+            $messages = $this->service->buildValidationMessages( $form->fields );
 
-            expect($messages)->toHaveKey('formData.name.required')
-                ->and($messages['formData.name.required'])->toContain('Full Name');
-        });
+            expect( $messages )->toHaveKey( 'formData.name.required' )
+                ->and( $messages['formData.name.required'] )->toContain( 'Full Name' );
+        } );
 
-        it('builds custom messages for email fields', function (): void {
+        it( 'builds custom messages for email fields', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->email()->create();
+            FormField::factory()->for( $form )->email()->create();
 
-            $messages = $this->service->buildValidationMessages($form->fields);
+            $messages = $this->service->buildValidationMessages( $form->fields );
 
-            expect($messages)->toHaveKey('formData.email.email');
-        });
+            expect( $messages )->toHaveKey( 'formData.email.email' );
+        } );
 
-        it('builds custom messages for file fields', function (): void {
+        it( 'builds custom messages for file fields', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->file()->create(['name' => 'resume', 'label' => 'Resume']);
+            FormField::factory()->for( $form )->file()->create( ['name' => 'resume', 'label' => 'Resume'] );
 
-            $messages = $this->service->buildValidationMessages($form->fields);
+            $messages = $this->service->buildValidationMessages( $form->fields );
 
-            expect($messages)->toHaveKey('formData.resume.file')
-                ->and($messages)->toHaveKey('formData.resume.mimes')
-                ->and($messages)->toHaveKey('formData.resume.max');
-        });
+            expect( $messages )->toHaveKey( 'formData.resume.file' )
+                ->and( $messages )->toHaveKey( 'formData.resume.mimes' )
+                ->and( $messages )->toHaveKey( 'formData.resume.max' );
+        } );
 
-        it('excludes layout fields from messages', function (): void {
+        it( 'excludes layout fields from messages', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->create(['name' => 'heading', 'type' => 'heading']);
+            FormField::factory()->for( $form )->create( ['name' => 'heading', 'type' => 'heading'] );
 
-            $messages = $this->service->buildValidationMessages($form->fields);
+            $messages = $this->service->buildValidationMessages( $form->fields );
 
-            expect($messages)->toBeEmpty();
-        });
-    });
+            expect( $messages )->toBeEmpty();
+        } );
+    } );
 
-    describe('request metadata', function (): void {
-        it('extracts metadata from request', function (): void {
-            $request = Request::create('/contact', 'POST', [], [], [], [
-                'REMOTE_ADDR' => '192.168.1.100',
+    describe( 'request metadata', function (): void {
+        it( 'extracts metadata from request', function (): void {
+            $request = Request::create( '/contact', 'POST', [], [], [], [
+                'REMOTE_ADDR'     => '192.168.1.100',
                 'HTTP_USER_AGENT' => 'TestBrowser/1.0',
-                'HTTP_REFERER' => 'https://google.com',
-            ]);
+                'HTTP_REFERER'    => 'https://google.com',
+            ] );
 
-            $metadata = $this->service->getRequestMetadata($request);
+            $metadata = $this->service->getRequestMetadata( $request );
 
-            expect($metadata)->toHaveKey('page_url')
-                ->and($metadata)->toHaveKey('referrer_url')
-                ->and($metadata)->toHaveKey('ip_address')
-                ->and($metadata)->toHaveKey('user_agent')
-                ->and($metadata['referrer_url'])->toBe('https://google.com')
-                ->and($metadata['user_agent'])->toBe('TestBrowser/1.0');
-        });
-    });
+            expect( $metadata )->toHaveKey( 'page_url' )
+                ->and( $metadata )->toHaveKey( 'referrer_url' )
+                ->and( $metadata )->toHaveKey( 'ip_address' )
+                ->and( $metadata )->toHaveKey( 'user_agent' )
+                ->and( $metadata['referrer_url'] )->toBe( 'https://google.com' )
+                ->and( $metadata['user_agent'] )->toBe( 'TestBrowser/1.0' );
+        } );
+    } );
 
-    describe('filter hooks', function (): void {
-        it('applies ap.forms.submissionData filter', function (): void {
-            if (! function_exists('addFilter')) {
-                $this->markTestSkipped('Hook system not available');
+    describe( 'filter hooks', function (): void {
+        it( 'applies ap.forms.submissionData filter', function (): void {
+            if ( ! function_exists( 'addFilter' ) ) {
+                $this->markTestSkipped( 'Hook system not available' );
             }
 
-            addFilter('ap.forms.submissionData', function (array $data, Form $form): array {
+            addFilter( 'ap.forms.submissionData', function ( array $data, Form $form): array {
                 $data['injected_field'] = 'hook_value';
 
                 return $data;
             });
 
             $form = Form::factory()->create();
-            FormField::factory()->for($form)->create(['name' => 'name', 'type' => 'text']);
-            FormField::factory()->for($form)->create(['name' => 'injected_field', 'type' => 'text']);
+            FormField::factory()->for( $form)->create( ['name' => 'name', 'type' => 'text']);
+            FormField::factory()->for( $form)->create( ['name' => 'injected_field', 'type' => 'text']);
 
-            $submission = $this->service->create($form, ['name' => 'John']);
+            $submission = $this->service->create( $form, ['name' => 'John']);
 
-            expect($submission->getValue('injected_field'))->toBe('hook_value');
+            expect( $submission->getValue( 'injected_field'))->toBe( 'hook_value');
         });
     });
 });
 
-afterEach(function (): void {
+afterEach( function (): void {
     // Clean up rate limiter
-    RateLimiter::clear('form-submission:1:192.168.1.1');
-    RateLimiter::clear('form-submission:1:192.168.1.2');
-    RateLimiter::clear('form-submission:2:192.168.1.1');
+    RateLimiter::clear( 'form-submission:1:192.168.1.1');
+    RateLimiter::clear( 'form-submission:1:192.168.1.2');
+    RateLimiter::clear( 'form-submission:2:192.168.1.1');
 
-    if (function_exists('removeAllFilters')) {
-        removeAllFilters('ap.forms.submissionData');
+    if ( function_exists( 'removeAllFilters')) {
+        removeAllFilters( 'ap.forms.submissionData');
     }
 });

--- a/tests/Feature/Services/SubmissionServiceTest.php
+++ b/tests/Feature/Services/SubmissionServiceTest.php
@@ -417,7 +417,7 @@ afterEach( function (): void {
     RateLimiter::clear( 'form-submission:1:192.168.1.2' );
     RateLimiter::clear( 'form-submission:2:192.168.1.1' );
 
-    if ( function_exists( 'removeAllFilters' )) {
-        removeAllFilters( 'ap.forms.submissionData');
+    if ( function_exists( 'removeAllFilters' ) ) {
+        removeAllFilters( 'ap.forms.submissionData' );
     }
 });

--- a/tests/Feature/Services/SubmissionServiceTest.php
+++ b/tests/Feature/Services/SubmissionServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 use ArtisanPackUI\Forms\Models\Form;
 use ArtisanPackUI\Forms\Models\FormField;
@@ -12,412 +12,412 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Storage;
 
-beforeEach( function (): void {
-    $this->service = app( SubmissionService::class );
-    Storage::fake( 'local' );
-} );
+beforeEach(function (): void {
+    $this->service = app(SubmissionService::class);
+    Storage::fake('local');
+});
 
-describe( 'SubmissionService', function (): void {
-    describe( 'create submission', function (): void {
-        it( 'creates a submission with form data', function (): void {
+describe('SubmissionService', function (): void {
+    describe('create submission', function (): void {
+        it('creates a submission with form data', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->create( [
-                'name'  => 'name',
+            FormField::factory()->for($form)->create([
+                'name' => 'name',
                 'label' => 'Name',
-                'type'  => 'text',
-            ] );
+                'type' => 'text',
+            ]);
 
-            $submission = $this->service->create( $form, [
+            $submission = $this->service->create($form, [
                 'name' => 'John Doe',
-            ] );
+            ]);
 
-            expect( $submission )->toBeInstanceOf( FormSubmission::class )
-                ->and( $submission->form_id )->toBe( $form->id )
-                ->and( $submission->getValue( 'name' ) )->toBe( 'John Doe' );
-        } );
+            expect($submission)->toBeInstanceOf(FormSubmission::class)
+                ->and($submission->form_id)->toBe($form->id)
+                ->and($submission->getValue('name'))->toBe('John Doe');
+        });
 
-        it( 'creates submission values for each field', function (): void {
+        it('creates submission values for each field', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->create( ['name' => 'name', 'label' => 'Name', 'type' => 'text'] );
-            FormField::factory()->for( $form )->create( ['name' => 'email', 'label' => 'Email', 'type' => 'email'] );
+            FormField::factory()->for($form)->create(['name' => 'name', 'label' => 'Name', 'type' => 'text']);
+            FormField::factory()->for($form)->create(['name' => 'email', 'label' => 'Email', 'type' => 'email']);
 
-            $submission = $this->service->create( $form, [
-                'name'  => 'John Doe',
+            $submission = $this->service->create($form, [
+                'name' => 'John Doe',
                 'email' => 'john@example.com',
-            ] );
+            ]);
 
-            expect( $submission->values )->toHaveCount( 2 )
-                ->and( $submission->getValue( 'name' ) )->toBe( 'John Doe' )
-                ->and( $submission->getValue( 'email' ) )->toBe( 'john@example.com' );
-        } );
+            expect($submission->values)->toHaveCount(2)
+                ->and($submission->getValue('name'))->toBe('John Doe')
+                ->and($submission->getValue('email'))->toBe('john@example.com');
+        });
 
-        it( 'stores metadata with submission', function (): void {
+        it('stores metadata with submission', function (): void {
             $form = Form::factory()->create();
 
-            $submission = $this->service->create( $form, [], [], [
-                'page_url'     => 'https://example.com/contact',
+            $submission = $this->service->create($form, [], [], [
+                'page_url' => 'https://example.com/contact',
                 'referrer_url' => 'https://google.com',
-                'ip_address'   => '192.168.1.100',
-                'user_agent'   => 'Mozilla/5.0',
-            ] );
+                'ip_address' => '192.168.1.100',
+                'user_agent' => 'Mozilla/5.0',
+            ]);
 
-            expect( $submission->page_url )->toBe( 'https://example.com/contact' )
-                ->and( $submission->referrer_url )->toBe( 'https://google.com' )
-                ->and( $submission->ip_address )->toBe( '192.168.1.100' )
-                ->and( $submission->user_agent )->toBe( 'Mozilla/5.0' );
-        } );
+            expect($submission->page_url)->toBe('https://example.com/contact')
+                ->and($submission->referrer_url)->toBe('https://google.com')
+                ->and($submission->ip_address)->toBe('192.168.1.100')
+                ->and($submission->user_agent)->toBe('Mozilla/5.0');
+        });
 
-        it( 'handles array values for checkbox groups', function (): void {
+        it('handles array values for checkbox groups', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->create( [
-                'name'  => 'interests',
+            FormField::factory()->for($form)->create([
+                'name' => 'interests',
                 'label' => 'Interests',
-                'type'  => 'checkbox_group',
-            ] );
+                'type' => 'checkbox_group',
+            ]);
 
-            $submission = $this->service->create( $form, [
+            $submission = $this->service->create($form, [
                 'interests' => ['sports', 'music', 'reading'],
-            ] );
+            ]);
 
-            $value = FormSubmissionValue::where( 'submission_id', $submission->id )
-                ->where( 'field_name', 'interests' )
+            $value = FormSubmissionValue::where('submission_id', $submission->id)
+                ->where('field_name', 'interests')
                 ->first();
 
-            expect( $value->value_array )->toBe( ['sports', 'music', 'reading'] );
-        } );
+            expect($value->value_array)->toBe(['sports', 'music', 'reading']);
+        });
 
-        it( 'ignores fields not in form', function (): void {
+        it('ignores fields not in form', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->create( ['name' => 'name', 'type' => 'text'] );
+            FormField::factory()->for($form)->create(['name' => 'name', 'type' => 'text']);
 
-            $submission = $this->service->create( $form, [
-                'name'          => 'John Doe',
+            $submission = $this->service->create($form, [
+                'name' => 'John Doe',
                 'unknown_field' => 'should be ignored',
-            ] );
+            ]);
 
-            expect( $submission->values )->toHaveCount( 1 );
-        } );
-    } );
+            expect($submission->values)->toHaveCount(1);
+        });
+    });
 
-    describe( 'file uploads', function (): void {
-        it( 'handles file upload', function (): void {
+    describe('file uploads', function (): void {
+        it('handles file upload', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->file()->create( ['name' => 'document'] );
+            FormField::factory()->for($form)->file()->create(['name' => 'document']);
 
-            $file = UploadedFile::fake()->create( 'test.pdf', 100 );
+            $file = UploadedFile::fake()->create('test.pdf', 100);
 
-            $submission = $this->service->create( $form, [], [
+            $submission = $this->service->create($form, [], [
                 'document' => $file,
-            ] );
+            ]);
 
-            expect( $submission->uploads )->toHaveCount( 1 );
+            expect($submission->uploads)->toHaveCount(1);
 
             $upload = $submission->uploads->first();
-            expect( $upload->original_name )->toBe( 'test.pdf' )
-                ->and( $upload->mime_type )->toBe( 'application/pdf' );
-        } );
+            expect($upload->original_name)->toBe('test.pdf')
+                ->and($upload->mime_type)->toBe('application/pdf');
+        });
 
-        it( 'stores file on configured disk', function (): void {
+        it('stores file on configured disk', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->file()->create( ['name' => 'document'] );
+            FormField::factory()->for($form)->file()->create(['name' => 'document']);
 
-            $file = UploadedFile::fake()->create( 'test.pdf', 100 );
+            $file = UploadedFile::fake()->create('test.pdf', 100);
 
-            $submission = $this->service->create( $form, [], [
+            $submission = $this->service->create($form, [], [
                 'document' => $file,
-            ] );
+            ]);
 
             $upload = $submission->uploads->first();
-            expect( Storage::disk( $upload->disk )->exists( $upload->path ) )->toBeTrue();
-        } );
+            expect(Storage::disk($upload->disk)->exists($upload->path))->toBeTrue();
+        });
 
-        it( 'creates submission value linking to upload', function (): void {
-            $form  = Form::factory()->create();
-            $field = FormField::factory()->for( $form )->file()->create( ['name' => 'document'] );
+        it('creates submission value linking to upload', function (): void {
+            $form = Form::factory()->create();
+            $field = FormField::factory()->for($form)->file()->create(['name' => 'document']);
 
-            $file = UploadedFile::fake()->create( 'test.pdf', 100 );
+            $file = UploadedFile::fake()->create('test.pdf', 100);
 
-            $submission = $this->service->create( $form, [], [
+            $submission = $this->service->create($form, [], [
                 'document' => $file,
-            ] );
+            ]);
 
-            $value = FormSubmissionValue::where( 'submission_id', $submission->id )
-                ->where( 'field_id', $field->id )
+            $value = FormSubmissionValue::where('submission_id', $submission->id)
+                ->where('field_id', $field->id)
                 ->first();
 
-            expect( $value->upload_id )->not->toBeNull();
-        } );
+            expect($value->upload_id)->not->toBeNull();
+        });
 
-        it( 'validates file extension against allowlist', function (): void {
-            config( ['artisanpack.forms.uploads.allowed_extensions' => ['pdf', 'doc']] );
-
-            $form = Form::factory()->create();
-            FormField::factory()->for( $form )->file()->create( ['name' => 'document'] );
-
-            $file = UploadedFile::fake()->create( 'test.exe', 100 );
-
-            expect( fn () => $this->service->create( $form, [], ['document' => $file] ) )
-                ->toThrow( InvalidArgumentException::class );
-        } );
-
-        it( 'allows file when extension is in allowlist', function (): void {
-            config( ['artisanpack.forms.uploads.allowed_extensions' => ['pdf', 'doc']] );
+        it('validates file extension against allowlist', function (): void {
+            config(['artisanpack.forms.uploads.allowed_extensions' => ['pdf', 'doc']]);
 
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->file()->create( ['name' => 'document'] );
+            FormField::factory()->for($form)->file()->create(['name' => 'document']);
 
-            $file = UploadedFile::fake()->create( 'test.pdf', 100 );
+            $file = UploadedFile::fake()->create('test.exe', 100);
 
-            $submission = $this->service->create( $form, [], ['document' => $file] );
+            expect(fn () => $this->service->create($form, [], ['document' => $file]))
+                ->toThrow(InvalidArgumentException::class);
+        });
 
-            expect( $submission->uploads )->toHaveCount( 1 );
-        } );
+        it('allows file when extension is in allowlist', function (): void {
+            config(['artisanpack.forms.uploads.allowed_extensions' => ['pdf', 'doc']]);
 
-        it( 'skips non-file field types for file uploads', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->text()->create( ['name' => 'name'] );
+            FormField::factory()->for($form)->file()->create(['name' => 'document']);
 
-            $file = UploadedFile::fake()->create( 'test.pdf', 100 );
+            $file = UploadedFile::fake()->create('test.pdf', 100);
 
-            $submission = $this->service->create( $form, ['name' => 'Test'], [
+            $submission = $this->service->create($form, [], ['document' => $file]);
+
+            expect($submission->uploads)->toHaveCount(1);
+        });
+
+        it('skips non-file field types for file uploads', function (): void {
+            $form = Form::factory()->create();
+            FormField::factory()->for($form)->text()->create(['name' => 'name']);
+
+            $file = UploadedFile::fake()->create('test.pdf', 100);
+
+            $submission = $this->service->create($form, ['name' => 'Test'], [
                 'name' => $file, // Passing file to non-file field
-            ] );
+            ]);
 
-            expect( $submission->uploads )->toHaveCount( 0 );
-        } );
-    } );
+            expect($submission->uploads)->toHaveCount(0);
+        });
+    });
 
-    describe( 'spam detection', function (): void {
-        it( 'detects spam when honeypot is filled', function (): void {
-            expect( $this->service->isSpam( 'spam-value', null ) )->toBeTrue()
-                ->and( $this->service->isSpam( '', null ) )->toBeFalse()
-                ->and( $this->service->isSpam( null, null ) )->toBeFalse();
-        } );
+    describe('spam detection', function (): void {
+        it('detects spam when honeypot is filled', function (): void {
+            expect($this->service->isSpam('spam-value', null))->toBeTrue()
+                ->and($this->service->isSpam('', null))->toBeFalse()
+                ->and($this->service->isSpam(null, null))->toBeFalse();
+        });
 
-        it( 'detects spam when submission is too fast', function (): void {
+        it('detects spam when submission is too fast', function (): void {
             $now = time();
 
             // 1 second ago - too fast
-            expect( $this->service->isSpam( '', $now - 1 ) )->toBeTrue();
+            expect($this->service->isSpam('', $now - 1))->toBeTrue();
 
             // 2 seconds ago - still too fast (< 3 seconds)
-            expect( $this->service->isSpam( '', $now - 2 ) )->toBeTrue();
+            expect($this->service->isSpam('', $now - 2))->toBeTrue();
 
             // 3 seconds ago - borderline, should pass (>= 3 seconds passes)
-            expect( $this->service->isSpam( '', $now - 3 ) )->toBeFalse();
+            expect($this->service->isSpam('', $now - 3))->toBeFalse();
 
             // 10 seconds ago - definitely ok
-            expect( $this->service->isSpam( '', $now - 10 ) )->toBeFalse();
-        } );
+            expect($this->service->isSpam('', $now - 10))->toBeFalse();
+        });
 
-        it( 'allows submission when both checks pass', function (): void {
+        it('allows submission when both checks pass', function (): void {
             $now = time();
 
-            expect( $this->service->isSpam( '', $now - 10 ) )->toBeFalse();
-        } );
+            expect($this->service->isSpam('', $now - 10))->toBeFalse();
+        });
 
-        it( 'detects spam when both honeypot and time fail', function (): void {
+        it('detects spam when both honeypot and time fail', function (): void {
             $now = time();
 
-            expect( $this->service->isSpam( 'bot-filled', $now ) )->toBeTrue();
-        } );
+            expect($this->service->isSpam('bot-filled', $now))->toBeTrue();
+        });
 
-        it( 'handles null formLoadedAt', function (): void {
+        it('handles null formLoadedAt', function (): void {
             // When formLoadedAt is null, only honeypot is checked
-            expect( $this->service->isSpam( '', null ) )->toBeFalse()
-                ->and( $this->service->isSpam( 'spam', null ) )->toBeTrue();
-        } );
-    } );
+            expect($this->service->isSpam('', null))->toBeFalse()
+                ->and($this->service->isSpam('spam', null))->toBeTrue();
+        });
+    });
 
-    describe( 'rate limiting', function (): void {
-        beforeEach( function (): void {
-            RateLimiter::clear( 'form-submission:1:192.168.1.1' );
-        } );
+    describe('rate limiting', function (): void {
+        beforeEach(function (): void {
+            RateLimiter::clear('form-submission:1:192.168.1.1');
+        });
 
-        it( 'is not rate limited initially', function (): void {
-            expect( $this->service->isRateLimited( '192.168.1.1', 1 ) )->toBeFalse();
-        } );
+        it('is not rate limited initially', function (): void {
+            expect($this->service->isRateLimited('192.168.1.1', 1))->toBeFalse();
+        });
 
-        it( 'records submission attempts', function (): void {
-            $this->service->recordAttempt( '192.168.1.1', 1 );
-            $this->service->recordAttempt( '192.168.1.1', 1 );
+        it('records submission attempts', function (): void {
+            $this->service->recordAttempt('192.168.1.1', 1);
+            $this->service->recordAttempt('192.168.1.1', 1);
 
             // Still under limit
-            expect( $this->service->isRateLimited( '192.168.1.1', 1 ) )->toBeFalse();
-        } );
+            expect($this->service->isRateLimited('192.168.1.1', 1))->toBeFalse();
+        });
 
-        it( 'rate limits after max attempts', function (): void {
+        it('rate limits after max attempts', function (): void {
             // Record 5 attempts (the limit)
-            for ( $i = 0; $i < 5; $i++ ) {
-                $this->service->recordAttempt( '192.168.1.1', 1 );
+            for ($i = 0; $i < 5; $i++) {
+                $this->service->recordAttempt('192.168.1.1', 1);
             }
 
             // 6th attempt should be rate limited
-            expect( $this->service->isRateLimited( '192.168.1.1', 1 ) )->toBeTrue();
-        } );
+            expect($this->service->isRateLimited('192.168.1.1', 1))->toBeTrue();
+        });
 
-        it( 'rate limits per IP and form', function (): void {
+        it('rate limits per IP and form', function (): void {
             // Max out one IP/form combo
-            for ( $i = 0; $i < 5; $i++ ) {
-                $this->service->recordAttempt( '192.168.1.1', 1 );
+            for ($i = 0; $i < 5; $i++) {
+                $this->service->recordAttempt('192.168.1.1', 1);
             }
 
-            expect( $this->service->isRateLimited( '192.168.1.1', 1 ) )->toBeTrue();
+            expect($this->service->isRateLimited('192.168.1.1', 1))->toBeTrue();
 
             // Different IP should not be limited
-            expect( $this->service->isRateLimited( '192.168.1.2', 1 ) )->toBeFalse();
+            expect($this->service->isRateLimited('192.168.1.2', 1))->toBeFalse();
 
             // Different form should not be limited
-            expect( $this->service->isRateLimited( '192.168.1.1', 2 ) )->toBeFalse();
-        } );
-    } );
+            expect($this->service->isRateLimited('192.168.1.1', 2))->toBeFalse();
+        });
+    });
 
-    describe( 'validation rules', function (): void {
-        it( 'builds validation rules for required fields', function (): void {
-            $form  = Form::factory()->create();
-            $field = FormField::factory()->for( $form )->required()->create( [
+    describe('validation rules', function (): void {
+        it('builds validation rules for required fields', function (): void {
+            $form = Form::factory()->create();
+            $field = FormField::factory()->for($form)->required()->create([
                 'name' => 'name',
                 'type' => 'text',
-            ] );
+            ]);
 
-            $rules = $this->service->buildValidationRules( $form->fields );
+            $rules = $this->service->buildValidationRules($form->fields);
 
-            expect( $rules )->toHaveKey( 'formData.name' )
-                ->and( $rules['formData.name'] )->toContain( 'required' );
-        } );
+            expect($rules)->toHaveKey('formData.name')
+                ->and($rules['formData.name'])->toContain('required');
+        });
 
-        it( 'excludes hidden fields from validation', function (): void {
+        it('excludes hidden fields from validation', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->required()->create( ['name' => 'visible', 'type' => 'text'] );
-            FormField::factory()->for( $form )->required()->create( ['name' => 'hidden', 'type' => 'text'] );
+            FormField::factory()->for($form)->required()->create(['name' => 'visible', 'type' => 'text']);
+            FormField::factory()->for($form)->required()->create(['name' => 'hidden', 'type' => 'text']);
 
             $hiddenFields = ['hidden' => true];
 
-            $rules = $this->service->buildValidationRules( $form->fields, $hiddenFields );
+            $rules = $this->service->buildValidationRules($form->fields, $hiddenFields);
 
-            expect( $rules )->toHaveKey( 'formData.visible' )
-                ->and( $rules )->not->toHaveKey( 'formData.hidden' );
-        } );
+            expect($rules)->toHaveKey('formData.visible')
+                ->and($rules)->not->toHaveKey('formData.hidden');
+        });
 
-        it( 'excludes layout fields from validation', function (): void {
+        it('excludes layout fields from validation', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->create( ['name' => 'text_field', 'type' => 'text'] );
-            FormField::factory()->for( $form )->create( ['name' => 'heading', 'type' => 'heading'] );
-            FormField::factory()->for( $form )->create( ['name' => 'paragraph', 'type' => 'paragraph'] );
-            FormField::factory()->for( $form )->create( ['name' => 'divider', 'type' => 'divider'] );
+            FormField::factory()->for($form)->create(['name' => 'text_field', 'type' => 'text']);
+            FormField::factory()->for($form)->create(['name' => 'heading', 'type' => 'heading']);
+            FormField::factory()->for($form)->create(['name' => 'paragraph', 'type' => 'paragraph']);
+            FormField::factory()->for($form)->create(['name' => 'divider', 'type' => 'divider']);
 
-            $rules = $this->service->buildValidationRules( $form->fields );
+            $rules = $this->service->buildValidationRules($form->fields);
 
-            expect( $rules )->toHaveKey( 'formData.text_field' )
-                ->and( $rules )->not->toHaveKey( 'formData.heading' )
-                ->and( $rules )->not->toHaveKey( 'formData.paragraph' )
-                ->and( $rules )->not->toHaveKey( 'formData.divider' );
-        } );
+            expect($rules)->toHaveKey('formData.text_field')
+                ->and($rules)->not->toHaveKey('formData.heading')
+                ->and($rules)->not->toHaveKey('formData.paragraph')
+                ->and($rules)->not->toHaveKey('formData.divider');
+        });
 
-        it( 'includes type-specific validation rules', function (): void {
+        it('includes type-specific validation rules', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->email()->create();
+            FormField::factory()->for($form)->email()->create();
 
-            $rules = $this->service->buildValidationRules( $form->fields );
+            $rules = $this->service->buildValidationRules($form->fields);
 
-            expect( $rules['formData.email'] )->toContain( 'email' );
-        } );
-    } );
+            expect($rules['formData.email'])->toContain('email');
+        });
+    });
 
-    describe( 'validation messages', function (): void {
-        it( 'builds custom messages for required fields', function (): void {
+    describe('validation messages', function (): void {
+        it('builds custom messages for required fields', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->required()->create( [
-                'name'  => 'name',
+            FormField::factory()->for($form)->required()->create([
+                'name' => 'name',
                 'label' => 'Full Name',
-                'type'  => 'text',
-            ] );
+                'type' => 'text',
+            ]);
 
-            $messages = $this->service->buildValidationMessages( $form->fields );
+            $messages = $this->service->buildValidationMessages($form->fields);
 
-            expect( $messages )->toHaveKey( 'formData.name.required' )
-                ->and( $messages['formData.name.required'] )->toContain( 'Full Name' );
-        } );
+            expect($messages)->toHaveKey('formData.name.required')
+                ->and($messages['formData.name.required'])->toContain('Full Name');
+        });
 
-        it( 'builds custom messages for email fields', function (): void {
+        it('builds custom messages for email fields', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->email()->create();
+            FormField::factory()->for($form)->email()->create();
 
-            $messages = $this->service->buildValidationMessages( $form->fields );
+            $messages = $this->service->buildValidationMessages($form->fields);
 
-            expect( $messages )->toHaveKey( 'formData.email.email' );
-        } );
+            expect($messages)->toHaveKey('formData.email.email');
+        });
 
-        it( 'builds custom messages for file fields', function (): void {
+        it('builds custom messages for file fields', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->file()->create( ['name' => 'resume', 'label' => 'Resume'] );
+            FormField::factory()->for($form)->file()->create(['name' => 'resume', 'label' => 'Resume']);
 
-            $messages = $this->service->buildValidationMessages( $form->fields );
+            $messages = $this->service->buildValidationMessages($form->fields);
 
-            expect( $messages )->toHaveKey( 'formData.resume.file' )
-                ->and( $messages )->toHaveKey( 'formData.resume.mimes' )
-                ->and( $messages )->toHaveKey( 'formData.resume.max' );
-        } );
+            expect($messages)->toHaveKey('formData.resume.file')
+                ->and($messages)->toHaveKey('formData.resume.mimes')
+                ->and($messages)->toHaveKey('formData.resume.max');
+        });
 
-        it( 'excludes layout fields from messages', function (): void {
+        it('excludes layout fields from messages', function (): void {
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->create( ['name' => 'heading', 'type' => 'heading'] );
+            FormField::factory()->for($form)->create(['name' => 'heading', 'type' => 'heading']);
 
-            $messages = $this->service->buildValidationMessages( $form->fields );
+            $messages = $this->service->buildValidationMessages($form->fields);
 
-            expect( $messages )->toBeEmpty();
-        } );
-    } );
+            expect($messages)->toBeEmpty();
+        });
+    });
 
-    describe( 'request metadata', function (): void {
-        it( 'extracts metadata from request', function (): void {
-            $request = Request::create( '/contact', 'POST', [], [], [], [
-                'REMOTE_ADDR'     => '192.168.1.100',
+    describe('request metadata', function (): void {
+        it('extracts metadata from request', function (): void {
+            $request = Request::create('/contact', 'POST', [], [], [], [
+                'REMOTE_ADDR' => '192.168.1.100',
                 'HTTP_USER_AGENT' => 'TestBrowser/1.0',
-                'HTTP_REFERER'    => 'https://google.com',
-            ] );
+                'HTTP_REFERER' => 'https://google.com',
+            ]);
 
-            $metadata = $this->service->getRequestMetadata( $request );
+            $metadata = $this->service->getRequestMetadata($request);
 
-            expect( $metadata )->toHaveKey( 'page_url' )
-                ->and( $metadata )->toHaveKey( 'referrer_url' )
-                ->and( $metadata )->toHaveKey( 'ip_address' )
-                ->and( $metadata )->toHaveKey( 'user_agent' )
-                ->and( $metadata['referrer_url'] )->toBe( 'https://google.com' )
-                ->and( $metadata['user_agent'] )->toBe( 'TestBrowser/1.0' );
-        } );
-    } );
+            expect($metadata)->toHaveKey('page_url')
+                ->and($metadata)->toHaveKey('referrer_url')
+                ->and($metadata)->toHaveKey('ip_address')
+                ->and($metadata)->toHaveKey('user_agent')
+                ->and($metadata['referrer_url'])->toBe('https://google.com')
+                ->and($metadata['user_agent'])->toBe('TestBrowser/1.0');
+        });
+    });
 
-    describe( 'filter hooks', function (): void {
-        it( 'applies forms.submission_data filter', function (): void {
-            if ( ! function_exists( 'addFilter' ) ) {
-                $this->markTestSkipped( 'Hook system not available' );
+    describe('filter hooks', function (): void {
+        it('applies ap.forms.submissionData filter', function (): void {
+            if (! function_exists('addFilter')) {
+                $this->markTestSkipped('Hook system not available');
             }
 
-            addFilter( 'forms.submission_data', function ( array $data, Form $form ): array {
+            addFilter('ap.forms.submissionData', function (array $data, Form $form): array {
                 $data['injected_field'] = 'hook_value';
 
                 return $data;
-            } );
+            });
 
             $form = Form::factory()->create();
-            FormField::factory()->for( $form )->create( ['name' => 'name', 'type' => 'text'] );
-            FormField::factory()->for( $form )->create( ['name' => 'injected_field', 'type' => 'text'] );
+            FormField::factory()->for($form)->create(['name' => 'name', 'type' => 'text']);
+            FormField::factory()->for($form)->create(['name' => 'injected_field', 'type' => 'text']);
 
-            $submission = $this->service->create( $form, ['name' => 'John'] );
+            $submission = $this->service->create($form, ['name' => 'John']);
 
-            expect( $submission->getValue( 'injected_field' ) )->toBe( 'hook_value' );
-        } );
-    } );
-} );
+            expect($submission->getValue('injected_field'))->toBe('hook_value');
+        });
+    });
+});
 
-afterEach( function (): void {
+afterEach(function (): void {
     // Clean up rate limiter
-    RateLimiter::clear( 'form-submission:1:192.168.1.1' );
-    RateLimiter::clear( 'form-submission:1:192.168.1.2' );
-    RateLimiter::clear( 'form-submission:2:192.168.1.1' );
+    RateLimiter::clear('form-submission:1:192.168.1.1');
+    RateLimiter::clear('form-submission:1:192.168.1.2');
+    RateLimiter::clear('form-submission:2:192.168.1.1');
 
-    if ( function_exists( 'removeAllFilters' ) ) {
-        removeAllFilters( 'forms.submission_data' );
+    if (function_exists('removeAllFilters')) {
+        removeAllFilters('ap.forms.submissionData');
     }
-} );
+});

--- a/tests/Feature/Services/SubmissionServiceTest.php
+++ b/tests/Feature/Services/SubmissionServiceTest.php
@@ -394,30 +394,30 @@ describe( 'SubmissionService', function (): void {
                 $this->markTestSkipped( 'Hook system not available' );
             }
 
-            addFilter( 'ap.forms.submissionData', function ( array $data, Form $form): array {
+            addFilter( 'ap.forms.submissionData', function ( array $data, Form $form ): array {
                 $data['injected_field'] = 'hook_value';
 
                 return $data;
-            });
+            } );
 
             $form = Form::factory()->create();
-            FormField::factory()->for( $form)->create( ['name' => 'name', 'type' => 'text']);
-            FormField::factory()->for( $form)->create( ['name' => 'injected_field', 'type' => 'text']);
+            FormField::factory()->for( $form )->create( ['name' => 'name', 'type' => 'text'] );
+            FormField::factory()->for( $form )->create( ['name' => 'injected_field', 'type' => 'text'] );
 
-            $submission = $this->service->create( $form, ['name' => 'John']);
+            $submission = $this->service->create( $form, ['name' => 'John'] );
 
-            expect( $submission->getValue( 'injected_field'))->toBe( 'hook_value');
-        });
-    });
-});
+            expect( $submission->getValue( 'injected_field' ) )->toBe( 'hook_value' );
+        } );
+    } );
+} );
 
 afterEach( function (): void {
     // Clean up rate limiter
-    RateLimiter::clear( 'form-submission:1:192.168.1.1');
-    RateLimiter::clear( 'form-submission:1:192.168.1.2');
-    RateLimiter::clear( 'form-submission:2:192.168.1.1');
+    RateLimiter::clear( 'form-submission:1:192.168.1.1' );
+    RateLimiter::clear( 'form-submission:1:192.168.1.2' );
+    RateLimiter::clear( 'form-submission:2:192.168.1.1' );
 
-    if ( function_exists( 'removeAllFilters')) {
+    if ( function_exists( 'removeAllFilters' )) {
         removeAllFilters( 'ap.forms.submissionData');
     }
 });

--- a/tests/Feature/Support/HookAliasesTest.php
+++ b/tests/Feature/Support/HookAliasesTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use ArtisanPackUI\Forms\Support\HookAliases;
+
+beforeEach(function (): void {
+    if (! function_exists('removeAllFilters')) {
+        $this->markTestSkipped('Hook system not available');
+    }
+
+    // Wipe both old and new names so the alias plumbing is exercised
+    // fresh in each test.
+    $pairs = [
+        'forms.field_types' => 'ap.forms.fieldTypes',
+        'forms.field_categories' => 'ap.forms.fieldCategories',
+        'forms.validation_rules' => 'ap.forms.validationRules',
+        'forms.form.created' => 'ap.forms.form.created',
+        'forms.form.updated' => 'ap.forms.form.updated',
+        'forms.form.deleted' => 'ap.forms.form.deleted',
+        'forms.submission.created' => 'ap.forms.submission.created',
+        'forms.submission.updated' => 'ap.forms.submission.updated',
+        'forms.submission.deleted' => 'ap.forms.submission.deleted',
+        'forms.webhook_payload' => 'ap.forms.webhookPayload',
+        'forms.settings_tabs' => 'ap.forms.settingsTabs',
+        'forms.submission_data' => 'ap.forms.submissionData',
+        'forms.export_headers' => 'ap.forms.exportHeaders',
+        'forms.export_data' => 'ap.forms.exportData',
+        'forms.notification_recipients' => 'ap.forms.notificationRecipients',
+        'forms.notification.before_send' => 'ap.forms.notification.beforeSend',
+        'forms.notification.sent' => 'ap.forms.notification.sent',
+        'forms.notification_message' => 'ap.forms.notificationMessage',
+    ];
+
+    foreach ($pairs as $old => $new) {
+        removeAllFilters($old);
+        removeAllFilters($new);
+    }
+});
+
+describe('HookAliases', function (): void {
+    it('is a no-op when deprecateHook is unavailable', function (): void {
+        // Sanity: the registrar must not error under any load order.
+        HookAliases::register();
+        expect(true)->toBeTrue();
+    });
+
+    it('routes old filter-name subscribers through the canonical hook', function (): void {
+        if (! function_exists('deprecateHook')) {
+            $this->markTestSkipped('hooks < 1.3.0 has no deprecation aliasing');
+        }
+
+        HookAliases::register();
+
+        $oldCalled = false;
+
+        addFilter('forms.field_types', function (array $types) use (&$oldCalled): array {
+            $oldCalled = true;
+            $types['legacy'] = ['label' => 'Legacy'];
+
+            return $types;
+        });
+
+        $result = applyFilters('ap.forms.fieldTypes', []);
+
+        expect($oldCalled)->toBeTrue();
+        expect($result)->toHaveKey('legacy');
+    });
+
+    it('routes old action-name subscribers through the canonical hook', function (): void {
+        if (! function_exists('deprecateHook')) {
+            $this->markTestSkipped('hooks < 1.3.0 has no deprecation aliasing');
+        }
+
+        HookAliases::register();
+
+        $oldCalled = false;
+
+        addAction('forms.form.created', function () use (&$oldCalled): void {
+            $oldCalled = true;
+        });
+
+        doAction('ap.forms.form.created', new stdClass);
+
+        expect($oldCalled)->toBeTrue();
+    });
+});

--- a/tests/Feature/Support/HookAliasesTest.php
+++ b/tests/Feature/Support/HookAliasesTest.php
@@ -1,87 +1,87 @@
 <?php
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 use ArtisanPackUI\Forms\Support\HookAliases;
 
-beforeEach(function (): void {
-    if (! function_exists('removeAllFilters')) {
-        $this->markTestSkipped('Hook system not available');
+beforeEach( function (): void {
+    if ( ! function_exists( 'removeAllFilters' ) ) {
+        $this->markTestSkipped( 'Hook system not available' );
     }
 
     // Wipe both old and new names so the alias plumbing is exercised
     // fresh in each test.
     $pairs = [
-        'forms.field_types' => 'ap.forms.fieldTypes',
-        'forms.field_categories' => 'ap.forms.fieldCategories',
-        'forms.validation_rules' => 'ap.forms.validationRules',
-        'forms.form.created' => 'ap.forms.form.created',
-        'forms.form.updated' => 'ap.forms.form.updated',
-        'forms.form.deleted' => 'ap.forms.form.deleted',
-        'forms.submission.created' => 'ap.forms.submission.created',
-        'forms.submission.updated' => 'ap.forms.submission.updated',
-        'forms.submission.deleted' => 'ap.forms.submission.deleted',
-        'forms.webhook_payload' => 'ap.forms.webhookPayload',
-        'forms.settings_tabs' => 'ap.forms.settingsTabs',
-        'forms.submission_data' => 'ap.forms.submissionData',
-        'forms.export_headers' => 'ap.forms.exportHeaders',
-        'forms.export_data' => 'ap.forms.exportData',
-        'forms.notification_recipients' => 'ap.forms.notificationRecipients',
+        'forms.field_types'              => 'ap.forms.fieldTypes',
+        'forms.field_categories'         => 'ap.forms.fieldCategories',
+        'forms.validation_rules'         => 'ap.forms.validationRules',
+        'forms.form.created'             => 'ap.forms.form.created',
+        'forms.form.updated'             => 'ap.forms.form.updated',
+        'forms.form.deleted'             => 'ap.forms.form.deleted',
+        'forms.submission.created'       => 'ap.forms.submission.created',
+        'forms.submission.updated'       => 'ap.forms.submission.updated',
+        'forms.submission.deleted'       => 'ap.forms.submission.deleted',
+        'forms.webhook_payload'          => 'ap.forms.webhookPayload',
+        'forms.settings_tabs'            => 'ap.forms.settingsTabs',
+        'forms.submission_data'          => 'ap.forms.submissionData',
+        'forms.export_headers'           => 'ap.forms.exportHeaders',
+        'forms.export_data'              => 'ap.forms.exportData',
+        'forms.notification_recipients'  => 'ap.forms.notificationRecipients',
         'forms.notification.before_send' => 'ap.forms.notification.beforeSend',
-        'forms.notification.sent' => 'ap.forms.notification.sent',
-        'forms.notification_message' => 'ap.forms.notificationMessage',
+        'forms.notification.sent'        => 'ap.forms.notification.sent',
+        'forms.notification_message'     => 'ap.forms.notificationMessage',
     ];
 
-    foreach ($pairs as $old => $new) {
-        removeAllFilters($old);
-        removeAllFilters($new);
+    foreach ( $pairs as $old => $new ) {
+        removeAllFilters( $old );
+        removeAllFilters( $new );
     }
-});
+} );
 
-describe('HookAliases', function (): void {
-    it('is a no-op when deprecateHook is unavailable', function (): void {
+describe( 'HookAliases', function (): void {
+    it( 'is a no-op when deprecateHook is unavailable', function (): void {
         // Sanity: the registrar must not error under any load order.
         HookAliases::register();
-        expect(true)->toBeTrue();
-    });
+        expect( true )->toBeTrue();
+    } );
 
-    it('routes old filter-name subscribers through the canonical hook', function (): void {
-        if (! function_exists('deprecateHook')) {
-            $this->markTestSkipped('hooks < 1.3.0 has no deprecation aliasing');
+    it( 'routes old filter-name subscribers through the canonical hook', function (): void {
+        if ( ! function_exists( 'deprecateHook' ) ) {
+            $this->markTestSkipped( 'hooks < 1.3.0 has no deprecation aliasing' );
         }
 
         HookAliases::register();
 
         $oldCalled = false;
 
-        addFilter('forms.field_types', function (array $types) use (&$oldCalled): array {
-            $oldCalled = true;
+        addFilter( 'forms.field_types', function ( array $types ) use ( &$oldCalled ): array {
+            $oldCalled       = true;
             $types['legacy'] = ['label' => 'Legacy'];
 
             return $types;
-        });
+        } );
 
-        $result = applyFilters('ap.forms.fieldTypes', []);
+        $result = applyFilters( 'ap.forms.fieldTypes', [] );
 
-        expect($oldCalled)->toBeTrue();
-        expect($result)->toHaveKey('legacy');
-    });
+        expect( $oldCalled )->toBeTrue();
+        expect( $result )->toHaveKey( 'legacy' );
+    } );
 
-    it('routes old action-name subscribers through the canonical hook', function (): void {
-        if (! function_exists('deprecateHook')) {
-            $this->markTestSkipped('hooks < 1.3.0 has no deprecation aliasing');
+    it( 'routes old action-name subscribers through the canonical hook', function (): void {
+        if ( ! function_exists( 'deprecateHook' ) ) {
+            $this->markTestSkipped( 'hooks < 1.3.0 has no deprecation aliasing' );
         }
 
         HookAliases::register();
 
         $oldCalled = false;
 
-        addAction('forms.form.created', function () use (&$oldCalled): void {
+        addAction( 'forms.form.created', function () use ( &$oldCalled ): void {
             $oldCalled = true;
-        });
+        } );
 
-        doAction('ap.forms.form.created', new stdClass);
+        doAction( 'ap.forms.form.created', new stdClass);
 
-        expect($oldCalled)->toBeTrue();
+        expect( $oldCalled)->toBeTrue();
     });
 });

--- a/tests/Feature/Support/HookAliasesTest.php
+++ b/tests/Feature/Support/HookAliasesTest.php
@@ -80,8 +80,8 @@ describe( 'HookAliases', function (): void {
             $oldCalled = true;
         } );
 
-        doAction( 'ap.forms.form.created', new stdClass);
+        doAction( 'ap.forms.form.created', new stdClass );
 
-        expect( $oldCalled)->toBeTrue();
-    });
+        expect( $oldCalled )->toBeTrue();
+    } );
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ namespace Tests;
 
 use ArtisanPackUI\Ai\AiServiceProvider;
 use ArtisanPackUI\Forms\FormsServiceProvider;
+use ArtisanPackUI\Hooks\Providers\HooksServiceProvider;
 use Illuminate\Foundation\Application;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Blade;
@@ -60,7 +61,10 @@ abstract class TestCase extends BaseTestCase
      */
     protected function getPackageProviders( $app ): array
     {
-        $providers = [LivewireServiceProvider::class];
+        $providers = [
+            HooksServiceProvider::class,
+            LivewireServiceProvider::class,
+        ];
 
         // AI provider is optional — only register when artisanpack-ui/ai is installed.
         if ( class_exists( AiServiceProvider::class ) ) {


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.3.0
- **Release Date:** 2026-07-21
- **Release Type:** Minor
- **Release Branch:** `release/1.3`
- **Target Branch:** `main`

## Release Summary

v1.3.0 finishes the cross-package hooks standardization for the forms package:

- **Wave 2** renamed all 18 pre-existing hooks from `forms.*` / snake_case to the ecosystem-standard `ap.forms.*` camelCase names, with `Support\HookAliases` registering deprecation aliases so existing subscribers keep firing (info-level log per unique resolution).
- **Wave 5** adds six new `ap.forms.*` extension points around validation lifecycle, field rendering, integration registration, and notification subject/body mutation.
- Hooks constraint bumped to `^1.3` and every `function_exists('applyFilters' | 'doAction')` guard removed across `src/` — hooks 1.3 is now a hard runtime requirement.

## Changelog

### Added

- Six new `ap.forms.*` hooks for Wave 5 (#58):
  - `ap.forms.beforeValidate` action — `FormRequest::prepareForValidation()`. Payload: `(FormRequest $request)`.
  - `ap.forms.validated` action — `FormRequest::passedValidation()`. Payload: `(FormRequest $request, array $validated)`.
  - `ap.forms.fieldRender` filter — pipes each field's rendered HTML through subscribers. Payload: `(string $html, FormField $field)`.
  - `ap.forms.integrationRegistered` action — `IntegrationService::registerIntegration($slug, $config)`. Payload: `(string $slug, array $config)`.
  - `ap.forms.notificationSubject` filter — mutates outgoing notification email subjects. Fires AFTER the legacy `notificationMessage` filter on the already-parsed template.
  - `ap.forms.notificationBody` filter — mutates outgoing notification email bodies. Same ordering guarantee.
- `Support\FiresValidationHooks` trait applied to `StoreFormRequest`, `UpdateFormRequest`, and `SubmitFormApiRequest`.
- `Support\FieldRenderer::render()` helper used by the form renderer view.
- `IntegrationService::registerIntegration(string $slug, array $config = [])`.

### Changed

- Bumped the `artisanpack-ui/hooks` constraint to `^1.3` and dropped every `function_exists('applyFilters' | 'doAction')` guard across `src/`.

### Deprecated

- All 18 hooks previously shipped under `forms.*` / snake_case names have been renamed to `ap.forms.*` camelCase (Wave 2). Existing subscribers continue firing via `Support\HookAliases`, which emits an info-level `HookDeprecations` log entry per unique resolution. **Aliases will be removed in the next major version — migrate subscribers to the new names before then.** Full rename map is in the README. (#57)

## Issues and Pull Requests

**Issues Fixed:**
- Closes #57
- Closes #58

**Related PRs:**
- #59 (Wave 2 rename)
- #60 (Wave 5 hooks)

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

Aliases keep every pre-1.3 hook subscriber working. A hard `hooks: ^1.3` requirement lands but existing installs on `^1.2` already pass because 1.3.0 is release-ready.

## Testing Checklist

- [x] All automated tests passing (878 tests, 2034 assertions)
- [x] Security scan completed (`composer audit`: no advisories after refreshed lock)
- [ ] Manual testing completed
- [ ] Accessibility tests passing
- [ ] Performance tests passing (if applicable)
- [ ] Tested in staging environment
- [x] Database migrations tested (n/a — no new migrations)

**Testing notes:**

- Fixed `tests/TestCase.php` to register `HooksServiceProvider` explicitly. Without it, `deprecateHook()` under Orchestra Testbench created throwaway `HookDeprecations` instances instead of writing to the singleton `Filter`/`Action` were resolved with, and the alias-routing tests couldn't observe the wiring. Now: 878 passed / 0 failed.

## Documentation Checklist

- [x] CHANGELOG updated
- [ ] README updated (rename map already merged in Wave 2)
- [x] API documentation updated — `docs/advanced/customization.md` now lists the six new hooks in the filters + actions tables
- [ ] Migration guide written (n/a — no breaking changes)
- [ ] Release notes written
- [ ] Wiki updated (if applicable)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (`composer.json` already on `1.3.0`)
- [ ] Git tag prepared: `v1.3.0` (post-merge)
- [x] Release branch created/updated: `release/1.3`
- [x] Dependencies updated and tested — `artisanpack-ui/hooks` locked at 1.3.0; `composer audit` clean; `composer validate` OK
- [x] Rollback plan prepared (revert PR; aliases keep 1.2 subscribers working during downgrade)

## Notes

**Dependency audit summary:**
- `composer audit`: **no advisories** after refreshing `artisanpack-ui/hooks` to `1.3.0` (which pulled in updated guzzle transitive deps).
- `composer outdated --direct`: a handful of minor/patch bumps available in dev deps (`friendsofphp/php-cs-fixer` 3.95.5 → 3.95.15, `laravel/pint` 1.29.1 → 1.29.3, `livewire/livewire` 4.3.1 → 4.3.3, ArtisanPack UI patch releases). Not blocking — deferring to the next release.
- Major bumps available for `orchestra/testbench` (10 → 11), `pestphp/pest` (3 → 4), `pestphp/pest-plugin-laravel` (3 → 4). Tracking separately.

**Lint / format:**
- `./vendor/bin/php-cs-fixer fix` — 0 files changed.
- `./vendor/bin/phpcs` — 168/168 clean.

---

**Release Manager:** @jacobmartella